### PR TITLE
FIX Adding players to block list links to lobby (fr) #21

### DIFF
--- a/ogkush.js
+++ b/ogkush.js
@@ -9693,10 +9693,10 @@ class OGInfinity {
   }
 
   generateIgnoreLink(playerId) {
-    return `https://s169-fr.ogame.gameforge.com/game/index.php?page=ignorelist&action=1&id=${playerId}`;
+    return `https://s${this.universe}-${this.gameLang}.ogame.gameforge.com/game/index.php?page=ignorelist&action=1&id=${playerId}`;
   }
   generateBuddyLink(playerId) {
-    return `https://s169-fr.ogame.gameforge.com/game/index.php?page=ingame&component=buddies&action=7&id=${playerId}&ajax=1`;
+    return `https://s${this.universe}-${this.gameLang}.ogame.gameforge.com/game/index.php?page=ingame&component=buddies&action=7&id=${playerId}&ajax=1`;
   }
 
   stalk(sender, player, delay) {


### PR DESCRIPTION
line 9695, universe was hardcoded

```js
  generateIgnoreLink(playerId) {
    return `https://s169-fr.ogame.gameforge.com/game/index.php?page=ignorelist&action=1&id=${playerId}`;
  }
  generateBuddyLink(playerId) {
    return `https://s169-fr.ogame.gameforge.com/game/index.php?page=ingame&component=buddies&action=7&id=${playerId}&ajax=1`;
  }
```
should be

```js
generateIgnoreLink(playerId) {
return `https://s${this.universe}-${this.gameLang}.ogame.gameforge.com/game/index.php?page=ignorelist&action=1&id=${playerId}`;
}
generateBuddyLink(playerId) {
return `https://s${this.universe}-${this.gameLang}.ogame.gameforge.com/game/index.php?page=ingame&component=buddies&action=7&id=${playerId}&ajax=1`;
}
```