### PR TITLE
add 'ro-RO' in commaSeparator

### DIFF
--- a/ogkush.js
+++ b/ogkush.js
@@ -58,7 +58,7 @@ if (redirect && redirect.indexOf('https') > -1) {
   window.location.href = redirect;
 }
 
-let commaSeparator = ['en-US', 'en-GB'];
+let commaSeparator = ['en-US', 'en-GB', 'ro-RO'];
 let locale = document
   .getElementById('cookiebanner')
   .getAttribute('data-locale');


### PR DESCRIPTION
This fixes #129 until GF may use in the future the right separators for .ro servers. If they do ever, this have to be reverted.