### PR TITLE
fix stat resource icons

### DIFF
--- a/global.css
+++ b/global.css
@@ -2515,27 +2515,25 @@ a.build-it_premium, button.build-it_premium {
 .ogk-stats .resourceIcon {
     border-radius: 5px;
     width: 30px;
-    background-position: -1px -124px;
     height: 20px;
-    background-size: 200px;
+    background-size: 434px;
     margin-right: 10px
 }
 
 .ogk-stats .resourceIcon.metal {
-    background-position: -2px -46px
+    background-position: -1px -109px;
 }
 
 .ogk-stats .resourceIcon.crystal {
-    background-position: -36px -40px
+    background-position: -34px -109px;
 }
 
 .ogk-stats .resourceIcon.deuterium {
-    background-position: -68px -40px
+    background-position: -66px -109px;
 }
 
 .ogk-stats .resourceIcon.darkmatter {
-    background-position: -120px -100px;
-    background-size: 300px
+    background-position: -131px -109px;
 }
 
 .ogk-grid .resourceIcon {


### PR DESCRIPTION
1. fix the resource icons in the statistics dialog

Before:
<img width="365" alt="before1" src="https://user-images.githubusercontent.com/62902968/184986524-5f97e450-8313-45ea-9102-39e7201527e7.png">
<img width="445" alt="before2" src="https://user-images.githubusercontent.com/62902968/184986527-451364cd-e897-44e7-8496-45e71f7b6229.png">

After:
<img width="348" alt="after1" src="https://user-images.githubusercontent.com/62902968/184986517-6cf5896b-c990-4f49-a8b1-9ea3c6a34140.png">
<img width="361" alt="after2" src="https://user-images.githubusercontent.com/62902968/184986523-b4865a5b-5e5f-4c71-bb87-786bb6e1de40.png">
