### PR TITLE
update trashsim link

### DIFF
--- a/ogkush.js
+++ b/ogkush.js
@@ -1857,7 +1857,7 @@ class OGInfinity {
       this.createDOM(
         "li",
         {},
-        `<a href="https://trashsim.universeview.be/${this.univerviewLang}" target="_blank">Trash</a>`
+        `<a href="https://trashsim.oplanet.eu/${this.univerviewLang}" target="_blank">Trash</a>`
       )
     );
     bar.appendChild(


### PR DESCRIPTION
Warsaalk leaves and closed down trashsim server. Fortunately the SGO of the Dutch community will start hosting the projects. 

[https://board.en.ogame.gameforge.com/index.php?thread/835718-trashsim-and-ogotcha-shutting-down/](url)

As now is working a redirection from old server to new one, but we can expect that this will not last forever. Updating now the link we can forget about it.