### PR TITLE
[PTRE] Add (or update) tool name sent to PTRE backend

### DIFF
--- a/main.js
+++ b/main.js
@@ -227,7 +227,7 @@ class DataHelper {
 
   updatePtreGalaxy(ptrePosition) {
     fetch(
-      'https://ptre.chez.gg/scripts/api_galaxy_import_infos.php?tool=oglight',
+      'https://ptre.chez.gg/scripts/api_galaxy_import_infos.php?tool=infinity',
       {
         priority: 'low',
         method: 'POST',

--- a/ogkush.js
+++ b/ogkush.js
@@ -2593,7 +2593,7 @@ class OGInfinity {
         (mainPlanet && mainPlanet.coords === coords) || false;
     }
 
-    fetch('https://ptre.chez.gg/scripts/oglight_import_player_activity.php', {
+    fetch('https://ptre.chez.gg/scripts/oglight_import_player_activity.php?tool=infinity', {
       priority: 'low',
       method: 'POST',
       body: JSON.stringify(ptreJSON),
@@ -3749,7 +3749,7 @@ class OGInfinity {
 
     let cleanPlayerName = encodeURIComponent(player.name);
     this.getJSON(
-      `https://ptre.chez.gg/scripts/oglight_get_player_infos.php?team_key=${this.json.options.ptreTK}&pseudo=${cleanPlayerName}&player_id=${player.id}&input_frame=${frame}`,
+      `https://ptre.chez.gg/scripts/oglight_get_player_infos.php?tool=infinity&team_key=${this.json.options.ptreTK}&pseudo=${cleanPlayerName}&player_id=${player.id}&input_frame=${frame}`,
       (result) => {
         if (result.code == 1) {
           let arrData =
@@ -10743,7 +10743,7 @@ class OGInfinity {
       this.sortTable(this.reportList);
     }
     if (Object.keys(ptreJSON).length > 0) {
-      fetch('https://ptre.chez.gg/scripts/oglight_import_player_activity.php', {
+      fetch('https://ptre.chez.gg/scripts/oglight_import_player_activity.php?tool=infinity', {
         method: 'POST',
         body: JSON.stringify(ptreJSON),
       })
@@ -11068,7 +11068,7 @@ class OGInfinity {
         );
         ptreBtn.addEventListener('click', () => {
           this.getJSON(
-            `https://ptre.chez.gg/scripts/oglight_import.php?team_key=${this.json.options.ptreTK}&sr_id=${report.apiKey}`,
+            `https://ptre.chez.gg/scripts/oglight_import.php?tool=infinity&team_key=${this.json.options.ptreTK}&sr_id=${report.apiKey}`,
             (result) => {
               fadeBox(result.message_verbose, result.code != 1);
             }


### PR DESCRIPTION
Hello @everteckhardt ,

I am PTRE developer and i just find out that my website was integrated to OG Infinity. And i saw some stuffs that could be improved.

OG Infinity is using same interfaces than OGLight. To improve analysis and for debug purposes, it's better to add a different `tool` name than OGLight's one to PTRE requests.

From now on, please add `?tool=infinity` GET parameter to each and every requests to PTRE `ptre.chez.gg/scripts/` route.
