### PR TITLE
Fix : Issue #22 Incorrect fuel consumption sum

### DIFF
--- a/ogkush.js
+++ b/ogkush.js
@@ -4873,7 +4873,7 @@ class OGInfinity {
       total += sums.harvest[0] + sums.harvest[1];
       total += sums.found[0] + sums.found[1] + sums.found[2];
       total += sums.adjust[0] + sums.adjust[1] + sums.adjust[2];
-      total -= sums.fuel;
+      total += sums.fuel;
 
       return total;
     };
@@ -5321,7 +5321,7 @@ class OGInfinity {
       total += sums.harvest[0] + sums.harvest[1];
       total += sums.loot[0] + sums.loot[1] + sums.loot[2];
       total += sums.adjust[0] + sums.adjust[1] + sums.adjust[2];
-      total -= sums.fuel;
+      total += sums.fuel;
       return total;
     };
 


### PR DESCRIPTION
### Bug : Fuel consumption is added instead of subtracted to profit. (Issue #22)
![Expedition](https://user-images.githubusercontent.com/81220223/112122323-705c2200-8bc0-11eb-8a61-a517351dfd43.png)
![Combat](https://user-images.githubusercontent.com/81220223/112122324-70f4b880-8bc0-11eb-963b-813996e6357f.png)

### Fix : Adding instead of Subtracting
(Fuel already has negative value unlike Losses so subtracting it mean adding)
