### PR TITLE
Fix use of fleetDispatcher outside fleetDispatch page

### DIFF
--- a/ogkush.js
+++ b/ogkush.js
@@ -1176,16 +1176,16 @@ class OGInfinity {
         }
         this.saveData();
       });
-    }
 
-    // Add updateMissions methods
-    fleetDispatcher.updateMissions = debounce( () => {
-      if(!fleetDispatcher.NO_UPDATE_MISSIONS){
-        fleetDispatcher.refreshTarget();
-        fleetDispatcher.updateTarget();
-        fleetDispatcher.fetchTargetPlayerData();
-      }
-    }, 200);
+      // Add updateMissions methods
+      fleetDispatcher.updateMissions = debounce( () => {
+        if(!fleetDispatcher.NO_UPDATE_MISSIONS){
+          fleetDispatcher.refreshTarget();
+          fleetDispatcher.updateTarget();
+          fleetDispatcher.fetchTargetPlayerData();
+        }
+      }, 200);
+    }
   }
 
   updateServerSettings() {


### PR DESCRIPTION
The fleetDispatcher.updateMissions definition was always done, not only in the fleetDispatch page were the Ogame fleetDispatcher is accessible.