### PR TITLE
Fix/renta point and comma madness

### DIFF
--- a/ogkush.js
+++ b/ogkush.js
@@ -11774,7 +11774,7 @@ class OGInfinity {
       factor = 1e3;
     }
     value = value.split(sep).join('');
-    return parseInt(value.replace('|', sep) * factor);
+    return parseInt(value.replace('|', '.') * factor);
   }
 
   removeNumSeparator(str) {

--- a/ogkush.js
+++ b/ogkush.js
@@ -10672,27 +10672,14 @@ class OGInfinity {
         .querySelector('.ctn')
         .textContent.replace(/(\D*)/, '')
         .replace(/%/, '');
-      let regexp = /(?<number>[0-9.,]*)(?<magnitude>[a-zA-Z*])?/;
-      let dirtyLootVal = data[3]
-        .querySelectorAll('.resspan')[0]
-        .textContent.replace(/(\D*)/, '');
-      report.metal = this.calcOrderOfMagnitude(
-        dirtyLootVal.match(regexp).groups.number,
-        dirtyLootVal.match(regexp).groups.magnitude
+      report.metal = this.cleanValue(
+        data[3].querySelectorAll('.resspan')[0].textContent.replace(/(\D*)/, '')
       );
-      dirtyLootVal = data[3]
-        .querySelectorAll('.resspan')[1]
-        .textContent.replace(/(\D*)/, '');
-      report.crystal = this.calcOrderOfMagnitude(
-        dirtyLootVal.match(regexp).groups.number,
-        dirtyLootVal.match(regexp).groups.magnitude
+      report.crystal = this.cleanValue(
+        data[3].querySelectorAll('.resspan')[1].textContent.replace(/(\D*)/, '')
       );
-      dirtyLootVal = data[3]
-        .querySelectorAll('.resspan')[2]
-        .textContent.replace(/(\D*)/, '');
-      report.deut = this.calcOrderOfMagnitude(
-        dirtyLootVal.match(regexp).groups.number,
-        dirtyLootVal.match(regexp).groups.magnitude
+      report.deut = this.cleanValue(
+        data[3].querySelectorAll('.resspan')[2].textContent.replace(/(\D*)/, '')
       );
       report.total = report.metal + report.crystal + report.deut;
       report.renta = Math.round((report.total * report.loot) / 100);
@@ -11335,28 +11322,6 @@ class OGInfinity {
       return playerList;
     }
     return [];
-  }
-
-  calcOrderOfMagnitude(number, magnitude, localize = false) {
-    let calculatedValue = this.cleanValue(number);
-    switch (magnitude) {
-    case 'K':
-      calculatedValue *= 1000;
-      break;
-    case 'M':
-      calculatedValue *= 1000000;
-      break;
-    case 'B':
-      calculatedValue *= 1000000000;
-      break;
-    case 'T':
-      calculatedValue *= 1000000000000;
-      break;
-    default:
-    }
-    return Number(
-      localize ? calculatedValue.toLocaleString(separatorLang) : calculatedValue
-    );
   }
 
   calcNeededShips(options) {


### PR DESCRIPTION
With version 2.2.0 servers with point as thousand separator get NaN for Renta, because fix #117 to fix servers with comma as thousand separator. Bug #115.

The cause of getting NaN in servers with comma as thousand separator is a unique change in fix #93, that don't work as intended way.

Reverting fix #117 and this specific change from fix #93 resolves bug #115 bug and don't break servers with point as thousand separator.

After this fix:

![imagen](https://user-images.githubusercontent.com/13818551/204065019-8d117372-bd3c-4876-b8c7-4bdfc5f42d89.png)
![imagen](https://user-images.githubusercontent.com/13818551/204065058-9a8da9a4-c481-42a9-87d2-d7d208d5d8ca.png)

