### PR TITLE
fix: Ensured successful resource parsing in espionage reports

### DIFF
--- a/ogkush.js
+++ b/ogkush.js
@@ -10664,12 +10664,27 @@ class OGInfinity {
         .textContent.replace(/(\D*)/, '')
         .replace(/%/, '');
       let regexp = /(?<number>[0-9.,]*)(?<magnitude>[a-zA-Z*])?/;
-      let dirtyLootVal = data[3].querySelectorAll('.resspan')[0].textContent.replace(/(\D*)/, '');
-      report.metal = this.calcOrderOfMagnitude(dirtyLootVal.match(regexp).groups.number, dirtyLootVal.match(regexp).groups.magnitude)
-      dirtyLootVal = data[3].querySelectorAll('.resspan')[1].textContent.replace(/(\D*)/, '');
-      report.crystal = this.calcOrderOfMagnitude(dirtyLootVal.match(regexp).groups.number, dirtyLootVal.match(regexp).groups.magnitude)
-      dirtyLootVal = data[3].querySelectorAll('.resspan')[2].textContent.replace(/(\D*)/, '');
-      report.deut = this.calcOrderOfMagnitude(dirtyLootVal.match(regexp).groups.number, dirtyLootVal.match(regexp).groups.magnitude)
+      let dirtyLootVal = data[3]
+        .querySelectorAll('.resspan')[0]
+        .textContent.replace(/(\D*)/, '');
+      report.metal = this.calcOrderOfMagnitude(
+        dirtyLootVal.match(regexp).groups.number,
+        dirtyLootVal.match(regexp).groups.magnitude
+      );
+      dirtyLootVal = data[3]
+        .querySelectorAll('.resspan')[1]
+        .textContent.replace(/(\D*)/, '');
+      report.crystal = this.calcOrderOfMagnitude(
+        dirtyLootVal.match(regexp).groups.number,
+        dirtyLootVal.match(regexp).groups.magnitude
+      );
+      dirtyLootVal = data[3]
+        .querySelectorAll('.resspan')[2]
+        .textContent.replace(/(\D*)/, '');
+      report.deut = this.calcOrderOfMagnitude(
+        dirtyLootVal.match(regexp).groups.number,
+        dirtyLootVal.match(regexp).groups.magnitude
+      );
       report.total = report.metal + report.crystal + report.deut;
       report.renta = Math.round((report.total * report.loot) / 100);
       report.apiKey =
@@ -11316,21 +11331,23 @@ class OGInfinity {
   calcOrderOfMagnitude(number, magnitude, localize = false) {
     let calculatedValue = this.cleanValue(number);
     switch (magnitude) {
-      case 'K':
-        calculatedValue *= 1000
-        break;
-      case 'M':
-        calculatedValue *= 1000000
-        break;
-      case 'B':
-        calculatedValue *= 1000000000
-        break;
-      case 'T':
-        calculatedValue *= 1000000000000
-        break;
-      default:
+    case 'K':
+      calculatedValue *= 1000;
+      break;
+    case 'M':
+      calculatedValue *= 1000000;
+      break;
+    case 'B':
+      calculatedValue *= 1000000000;
+      break;
+    case 'T':
+      calculatedValue *= 1000000000000;
+      break;
+    default:
     }
-    return Number((localize ? calculatedValue.toLocaleString(separatorLang) : calculatedValue));
+    return Number(
+      localize ? calculatedValue.toLocaleString(separatorLang) : calculatedValue
+    );
   }
 
   calcNeededShips(options) {

--- a/ogkush.js
+++ b/ogkush.js
@@ -10663,15 +10663,13 @@ class OGInfinity {
         .querySelector('.ctn')
         .textContent.replace(/(\D*)/, '')
         .replace(/%/, '');
-      report.metal = this.cleanValue(
-        data[3].querySelectorAll('.resspan')[0].textContent.replace(/(\D*)/, '')
-      );
-      report.crystal = this.cleanValue(
-        data[3].querySelectorAll('.resspan')[1].textContent.replace(/(\D*)/, '')
-      );
-      report.deut = this.cleanValue(
-        data[3].querySelectorAll('.resspan')[2].textContent.replace(/(\D*)/, '')
-      );
+      let regexp = /(?<number>[0-9.,]*)(?<magnitude>[a-zA-Z*])?/;
+      let dirtyLootVal = data[3].querySelectorAll('.resspan')[0].textContent.replace(/(\D*)/, '');
+      report.metal = this.calcOrderOfMagnitude(dirtyLootVal.match(regexp).groups.number, dirtyLootVal.match(regexp).groups.magnitude)
+      dirtyLootVal = data[3].querySelectorAll('.resspan')[1].textContent.replace(/(\D*)/, '');
+      report.crystal = this.calcOrderOfMagnitude(dirtyLootVal.match(regexp).groups.number, dirtyLootVal.match(regexp).groups.magnitude)
+      dirtyLootVal = data[3].querySelectorAll('.resspan')[2].textContent.replace(/(\D*)/, '');
+      report.deut = this.calcOrderOfMagnitude(dirtyLootVal.match(regexp).groups.number, dirtyLootVal.match(regexp).groups.magnitude)
       report.total = report.metal + report.crystal + report.deut;
       report.renta = Math.round((report.total * report.loot) / 100);
       report.apiKey =
@@ -11313,6 +11311,26 @@ class OGInfinity {
       return playerList;
     }
     return [];
+  }
+
+  calcOrderOfMagnitude(number, magnitude, localize = false) {
+    let calculatedValue = this.cleanValue(number);
+    switch (magnitude) {
+      case 'K':
+        calculatedValue *= 1000
+        break;
+      case 'M':
+        calculatedValue *= 1000000
+        break;
+      case 'B':
+        calculatedValue *= 1000000000
+        break;
+      case 'T':
+        calculatedValue *= 1000000000000
+        break;
+      default:
+    }
+    return Number((localize ? calculatedValue.toLocaleString(separatorLang) : calculatedValue));
   }
 
   calcNeededShips(options) {


### PR DESCRIPTION
Original issue:
<img width="671" alt="Screen Shot 2022-10-26 at 1 13 16 PM" src="https://user-images.githubusercontent.com/23270631/198127567-824d3aa0-8b86-484f-b25b-e270d6cea807.png">

After fix:
<img width="667" alt="Screen Shot 2022-10-26 at 1 12 23 PM" src="https://user-images.githubusercontent.com/23270631/198127626-5e1f8e25-2cb6-4c10-93e8-21d416683124.png">


In response to Issue #115 