### PR TITLE
Improvement/return on investment

### DIFF
--- a/global.css
+++ b/global.css
@@ -148,9 +148,11 @@
 div#banner_skyscraper {
   position: absolute;
   top: 7.5em !important;
-  left: auto !important;
-  right: -165px !important;
-  /*left: 1160px !important;*/
+  right: -120px !important;
+  }
+
+  div#banner_skyscraper a.close_details {
+    right: 0 !important
 }
 
 div#banner_skyscraper.fix-banner {
@@ -170,24 +172,24 @@ div#banner_skyscraper.fix-banner {
   background: linear-gradient(#1d2732, #131c24) !important;
 }
 
-#resources .res_wrap:nth-child(2) input[type="text"],
 .metal + input[type="text"],
+input[id="metal"],
 input[type="text"].metal {
   color: #ffaacca1 !important;
   border: solid 1px rgb(58 72 86) !important;
   box-shadow: none !important;
 }
 
-#resources .res_wrap:nth-child(3) input[type="text"],
 .crystal ~ input[type="text"],
+input[id="crystal"],
 input[type="text"].crystal {
   color: #73e5ffc7 !important;
   border: solid 1px rgb(58 72 86) !important;
   box-shadow: none !important;
 }
 
-#resources .res_wrap:nth-child(4) input[type="text"],
 .deuterium ~ input[type="text"],
+input[id="deuterium"],
 input[type="text"].deuterium {
   color: #a6e0b0 !important;
   border: solid 1px rgb(58 72 86) !important;
@@ -206,7 +208,7 @@ input[type="password"]::selection {
 input[type="text"],
 input[type="password"] {
   background: -webkit-linear-gradient(top, #0d151b 0, #1f2a35 100%) !important;
-  color: #bbb !important;
+  color: #bbb;
   border: solid 1px rgb(58 72 86) !important;
   box-shadow: none !important;
   line-height: 23px !important;
@@ -455,9 +457,17 @@ input[type="password"] {
 }
 
 .ogl-settings .btn_blue.save {
-  width: 30px;
+  width: fit-content;
+    min-width: 30px;
   align-self: flex-end;
   margin-top: 5px;
+}
+
+.ogl-settings .btn_blue.update {
+  width: fit-content;
+  min-width: 30px;
+  margin-top: 0px;
+  margin-left: 5px;
 }
 
 .fleetStatus .ogl-backLast {
@@ -1218,6 +1228,7 @@ input[type="password"] {
 
 .res .ogi-crystalLeft,
 .res .ogi-deuteriumLeft,
+.res .ogi-foodLeft,
 .res .ogi-metalLeft {
   font-size: 10px;
   position: relative;
@@ -1863,7 +1874,8 @@ strong {
   font-weight: 800;
 }
 
-#technologydetails .build_duration time {
+#technologydetails .build_duration time,
+#technologydetails .roi_duration time {
   text-align: right;
 }
 
@@ -2338,6 +2350,10 @@ button.build-it_premium {
   grid-template-columns: repeat(3, 1fr);
 }
 
+.ogl-tooltip .ogk-cargo.spio {
+  grid-template-columns: repeat(4, 1fr);
+}
+
 .ogl-tooltip .ogk-cargo > div {
   margin: 2px;
 }
@@ -2397,7 +2413,7 @@ button.build-it_premium {
   min-width: 450px;
   width: auto;
   height: auto;
-  margin: 10px;
+  margin: 5px;
   padding: 15px 20px;
   background: #0d1117;
   display: flex;
@@ -2499,7 +2515,7 @@ button.build-it_premium {
 }
 
 .ogk-stats .ogk-details .ogk-fleet a {
-  width: 30px;
+  width: 25px;
   height: 25px;
   margin-right: 10px;
 }
@@ -2652,28 +2668,35 @@ button.build-it_premium {
 }
 
 .ogk-stats .resourceIcon {
-  border-radius: 5px;
+  background: transparent url("//gf3.geo.gfsrv.net/cdned/7f14c18b15064d2604c5476f5d10b3.png") 0 0 no-repeat;
+    background-size: 400px, auto;
   width: 30px;
-  background-position: -1px -124px;
   height: 20px;
-  background-size: 434px;
-  margin-right: 10px;
+  float: left;
+  }
+
+  .ogk-stats .ogk-title .resourceIcon {
+    margin-right: 5px;
 }
 
 .ogk-stats .resourceIcon.metal {
-  background-position: -1px -109px;
+  background-position: 0px -100px;
 }
 
 .ogk-stats .resourceIcon.crystal {
-  background-position: -34px -109px;
+  background-position: -30px -100px;
 }
 
 .ogk-stats .resourceIcon.deuterium {
-  background-position: -66px -109px;
+  background-position: -60px -100px;
+  }
+
+  .ogk-stats .resourceIcon.energy {
+    background-position: -90px -100px;
 }
 
 .ogk-stats .resourceIcon.darkmatter {
-  background-position: -131px -109px;
+  background-position: -120px -100px;
 }
 
 .ogk-grid .resourceIcon {
@@ -2730,6 +2753,83 @@ button.build-it_premium {
 
 #fleetdispatchcomponent .toggleHeader {
   display: none;
+}
+
+#fleet2 #resources .res_wrap {
+  width: 160px !important;
+}
+
+#fleet2 .res {
+  width: 100px !important;
+}
+
+#fleet2 .res input {
+  margin: 1px 0px 1px 3px !important;
+  width: 100px !important;
+}
+
+#fleet2 .target {
+  padding: 0 !important;
+}
+
+#fleet2 .target a {
+  transform: scale(0.75);
+}
+
+#fleet2 .coords {
+  height: 25px !important;
+  margin: 0px 1px 1px 1px;
+}
+
+#fleet2 #mission {
+  margin: 0 auto !important;
+}
+
+#buttonz .content {
+  margin: 0 !important;
+}
+
+#fleet2 #missionNameWrapper {
+  font-size: 10px !important;
+  padding: 10px 0px 10px 25px !important;
+}
+
+#ogi-fleet2-ships {
+  height: fit-content;
+}
+
+#ogi-fleet2-ships .content {
+  min-height: 25px !important;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr 3fr);
+  grid-gap: 5px;
+  padding: 0px 12px 0px 12px !important;
+}
+
+#ogi-fleet2-ships .ogl-fleet-ship {
+  display: flex;
+  margin: 0px 5px 0px 10px !important;
+}
+
+#ogi-fleet2-ships .ogl-fleet-ship:hover {
+  border: solid 1px #5f5d6b !important;
+}
+
+#ogi-fleet2-ships .ogl-fleet-ship:hover+span {
+  color: #ffff !important;
+}
+
+#ogi-fleet2-ships .ogl-fleet-ship+span {
+  line-height: 25px;
+  text-align: left;
+}
+
+#fleet2 .briefing_overlay {
+  margin: 0 !important;
+}
+
+#productionboxBottom {
+  position: relative !important;
 }
 
 .spinner {
@@ -3499,9 +3599,14 @@ button.build-it_premium {
   background: linear-gradient(to right, #886c1a, #090e13);
 }
 
-.moonlink.ogl-target,
-.planetlink.ogl-target {
-  outline-color: #fff;
+.moonlink.ogl-target.mission-3,
+.planetlink.ogl-target.mission-3 {
+  outline-color: #7ead3d;
+}
+
+.moonlink.ogl-target.mission-4,
+.planetlink.ogl-target.mission-4 {
+  outline-color: #34a37b;
 }
 
 .ogl-target {
@@ -3560,6 +3665,8 @@ button.build-it_premium {
 
 .smallplanet .moonlink img {
   display: block;
+  height: 20px;
+  width: 20px;
   left: 43px !important;
 }
 
@@ -4310,7 +4417,7 @@ a {
 }
 
 .tooltip {
-  color: none;
+  color: inherit !important;
 }
 
 .ogl-tooltip a[href] {
@@ -4418,7 +4525,7 @@ span.espionageDefText {
 
 .ogl-tooltip.ogl-active .ogl-stalkPlanets .ogl-moon-div.ogl-active:hover .ogl-moon-hover {
   width: 25px !important;
-  margin-left: 46px;      
+  margin-left: 46px;
 }
 
 /* .mCSB_container .ogl-stalkPlanets .ogl-moon-div.ogl-active:hover .ogl-moon-hover {
@@ -4581,10 +4688,10 @@ body.ogame select {
 }
 
 .ogl-fleet-ship {
-  background-size: calc(100px * 10) !important;
+  background-size: calc(25px * 20) !important;
   background: url("https://gf3.geo.gfsrv.net/cdn53/7a9861be0c38bf7de05a57c56d73cf.jpg");
   width: 25px;
-  height: 20px;
+  height: 25px;
   border: solid 1px #5f5d6b;
 }
 
@@ -4602,155 +4709,208 @@ body.ogame select {
 }
 
 .ogl-tech-113 {
-  background-position: 0.6% 68.2% !important;
+  /* Energy Technology */
+  background-position: calc(5.2625% * 0) 68.97% !important;
+}
+
+.ogl-tech-120 {
+  /* Laser Technology */
+  background-position: calc(5.2625% * 1) 68.97% !important;
+}
+
+.ogl-tech-121 {
+  /* Ion Technology */
+  background-position: calc(5.2625% * 2) 68.97% !important;
 }
 
 .ogl-tech-114 {
-  background-position: 17% 68.3% !important;
-}
-
-.ogl-tech-115 {
-  background-position: 28% 68.5% !important;
-}
-
-.ogl-tech-117 {
-  background-position: 32% 68.5% !important;
-}
-
-.ogl-tech-118 {
-  background-position: 37% 68.5% !important;
-}
-
-.ogl-tech-108 {
-  background-position: 47.3% 68.5% !important;
-}
-
-.ogl-tech-109 {
-  background-position: 73% 68.5% !important;
-}
-
-.ogl-tech-110 {
-  background-position: 78% 68.5% !important;
-}
-
-.ogl-tech-111 {
-  background-position: 67% 68.5% !important;
-}
-
-.ogl-tech-124 {
-  background-position: 51.3% 68.3% !important;
+  /* Hyperspace Technology */
+  background-position: calc(5.2625% * 3) 68.97% !important;
 }
 
 .ogl-tech-122 {
-  background-position: 22.6% 68.4% !important;
+  /* Plasma Technology */
+  background-position: calc(5.2625% * 4) 68.97% !important;
 }
 
-.ogl-fleet-203 {
-  background-position: 46.9% 51.5% !important;
+.ogl-tech-115 {
+  /* Combustion Drive */
+  background-position: calc(5.2625% * 5) 68.97% !important;
 }
 
-.ogl-fleet-202 {
-  background-position: 42.3% 52% !important;
+.ogl-tech-117 {
+  /* Impulse Drive */
+  background-position: calc(5.2625% * 6) 68.97% !important;
 }
 
-.ogl-fleet-208 {
-  background-position: 52.9% 51.8% !important;
+.ogl-tech-118 {
+  /* Hyperspace Drive */
+  background-position: calc(5.2625% * 7) 68.97% !important;
 }
 
-.ogl-fleet-209 {
-  background-position: 57.3% 52% !important;
+.ogl-tech-106 {
+  /* Espionage Technology */
+  background-position: calc(5.2625% * 8) 68.97% !important;
 }
 
-.ogl-fleet-210 {
-  background-position: 62.9% 52.5% !important;
+.ogl-tech-108 {
+  /* Computer Technology */
+  background-position: calc(5.2625% * 9) 68.97% !important;
 }
 
-.ogl-fleet-212 {
-  background-position: 67.9% 51.8% !important;
+.ogl-tech-124 {
+  /* Astrophysics */
+  background-position: calc(5.2625% * 10) 68.97% !important;
+}
+
+.ogl-tech-123 {
+  /* Gravitopn Technology */
+  background-position: calc(5.2625% * 11) 68.97% !important;
+}
+
+.ogl-tech-199 {
+  /* Armour Technology */
+  background-position: calc(5.2625% * 12) 68.97% !important;
+}
+
+.ogl-tech-111 {
+  /* Armour Technology */
+  background-position: calc(5.2625% * 13) 68.97% !important;
+}
+
+.ogl-tech-109 {
+  /* Weapon Technology */
+  background-position: calc(5.2625% * 14) 68.97% !important;
+}
+
+.ogl-tech-110 {
+  /* Shielding Technology */
+  background-position: calc(5.2625% * 15) 68.97% !important;
 }
 
 .ogl-fleet-204 {
-  background-position: 0.9% 52% !important;
+  /* Light Fighter */
+  background-position: calc(5.2625% * 0) 51.73% !important;
 }
 
 .ogl-fleet-205 {
-  background-position: 5.9% 52% !important;
+  /* Heavy Fighter */
+  background-position: calc(5.2625% * 1) 51.73% !important;
 }
 
 .ogl-fleet-206 {
-  background-position: 10.9% 52% !important;
+  /* Cruiser */
+  background-position: calc(5.2625% * 2) 51.73% !important;
 }
 
 .ogl-fleet-207 {
-  background-position: 15.9% 51.5% !important;
+  /* Battleship */
+  background-position: calc(5.2625% * 3) 51.73% !important;
 }
 
 .ogl-fleet-215 {
-  background-position: 21% 51.8% !important;
+  /* Battlecruiser */
+  background-position: calc(5.2625% * 4) 51.73% !important;
 }
 
 .ogl-fleet-211 {
-  background-position: 26.9% 51.5% !important;
+  /* Bomb */
+  background-position: calc(5.2625% * 5) 51.73% !important;
 }
 
 .ogl-fleet-213 {
-  background-position: 31.9% 51.5% !important;
+  /* Destroyer */
+  background-position: calc(5.2625% * 6) 51.73% !important;
 }
 
 .ogl-fleet-214 {
-  background-position: 36.9% 51% !important;
+  /* Death Star */
+  background-position: calc(5.2625% * 7) 51.73% !important;
 }
 
-.ogl-fleet-217 {
-  background-position: 84% 51.8% !important;
+.ogl-fleet-202 {
+  /* Small Cargo */
+  background-position: calc(5.2625% * 8) 51.73% !important;
+}
+
+.ogl-fleet-203 {
+  /* Large Cargo */
+  background-position: calc(5.2625% * 9) 51.73% !important;
+}
+
+.ogl-fleet-208 {
+  /* Colony Ship */
+  background-position: calc(5.2625% * 10) 51.73% !important;
+}
+
+.ogl-fleet-209 {
+  /* Recycler */
+  background-position: calc(5.2625% * 11) 51.73% !important;
+}
+
+.ogl-fleet-210 {
+  /* Espionage Probe */
+  background-position: calc(5.2625% * 12) 51.73% !important;
+}
+
+.ogl-fleet-212 {
+  /* Solar Satellite */
+  background-position: calc(5.2625% * 13) 51.73% !important;
 }
 
 .ogl-fleet-218 {
-  background-position: 73% 52.1% !important;
+  /* Reaper */
+  background-position: calc(5.2625% * 14) 51.73% !important;
 }
 
 .ogl-fleet-219 {
-  background-position: 79% 51.7% !important;
+  /* Pathfinder */
+  background-position: calc(5.2625% * 15) 51.73% !important;
+}
+
+.ogl-fleet-217 {
+  /* Crawler */
+  background-position: calc(5.2625% * 16) 51.73% !important;
 }
 
 .ogl-fleet-401 {
-  background-position: 0 34% !important;
+  background-position: calc(5.2625% * 0) 34.5% !important;
 }
 
 .ogl-fleet-402 {
-  background-position: 5.3% 34% !important;
+  background-position: calc(5.2625% * 1) 34.5% !important;
 }
 
 .ogl-fleet-403 {
-  background-position: 11% 34% !important;
+  background-position: calc(5.2625% * 2) 34.5% !important;
 }
 
 .ogl-fleet-404 {
-  background-position: 16% 34% !important;
+  background-position: calc(5.2625% * 3) 34.5% !important;
 }
 
 .ogl-fleet-405 {
-  background-position: 21% 34.5% !important;
+  background-position: calc(5.2625% * 4) 34.5% !important;
 }
 
 .ogl-fleet-406 {
-  background-position: 27% 33.8% !important;
+  background-position: calc(5.2625% * 5) 34.5% !important;
 }
 
 .ogl-fleet-407 {
-  background-position: 32% 33.8% !important;
+  background-position: calc(5.2625% * 6) 34.5% !important;
 }
 
 .ogl-fleet-408 {
-  background-position: 37% 33.8% !important;
+  background-position: calc(5.2625% * 7) 34.5% !important;
 }
 
 .ogl-fleet-502 {
-  background-position: 42.4% 34.2% !important;
+  background-position: calc(5.2625% * 8) 34.5% !important;
 }
 
 .ogl-fleet-503 {
-  background-position: 46.4% 34% !important;
+  background-position: calc(5.2625% * 9) 34.5% !important;
 }
 
 .ogl-moon-icon {
@@ -4769,9 +4929,17 @@ body.ogame select {
   margin: 4px;
 }
 
+.ogl-mines-content,
+.ogl-fleet-content {
+  width: 90vw;
+  overflow: auto !important;
+  display: block !important;
+  max-height: 80vh;
+}
+
 .ogl-fleet-content .ogl-option {
   height: 20px;
-  width: 40px;
+  width: 20px;
   margin: 3px 15px 3px 15px;
   border: 1px solid #3b4a5c;
 }
@@ -4779,6 +4947,7 @@ body.ogame select {
 .ogl-fleet-table {
   color: #ccc;
   text-align: center;
+  margin: auto;
 }
 
 .ogl-fleet-table th p {
@@ -5825,11 +5994,6 @@ div[data-marker]:hover {
   width: 35px;
 }
 
-resourceIcon.metal {
-  background-position: -1px -174px !important;
-  background-size: 430px auto !important;
-}
-
 .ogl-keepRes {
   background: linear-gradient(to top, #de8225, #da5a15);
   border: none;
@@ -6130,7 +6294,7 @@ hr {
 }
 
 .ogl-dialogOverlay.ogl-active {
-  align-items: center;
+  align-items: flex-start;
   background: rgba(0, 0, 0, 0.7);
   display: flex;
   justify-content: center;
@@ -6144,7 +6308,6 @@ hr {
 
 .ogl-dialog {
   background: #262e39;
-  background: #222a33;
   display: flex;
   overflow: hidden;
   padding: 20px;
@@ -6325,18 +6488,17 @@ table.fleetinfo tr:nth-child(odd) {
 
 .ogl-metal,
 table.fleetinfo tr:nth-last-child(3) {
-  color: #af866a;
-  color: #ffaacca1;
+  color: #ffaacca1 !important;
 }
 
 .ogl-crystal,
 table.fleetinfo tr:nth-last-child(2) {
-  color: #73e5ffc7;
+  color: #73e5ffc7 !important;
 }
 
 .ogl-deut,
 table.fleetinfo tr:nth-last-child(1) {
-  color: #a6e0b0;
+  color: #a6e0b0 !important;
 }
 
 .btn_blue {
@@ -7191,4 +7353,604 @@ span.resbuttons {
   position: relative !important;
   top: 0 !important;
   margin-left: 25px !important;
+}
+
+.ogk-stats .ogk-roi-details {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.ogk-stats .ogk-roi-details .ogk-box {
+  padding: 15px 15px !important;
+}
+
+.ogk-stats .ogk-roi-details .ogk-roi {
+  display: grid;
+  grid-template-columns: repeat(10, 1fr);
+  grid-gap: 15px;
+  width: fit-content;
+  justify-items: baseline;
+}
+
+.ogk-stats .ogk-roi-details .ogk-roi>div {
+  display: flex;
+  align-items: center;
+  /* font-weight: 800; */
+}
+
+.ogk-stats .ogk-roi-details .ogk-roi a {
+  width: 50px;
+  height: 50px;
+  text-align: center;
+  color: #ffff !important;
+  font-size: 20px !important;
+  text-shadow: #000 0px 0px 2px, #000 0px 0px 2px, #000 0px 0px 2px, #000 0px 0px 2px, #000 0px 0px 2px;
+  text-decoration-line: none !important;
+}
+
+.ogk-stats .ogk-roi-details .ogk-roi p {
+  text-align: center;
+  color: #ffff;
+  font-size: 9px;
+  text-shadow: #000 0px 0px 2px, #000 0px 0px 2px, #000 0px 0px 2px, #000 0px 0px 2px, #000 0px 0px 2px;
+}
+
+.ogl-roi-tech {
+  background-size: 1000px 1500px !important;
+  background: url("https://gf3.geo.gfsrv.net/cdn53/7a9861be0c38bf7de05a57c56d73cf.jpg");
+  width: 50px !important;
+  height: 50px !important;
+  border: solid 2px #5f5d6b !important;
+}
+
+.ogl-roi-tech:hover {
+  border: solid 2px #da961a !important;
+}
+
+.ogl-roi-tech:hover p,
+.ogl-roi-tech:hover span {
+  color: #da961a !important;
+}
+
+.ogl-roi-tech.construction {
+  border: solid 2px #b00001 !important;
+}
+
+.ogl-roi-tech.inConstruction {
+  border: solid 2px #93c900 !important;
+}
+
+.ogl-roi-tech.ogl-tech-1 {
+  background-position: 0% 0% !important;
+}
+
+.ogl-roi-tech.ogl-tech-2 {
+  background-position: 5.2% 0% !important;
+}
+
+.ogl-roi-tech.ogl-tech-3 {
+  background-position: 10.5% 0% !important;
+}
+
+.ogl-roi-tech.ogl-tech-122 {
+  background-position: 21.1% 68.96% !important;
+}
+
+.ogl-roi-tech.ogl-tech-124 {
+  background-position: 52.58% 68.96% !important;
+}
+
+.ogk-roi-desc {
+  align-self: center;
+  width: 675px;
+  height: fit-content;
+  overflow-wrap: break-word;
+  color: #5d7fa4;
+}
+
+.ogk-settings-box {
+  grid-template-columns: 60% 40%;
+  grid-gap: 10px;
+  width: fit-content;
+  margin: auto;
+  display: flex;
+  justify-content: center;
+  flex-direction: row;
+  align-self: center;
+}
+
+.ogk-tradeRate-box {
+  z-index: 1;
+  border-radius: 10px;
+  width: auto;
+  height: auto;
+  margin: 10px;
+  padding: 5px 15px 15px 15px;
+  background: rgb(13, 17, 23);
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  align-self: center;
+}
+
+.ogk-tradeRate-box .ogk-tradeRate-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 33px 45px);
+  width: 260px;
+  column-gap: 5px;
+  justify-items: baseline;
+}
+
+.ogk-tradeRate-box .ogk-tradeRate-text {
+  color: #5d7fa4;
+  width: 250px;
+  text-align: center;
+  font-size: 14px;
+  margin-bottom: 5px;
+}
+
+.ogl-tradeRate-input {
+  width: 32px;
+  height: 20px;
+  padding: 0px 5px !important;
+  margin: 2px 0px 2px 0px;
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.ogk-tradeRate-grid .resourceIcon {
+  height: 20px;
+  margin: 2px 0px 2px 0px;
+}
+
+.ogk-filter-box,
+.ogk-crawler-box {
+  z-index: 1;
+  border-radius: 10px;
+  width: auto;
+  height: auto;
+  margin: 10px;
+  padding: 5px 15px 15px 15px;
+  background: rgb(13, 17, 23);
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  align-self: center;
+}
+
+.ogk-filter-box .ogk-filter-text,
+.ogk-crawler-box .ogk-crawler-text {
+  color: #5d7fa4;
+  width: auto;
+  text-align: center;
+  font-size: 14px;
+  margin-bottom: 5px;
+}
+
+.ogk-crawler-box .ogk-crawler-grid {
+  display: grid;
+  grid-template-columns: 50px 15px;
+  width: auto;
+  column-gap: 5px;
+  justify-items: baseline;
+}
+
+select#filterRoi,
+select#crawlerPercent {
+  color: #5d7fa4;
+  background-color: #0d1014 !important;
+  border-color: rgb(58, 72, 86);
+  border-radius: 3px;
+}
+
+select#filterRoi>option,
+select#crawlerPercent>option {
+  color: #5d7fa4;
+  background-color: #0d1014 !important;
+  border-color: rgb(58, 72, 86);
+  border-radius: 3px;
+}
+
+.ogk-filter-box .ogk-filter-grid {
+  display: grid;
+  grid-template-columns: 150px 15px;
+  width: auto;
+  column-gap: 5px;
+  justify-items: baseline;
+}
+
+.overcharge {
+  color: #399fff !important;
+}
+
+.ogl-solar-satellite {
+  background-size: calc(100px * 5) !important;
+  background: url("https://gf3.geo.gfsrv.net/cdn53/7a9861be0c38bf7de05a57c56d73cf.jpg");
+  background-position: 67.9% 51.8% !important;
+  width: 10px;
+  height: 10px;
+  border: solid 1px #5f5d6b;
+  margin: 1px;
+  float: right !important;
+}
+
+.ogl-solar-satellite:hover {
+  border: solid 1px #da961a;
+}
+
+.ogl-solar-satellite:hover+span {
+  color: #da961a;
+}
+
+li.resource.energy.icon.insufficient {
+  width: fit-content !important;
+}
+
+#planetdata {
+  margin-top: 7px !important;
+  margin-right: 5px !important;
+  height: 220px !important;
+}
+
+#planetDetails {
+  height: 200px !important;
+  line-height: 13px !important;
+}
+
+#planetOptions {
+  margin: -1px 1px 2px 3px !important;
+}
+
+.noShips {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.noShips .ogl-res-transport {
+  grid-template-columns: repeat(4, 1fr 2fr);
+  height: 30px;
+  width: fit-content;
+}
+
+.noShips span {
+  width: fit-content;
+  color: #b00001;
+}
+
+.noShips a {
+  border-color: #b00001;
+}
+
+.ogl-tooltip .ogk-collect-cargo {
+  width: auto;
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+}
+
+.ogl-tooltip .ogk-expedition-cargo {
+  width: auto;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+}
+
+.ogl-fleet-ship.choice {
+  width: 20px;
+  height: 20px;
+  background-size: calc(50px * 10) !important;
+}
+
+.choice-mission-icon {
+  background: url("https://gf2.geo.gfsrv.net/cdn14/f45a18b5e55d2d38e7bdc3151b1fee.jpg") no-repeat;
+  width: 20px;
+  height: 20px;
+  background-size: 220px;
+  overflow: hidden;
+}
+
+.choice-mission-icon:hover {
+  border: solid 1px #da961a;
+}
+
+.choice-mission-icon.ogl-mission-3 {
+  background-position: -100px 0px !important;
+}
+
+.choice-mission-icon.ogl-mission-4 {
+  background-position: -60px 0px !important;
+}
+
+.choice-target {
+  width: 20px;
+  height: 20px;
+  margin-left: 0px !important;
+}
+
+.choice-target:hover {
+  border: solid 1px #da961a;
+}
+
+.choice-target.planet {
+  width: 20px;
+  height: 20px;
+  background: url("chrome-extension://__MSG_@@extension_id__/res/planet.png") no-repeat left top;
+  background-size: 20px 18px;
+  opacity: 0.6;
+}
+
+.choice-target.moon {
+  width: 20px;
+  height: 20px;
+  background: url("chrome-extension://__MSG_@@extension_id__/res/moon.png") no-repeat left top;
+  background-size: 24px 19px;
+  background-position: -2px, 2px;
+  opacity: 0.6;
+}
+
+.ogl-collect,
+.ogl-expedition {
+  background: url(https://gf2.geo.gfsrv.net/cdn7e/41c09757d8212f48fc574515c8bc87.jpg);
+  background-position: calc(-8px * 30) 0 !important;
+  background-size: calc(30px * 14) !important;
+  border: 1px solid #000;
+  cursor: pointer;
+  display: inline-block;
+  height: 30px;
+  position: relative;
+  width: 30px;
+  z-index: 10;
+}
+
+.ogl-expedition:before {
+  background: url(https://gf2.geo.gfsrv.net/cdn14/f45a18b5e55d2d38e7bdc3151b1fee.jpg) no-repeat;
+  background-size: calc(36px * 11) !important;
+  background-position: -3px -5px;
+  border: 1px solid #000;
+  content: "";
+  display: block;
+  height: 28px;
+  right: -5px;
+  position: absolute;
+  top: -5px;
+  transform: scale(0.5);
+  transform-origin: top right;
+  width: 28px;
+}
+
+.ogl-collect:before {
+  background: url(https://gf2.geo.gfsrv.net/cdn14/f45a18b5e55d2d38e7bdc3151b1fee.jpg) no-repeat;
+  background-size: calc(36px * 11) !important;
+  background-position: -40px -5px;
+  border: 1px solid #000;
+  content: "";
+  display: block;
+  height: 28px;
+  right: -5px;
+  position: absolute;
+  top: -5px;
+  transform: scale(0.5);
+  transform-origin: top right;
+  width: 28px;
+}
+
+.ogl-collect:after {
+  background: url(https://gf2.geo.gfsrv.net/cdn14/f45a18b5e55d2d38e7bdc3151b1fee.jpg) no-repeat;
+  background-size: calc(36px * 11) !important;
+  background-position: -184px -4px;
+  border: 1px solid #000;
+  content: "";
+  display: block;
+  height: 28px;
+  right: -6px;
+  position: absolute;
+  top: 2px;
+  transform: scale(0.25);
+  transform-origin: top right;
+  width: 28px;
+}
+
+.ogl-collect.statio:after {
+  background-position: -112px -4px;
+}
+
+.ogl-collect:hover,
+.ogl-expedition:hover {
+  border: 1px solid orange;
+}
+
+.ogl-collect.largeCargo,
+.ogl-expedition.largeCargo {
+  background-position: calc(-9px * 30) 0 !important;
+}
+
+.pathFinder {
+  background-size: calc(30px * 20) !important;
+  background: url("https://gf3.geo.gfsrv.net/cdn53/7a9861be0c38bf7de05a57c56d73cf.jpg");
+  background-position: calc(5.2625% * 15) 51.73% !important;
+  height: 30px;
+  width: 30px;
+}
+
+.ogl-target.mission-3 {
+  border-color: #7ead3d !important;
+}
+
+.ogl-target.mission-4 {
+  border-color: #34a37b !important;
+}
+
+.ogl-prodOverview-content td {
+  padding: 15px;
+}
+
+.ogl-prodOverview-content td {
+  column-width: 80px;
+}
+
+.ogl-prodOverview-icon {
+  background-size: calc(30px * 20) !important;
+  background: url("https://gf3.geo.gfsrv.net/cdn53/7a9861be0c38bf7de05a57c56d73cf.jpg");
+  height: 30px;
+  width: 30px;
+  border: solid 1px #5f5d6b;
+  margin: auto;
+  padding: 0 !important;
+}
+
+.ogl-prodOverview-icon.mines {
+  background-position: 0% 0% !important;
+}
+
+.ogl-prodOverview-icon.plasma {
+  background-position: calc(5.2625% * 4) 68.97% !important;
+}
+
+.ogl-prodOverview-icon.crawler {
+  background-position: calc(5.2625% * 16) 51.73% !important;
+}
+
+.ogl-prodOverview-icon.items {
+  background: url("https://gf2.geo.gfsrv.net/cdnab/0c604ee3171ccb9a2c6398fb543bda.png");
+  background-size: calc(30px * 14) !important;
+  background-position: 23% 50% !important;
+}
+
+.ogl-prodOverview-icon.lifeform {
+  background: url("https://gf3.geo.gfsrv.net/cdn81/ce44d444b7d14a3ea6fa51fa6c1148.png");
+  background-size: calc(30px * 16) !important;
+  background-position: 100% 50% !important;
+}
+
+.allOfficers.prodOverview {
+  transform: scale(0.3);
+  border: solid 1px #5f5d6b;
+  margin: auto;
+}
+
+.characterclass.medium.prodOverview {
+  transform: scale(0.5);
+  border: solid 1px #5f5d6b;
+  margin: auto;
+}
+
+.allianceclass.prodOverview {
+  transform: scale(0.5);
+  border: solid 1px #5f5d6b;
+  margin: auto;
+}
+
+.ogl-prodOverview-icon.energy {
+  background-position: calc(5.2625% * 4) 0% !important;
+}
+
+.planetlink.finished {
+  border: solid 1px orange;
+}
+
+.ogk-navPanel {
+  min-width: 125px;
+  width: max-content;
+  position: relative;
+  padding: 10px;
+  margin: 10px 0px 0px 10px;
+  display: grid;
+  align-content: center !important;
+  grid-gap: 10px;
+  grid-template-columns: 1fr 1fr;
+}
+
+.galaxy_icons.ogk-nav {
+  align-self: center;
+  height: 58px !important;
+  width: 58px !important;
+  background-size: 90px auto !important;
+  margin: 0px 0px 0px 0px;
+  border-radius: 10px 10px 10px 10px;
+}
+
+.galaxy_icons.ogk-nav.left {
+  background-position: 0px 0px !important;
+}
+
+.galaxy_icons.ogk-nav.right {
+  background-position: 0px -58px !important;
+}
+
+.galaxy_icons.ogk-nav.up {
+  background-position: 0px 0px !important;
+  transform: rotate(90deg);
+}
+
+.galaxy_icons.ogk-nav.down {
+  background-position: 0px -58px !important;
+  transform: rotate(90deg);
+}
+
+.galaxy_icons:hover {
+  outline: 1px solid #ffc937;
+}
+
+table.flyingFleet {
+  min-width: 130px;
+  width: max-content !important;
+  border-collapse: separate !important;
+  border-spacing: 0 !important;
+  text-indent: initial !important;
+}
+
+table.flyingFleet tr:nth-child(2n) {
+  box-shadow: rgba(0, 0, 0, 0.4) 0px 50px inset;
+}
+
+table.flyingFleet th {
+  font-weight: 700;
+  color: #848484;
+  text-align: left !important;
+  display: table-cell !important;
+}
+
+table.flyingFleet tr td {
+  text-align: left;
+  display: table-cell !important;
+}
+
+table.flyingFleet tr td,
+table.flyingFleet tr th {
+  padding: 2px 5px !important;
+}
+
+table.flyingFleet th.ogl-metal,
+table.flyingFleet td.ogl-metal {
+  color: #ffaacca1 !important;
+}
+
+table.flyingFleet th.ogl-crystal,
+table.flyingFleet td.ogl-crystal {
+  color: #73e5ffc7 !important;
+}
+
+table.flyingFleet th.ogl-deut,
+table.flyingFleet td.ogl-deut {
+  color: #a6e0b0 !important;
+}
+
+table.flyingFleet td.value {
+  text-align: right !important;
+  padding-left: 5px;
+}
+
+table.flyingFleet td.own {
+  color: #6f9fc8 !important;
+}
+
+table.flyingFleet td.friendly {
+  color: #d29d00 !important;
+}
+
+.smallplanet .lifeform-item-icon.small {
+  opacity: 40%;
+  position: relative;
+  left: 67px !important;
+  top: 1px !important;
 }

--- a/global.css
+++ b/global.css
@@ -206,6 +206,14 @@ input[type="text"].deuterium {
   box-shadow: none !important;
 }
 
+.ogl-fleet-coords + input[type="text"],
+input[id="food"],
+input[type="text"].food {
+  color: #f5b739 !important;
+  border: solid 1px rgb(58 72 86) !important;
+  box-shadow: none !important;
+}
+
 input[disabled] {
   filter: grayscale(1);
 }

--- a/global.css
+++ b/global.css
@@ -2042,7 +2042,7 @@ button.build-it_premium {
 
 #technologydetails .resource.icon {
   height: 75px !important;
-  width: 60px !important;
+  width: 60px;
   margin: 0 2px;
 }
 
@@ -7585,6 +7585,11 @@ select#crawlerPercent>option {
 
 li.resource.energy.icon.insufficient {
   width: fit-content !important;
+}
+
+li.resource {
+    width: fit-content !important;
+    min-width: 65px;
 }
 
 #planetdata {

--- a/global.css
+++ b/global.css
@@ -172,6 +172,16 @@ div#banner_skyscraper.fix-banner {
   background: linear-gradient(#1d2732, #131c24) !important;
 }
 
+input[type="text"],
+input[type="password"] {
+  background: -webkit-linear-gradient(top, #0d151b 0, #1f2a35 100%) !important;
+  color: #bbb !important;
+  border: solid 1px rgb(58 72 86) !important;
+  box-shadow: none !important;
+  line-height: 23px !important;
+  background: -webkit-linear-gradient(top, rgb(14 17 23) 0, rgb(35 43 51) 100%) !important;
+}
+
 .metal + input[type="text"],
 input[id="metal"],
 input[type="text"].metal {
@@ -203,16 +213,6 @@ input[disabled] {
 input[type="text"]::selection,
 input[type="password"]::selection {
   background-color: #a2a2a2;
-}
-
-input[type="text"],
-input[type="password"] {
-  background: -webkit-linear-gradient(top, #0d151b 0, #1f2a35 100%) !important;
-  color: #bbb;
-  border: solid 1px rgb(58 72 86) !important;
-  box-shadow: none !important;
-  line-height: 23px !important;
-  background: -webkit-linear-gradient(top, rgb(14 17 23) 0, rgb(35 43 51) 100%) !important;
 }
 
 .ogl-res-filler .ogk-real-cargo {

--- a/global.css
+++ b/global.css
@@ -3984,16 +3984,6 @@ button.build-it_premium:hover {
   font-style: italic !important;
 }
 
-.ogl-afull {
-  color: #d29d00 !important;
-  font-style: oblique;
-}
-
-.ogl-full {
-  color: #d43635 !important;
-  font-style: oblique;
-}
-
 .ogl-search-result {
   min-height: 100px;
   max-height: 200px;
@@ -6560,6 +6550,16 @@ table.fleetinfo tr:nth-last-child(1),
 .ogl-food,
 .hasLifeforms table.fleetinfo tr:nth-last-child(1) {
   color: #f5b739 !important;
+}
+
+.ogl-afull {
+  color: #d29d00 !important;
+  font-style: oblique;
+}
+
+.ogl-full {
+  color: #d43635 !important;
+  font-style: oblique;
 }
 
 .btn_blue {

--- a/global.css
+++ b/global.css
@@ -6137,7 +6137,7 @@ div[data-marker]:hover {
   padding: 10px;
   position: absolute;
   transform: translateX(-50%) translateY(-100%);
-  max-width: 400px;
+  max-width: 600px;
   width: max-content;
   z-index: 99999999 !important;
 }

--- a/global.css
+++ b/global.css
@@ -1890,6 +1890,10 @@ strong {
   font-weight: 800;
 }
 
+#technologydetails button.details {
+  color: #fff !important;
+}
+
 #technologydetails .ogk-lvl {
   font-size: 14px;
   font-weight: 800;

--- a/global.css
+++ b/global.css
@@ -390,7 +390,9 @@ input[type="password"]::selection {
 
 .ogl-settings {
   display: flex;
-  width: 650px;
+  width: fit-content;
+  min-width: 650px;
+  max-width: 900px;
   justify-content: space-around;
   overflow: auto;
 }
@@ -6298,7 +6300,7 @@ hr {
 }
 
 .ogl-dialogOverlay.ogl-active {
-  align-items: flex-start;
+  align-items: center;
   background: rgba(0, 0, 0, 0.7);
   display: flex;
   justify-content: center;
@@ -6308,6 +6310,12 @@ hr {
   height: 100%;
   width: 100%;
   z-index: 10000;
+}
+
+@supports selector(:has(*)) {
+  .ogl-dialogOverlay.ogl-active:has(div.ogl-tabs) {
+    align-items: flex-start;
+  }
 }
 
 .ogl-dialog {

--- a/global.css
+++ b/global.css
@@ -683,23 +683,26 @@ input[type="password"]::selection {
 
 #selectMinCrystal,
 #selectMinDeuterium,
+#selectMinFood,
 #selectMinMetal {
   position: relative;
-  left: -65px;
+  left: -74px;
 }
 
 #selectMaxCrystal,
 #selectMaxDeuterium,
+#selectMaxFood,
 #selectMaxMetal {
   position: relative;
-  left: -67px;
+  left: -76px;
 }
 
 #selectMostCrystal,
 #selectMostDeuterium,
+#selectMostFood,
 #selectMostMetal {
   position: relative;
-  left: -66px;
+  left: -75px;
 }
 
 .ogl-dest .ogl-planet-icon {
@@ -1239,6 +1242,7 @@ input[type="password"]::selection {
   display: block;
   margin-top: 1px;
   color: #ccc;
+  text-align: right;
 }
 
 #fleet3 #sendfleet #resources .res_wrap {

--- a/global.css
+++ b/global.css
@@ -1983,17 +1983,46 @@ strong {
   display: none !important;
 }
 
-a.build-it_premium,
-button.build-it_premium {
-  width: 150px !important;
-  background: transparent url("https://gf1.geo.gfsrv.net/cdnfc/35658d707df040ae66b71215d187c1.png") -30px 0 no-repeat !important;
+#technologydetails a.upgrade,
+#technologydetails button.upgrade {
+  width: 95px !important;
+  height: 36px !important;
+  background: transparent url("https://https://gf3.geo.gfsrv.net/cdneb/f5f81e8302aaad56c958c033677fb8.png") 0 0 no-repeat;
+  background-size: 367px !important;
   border-radius: 5px;
   padding: 0 !important;
 }
 
+#technologydetails a.upgrade:hover,
+#technologydetails button.upgrade:hover {
+  background-position-y: -36px !important;
+}
+
+a.build-it_premium,
+button.build-it_premium {
+  width: 95px !important;
+  height: 36px !important;
+  background: transparent url("https://gf1.geo.gfsrv.net/cdnfc/35658d707df040ae66b71215d187c1.png") 0 0 no-repeat !important;
+  background-size: 140px !important;
+  border-radius: 5px;
+  padding: 0 !important;
+}
+
+a.build-it_premium:hover,
+button.build-it_premium:hover {
+  background-position-y: -36px !important;
+}
+
+#technologydetails a.upgrade span,
+#technologydetails button.upgrade span {
+  font-size: 14px;
+  line-height: 36px !important;
+}
+
 #technologydetails button.build-it_premium span,
 #technologydetails button.build-it_premium:disabled span {
-  padding-left: 0 !important;
+  font-size: 14px;
+  line-height: 36px !important;
 }
 
 .premium_info {

--- a/global.css
+++ b/global.css
@@ -147,7 +147,11 @@
 
 #bannerSkyscrapercomponent {
   position: absolute;
-  left: 1150px;
+  left: 1160px;
+}
+
+#planetbarcomponent #bannerSkyscrapercomponent {
+  left: 318px;
 }
 
 div#bannerSkyscrapercomponent {

--- a/global.css
+++ b/global.css
@@ -145,18 +145,17 @@
   position: unset !important;
 }
 
-div#banner_skyscraper {
+#bannerSkyscrapercomponent {
   position: absolute;
-  top: 7.5em !important;
-  right: -120px !important;
-  }
-
-  div#banner_skyscraper a.close_details {
-    right: 0 !important
+  left: 1150px;
 }
 
-div#banner_skyscraper.fix-banner {
-  top: -4.5em !important;
+div#bannerSkyscrapercomponent {
+  margin: 0 !important;
+}
+
+div#banner_skyscraper a.close_details {
+  right: auto !important;
 }
 
 #galaxyContent td {
@@ -4491,7 +4490,7 @@ small {
 
 #pageContent > #right {
   float: left !important;
-  width: max-content !important;
+  width: 300px !important;
 }
 
 #top {
@@ -6540,18 +6539,26 @@ table.fleetinfo tr:nth-child(odd) {
 }
 
 .ogl-metal,
-table.fleetinfo tr:nth-last-child(3) {
+table.fleetinfo tr:nth-last-child(3),
+.hasLifeforms table.fleetinfo tr:nth-last-child(4) {
   color: #ffaacca1 !important;
 }
 
 .ogl-crystal,
-table.fleetinfo tr:nth-last-child(2) {
+table.fleetinfo tr:nth-last-child(2),
+.hasLifeforms table.fleetinfo tr:nth-last-child(3) {
   color: #73e5ffc7 !important;
 }
 
 .ogl-deut,
-table.fleetinfo tr:nth-last-child(1) {
+table.fleetinfo tr:nth-last-child(1),
+.hasLifeforms table.fleetinfo tr:nth-last-child(2) {
   color: #a6e0b0 !important;
+}
+
+.ogl-food,
+.hasLifeforms table.fleetinfo tr:nth-last-child(1) {
+  color: #f5b739 !important;
 }
 
 .btn_blue {
@@ -7253,39 +7260,8 @@ span.resbuttons {
   margin: 9px 0 !important;
 }
 
-/* SPytable MOD*/
-
-#messages .subtabs {
-  width: 665px !important;
-}
-
-#contentWrapper,
-#contentWrapper #buttonz {
-  width: 715px !important;
-}
-
-#contentWrapper #buttonz .content {
-  background-size: 715px !important;
-}
-
-#eventHeader {
-  background-size: 715px !important;
-}
-
-#eventFooter {
-  background-size: 707px !important;
-}
-
-#eventContent {
-  background-size: 700px !important;
-}
-
-#buttonz .header {
-  background-size: 715px !important;
-}
-
 .trash_box {
-  left: -654px !important;
+  left: -620px !important;
 }
 .ogi-loader-container {
   position: relative;
@@ -8011,4 +7987,5 @@ table.flyingFleet td.friendly {
   position: relative;
   left: 67px !important;
   top: 1px !important;
+  z-index: auto;
 }

--- a/global.css
+++ b/global.css
@@ -419,9 +419,10 @@ input[type="password"]::selection {
   margin-left: 30px;
 }
 
-.ogl-settings h1 {
+.ogl-settings h1,
+.ogl-settings h1.tooltip {
   font-weight: 800;
-  color: #5d7fa4;
+  color: #5d7fa4 !important;
   font-size: 12px;
 }
 

--- a/ogkush.js
+++ b/ogkush.js
@@ -8856,7 +8856,21 @@ class OGInfinity {
         player[i] += planet.production.production[1004][i];
         alliance[i] += planet.production.production[1005][i];
         energy[i] -= planet.production.production[12][i];
-        if (lifeform) lifeform[i] += planet.production.production[1006][i];
+        if (lifeform) lifeform[i] += (
+          planet.production.hourly[i] -
+          planet.production.production[1][i] -
+          planet.production.production[2][i] -
+          planet.production.production[3][i] -
+          planet.production.generalIncoming[i] -
+          planet.production.production[122][i] -
+          planet.production.production[217][i] -
+          planet.production.production[1000][i] -
+          planet.production.production[1001][i] -
+          planet.production.production[1003][i] -
+          planet.production.production[1004][i] -
+          planet.production.production[1005][i] -
+          planet.production.production[12][i]
+        );
       }
     });
     header.appendChild(this.createDOM("th", { class: "ogl-sum-symbol" }, "Σ"));
@@ -10572,18 +10586,6 @@ class OGInfinity {
         src: "https://gf3.geo.gfsrv.net/cdnea/fa0c8ee62604e3af52e6ef297faf3c.gif",
       })
     );
-    $("#selectMinMetal").after(
-      this.createDOM("a", { id: "selectMostMetal", class: "select-most-min" })
-    );
-    $("#selectMinCrystal").after(
-      this.createDOM("a", { id: "selectMostCrystal", class: "select-most-min" })
-    );
-    $("#selectMinDeuterium").after(
-      this.createDOM("a", {
-        id: "selectMostDeuterium",
-        class: "select-most-min",
-      })
-    );
     $("#selectMaxMetal").after(
       this.createDOM("span", { class: "ogi-metalLeft" }, "-")
     );
@@ -11770,7 +11772,8 @@ class OGInfinity {
           crystalFiller,
           document.querySelector("input#crystal"),
           deutFiller,
-          document.querySelector("input#deuterium")
+          document.querySelector("input#deuterium"),
+          document.querySelector("input#food")
         ].forEach(elem => {
           elem.addEventListener("keyup", (event) => {
             const CODE = event.code;
@@ -11801,7 +11804,8 @@ class OGInfinity {
           crystalFiller,
           document.querySelector("input#crystal"),
           deutFiller,
-          document.querySelector("input#deuterium")
+          document.querySelector("input#deuterium"),
+          document.querySelector("input#food")
         ].forEach(elem => {
           elem.addEventListener("input", (event) => {
             if (event.data == "K" || event.data == "k" || event.data == "0k") {
@@ -11829,10 +11833,17 @@ class OGInfinity {
           class: "select-most-min",
         })
       );
-      if (lifeforms)
+      if (lifeforms) {
+        $("#selectMinFood").after(
+          this.createDOM("a", {
+            id: "selectMostFood",
+            class: "select-most-min",
+          })
+        );
         $("#selectMaxFood").after(
           this.createDOM("span", { class: "ogi-foodLeft" }, "-")
         );
+      }
       $("#selectMaxMetal").after(
         this.createDOM("span", { class: "ogi-metalLeft" }, "-")
       );
@@ -12058,6 +12069,20 @@ class OGInfinity {
         fleetDispatcher.refresh();
         refreshRes();
       });
+      if (lifeforms) {
+        $("#selectMostFood").on("click", () => {
+          let capacity = fleetDispatcher.getFreeCargoSpace();
+          fleetDispatcher.cargoFood = Math.min(
+            fleetDispatcher.cargoFood + capacity,
+            Math.max(
+              0,
+              foodAvailable - (kept[3] || 0)
+            )
+          );
+          fleetDispatcher.refresh();
+          refreshRes();
+        });
+      }
       $("#backToFleet2").on("click", () => {
         firstResRefresh = true;
       });

--- a/ogkush.js
+++ b/ogkush.js
@@ -5658,18 +5658,18 @@ class OGInfinity {
     fleetInfo.appendChild(
       this.createDOM(
         "span",
-        {},
+        { class: "tooltip", "data-title": toFormatedNumber(totalSum) },
         `${this.getTranslatedText(63)}: <strong>${toFormatedNumber(
-          totalSum
+          totalSum, null, totalSum >= 1e6
         )}</strong><small> ${this.getTranslatedText(64)}</small>`
       )
     );
     fleetInfo.appendChild(
       this.createDOM(
         "span",
-        {},
+        { class: "tooltip", "data-title": toFormatedNumber(transport) },
         `${this.getTranslatedText(47)}: <strong>${toFormatedNumber(
-          transport
+          transport, null, transport >= 1e6
         )}</strong>`
       )
     );
@@ -5678,9 +5678,9 @@ class OGInfinity {
     fleetInfo.appendChild(
       this.createDOM(
         "span",
-        {},
+        { class: "tooltip", "data-title": toFormatedNumber(rcpower) },
         `${this.getTranslatedText(65)}: <strong>${toFormatedNumber(
-          rcpower
+          rcpower, null, rcpower >= 1e6
         )}</strong>`
       )
     );

--- a/ogkush.js
+++ b/ogkush.js
@@ -13163,15 +13163,15 @@ class OGInfinity {
 
   getFlyingRes() {
     let met = 0,
-      cri = 0,
-      deut = 0;
+        cri = 0,
+        deut = 0;
     let fleetCount = {};
     let uniques = {};
     let transports = {};
     let ids = [];
     let planets = {};
     document.querySelectorAll(".eventFleet").forEach((line) => {
-      let tooltip = line.querySelector(".tooltip");
+      let tooltip = line.querySelector(".icon_movement .tooltip");
       let id = Number(line.getAttribute("id").split("-")[1]);
       let back =
         line.getAttribute("data-return-flight") == "false" ? false : true;

--- a/ogkush.js
+++ b/ogkush.js
@@ -50,24 +50,10 @@ var dataHelper = (function () {
 
   return { getExpeditionType: expedition, getPlayer: Get, filter: filter };
 })();
-let dotted = (value) => parseInt(value).toLocaleString(separatorLang);
 let redirect = localStorage.getItem("ogl-redirect");
 if (redirect && redirect.indexOf("https") > -1) {
   localStorage.setItem("ogl-redirect", false);
   window.location.href = redirect;
-}
-
-let commaSeparator = ["en-US", "en-GB", "ro-RO"];
-
-let locale = document
-  .getElementById("cookiebanner")
-  .getAttribute("data-locale");
-let separatorLang;
-
-if (commaSeparator.indexOf(locale) !== -1) {
-  separatorLang = "en-US";
-} else {
-  separatorLang = "de-DE";
 }
 
 (function goodbyeTipped() {
@@ -106,7 +92,127 @@ Element.prototype.empty = function (e) {
 Element.prototype.html = function (html) {
   this.innerHTML = DOMPurify.sanitize(html);
 };
-let SHIP_COSTS = {
+
+function getSeparator(locale, separatorType) {
+  const numberWithGroupAndDecimalSeparator = 1000.1;
+  return Intl.NumberFormat(locale)
+    .formatToParts(numberWithGroupAndDecimalSeparator)
+    .find((part) => part.type === separatorType).value;
+}
+
+function toFormatedNumber(value, precision = null, units = false) {
+  let locale = document
+    .querySelector("#cookiebanner")
+    .getAttribute("data-locale");
+  if (isNaN(value) || value == undefined || value == null) return undefined;
+
+  if (units) {
+    let neg = false;
+    if (value < 0) {
+      neg = true;
+      value *= -1;
+    }
+
+    const abbrev = [
+      "",
+      LocalizationStrings["unitKilo"],
+      LocalizationStrings["unitMega"],
+      LocalizationStrings["unitMilliard"],
+      "T",
+    ];
+    const unrangifiedOrder = Math.floor(Math.log10(Math.abs(value)) / 3);
+    const order = Math.max(0, Math.min(unrangifiedOrder, abbrev.length - 1));
+    const suffix = abbrev[order];
+
+    if (precision == null) {
+      let significantDigits = 3;
+      let maxPrecision = String(value / Math.pow(10, order * 3)).split(".")[1]
+        ? String(value / Math.pow(10, order * 3)).split(".")[1].length
+        : 0;
+      let prevPrecision = Math.max(
+        significantDigits -
+          String(value / Math.pow(10, order * 3)).split(".")[0].length
+      );
+      for (let p = Math.min(maxPrecision, prevPrecision); p > 0; p--) {
+        if (
+          (value / Math.pow(10, order * 3))
+            .toLocaleString(locale, {
+              minimumFractionDigits: p,
+              maximumFractionDigits: p,
+            })
+            .slice(-1) != 0
+        ) {
+          precision = p;
+          break;
+        }
+      }
+    }
+    return (
+      (neg ? "-" : "") +
+      (value / Math.pow(10, order * 3)).toLocaleString(locale, {
+        minimumFractionDigits: precision,
+        maximumFractionDigits: precision,
+      }) +
+      suffix
+    );
+  } else {
+    return value.toLocaleString(locale, {
+      minimumFractionDigits: precision ? precision : 0,
+      maximumFractionDigits: precision ? precision : 2,
+    });
+  }
+}
+
+function fromFormatedNumber(value, int = false) {
+  let locale = document
+    .querySelector("#cookiebanner")
+    .getAttribute("data-locale");
+  let decimalSeparator = getSeparator(locale, "decimal");
+  let groupSeparator = getSeparator(locale, "group");
+  let order = 1;
+  if (value.includes("T")) {
+    order = 1e12;
+    value = value.replace("T", "");
+  }
+  if (value.includes(LocalizationStrings["unitMilliard"])) {
+    order = 1e9;
+    value = value.replace(LocalizationStrings["unitMilliard"], "");
+  }
+  if (value.includes(LocalizationStrings["unitMega"])) {
+    order = 1e6;
+    value = value.replace(LocalizationStrings["unitMega"], "");
+  }
+  if (value.includes(LocalizationStrings["unitKilo"]) || value.includes("k")) {
+    order = 1e3;
+    value = value.replace(LocalizationStrings["unitKilo"], "");
+  }
+  value = value.replaceAll(groupSeparator, "");
+  value = Number(value.replace(decimalSeparator, "."));
+  value *= order;
+  return int ? parseInt(value) : value;
+}
+
+function waitForElementToDisplay(
+  selector,
+  callback,
+  checkFrequencyInMs = 10,
+  timeoutInMs = 5000
+) {
+  var startTimeInMs = Date.now();
+  (function loopSearch() {
+    if (document.querySelector(selector) != null) {
+      callback();
+      return;
+    } else {
+      setTimeout(function () {
+        if (timeoutInMs && Date.now() - startTimeInMs > timeoutInMs) return;
+        loopSearch();
+      }, checkFrequencyInMs);
+    }
+  })();
+}
+
+const SHIP_COSTS = {
   202: [2, 2, 0],
   203: [6, 6, 0],
   204: [3, 1, 0],
@@ -125,7 +231,7 @@ let SHIP_COSTS = {
   219: [8, 15, 8],
 };
 
-let UNIVERSVIEW_LANGS = [
+const UNIVERSVIEW_LANGS = [
   "en",
   "cs",
   "es",
@@ -148,15 +254,1163 @@ let UNIVERSVIEW_LANGS = [
   "ko",
 ];
 
-let PLAYER_CLASS_EXPLORER = 3;
-let PLAYER_CLASS_WARRIOR = 2;
-let PLAYER_CLASS_MINER = 1;
-let PLAYER_CLASS_NONE = 0;
+const PLAYER_CLASS_EXPLORER = 3;
+const PLAYER_CLASS_WARRIOR = 2;
+const PLAYER_CLASS_MINER = 1;
+const PLAYER_CLASS_NONE = 0;
 
-let ALLY_CLASS_EXPLORER = 3;
-let ALLY_CLASS_WARRIOR = 2;
-let ALLY_CLASS_MINER = 1;
-let ALLY_CLASS_NONE = 0;
+const ALLY_CLASS_EXPLORER = 3;
+const ALLY_CLASS_WARRIOR = 2;
+const ALLY_CLASS_MINER = 1;
+const ALLY_CLASS_NONE = 0;
+
+const BUIDLING_INFO = {
+  // supplies
+  1: {
+    name: "Metal Mine",
+    baseCost: [60, 15, 0],
+    factorCost: 1.5,
+    baseCons: 10,
+    factorCons: 1.1,
+  },
+  2: {
+    name: "Crystal Mine",
+    baseCost: [48, 24, 0],
+    factorCost: 1.6,
+    baseCons: 10,
+    factorCons: 1.1,
+  },
+  3: {
+    name: "Deuterium Synthesizer",
+    baseCost: [225, 75, 0],
+    factorCost: 1.5,
+    baseCons: 20,
+    factorCons: 1.1,
+  },
+  4: {
+    name: "Solar Plant",
+    baseCost: [75, 30, 0],
+    factorCost: 1.5,
+  },
+  12: {
+    name: "Fusion Reactor",
+    baseCost: [900, 360, 180],
+    factorCost: 1.8,
+    baseCons: 10,
+    factorCons: 1.1,
+  },
+  22: {
+    name: "Metal Storage",
+    baseCost: [1000, 0, 0],
+    factorCost: 2,
+  },
+  23: {
+    name: "Crystal Storage",
+    baseCost: [1000, 500, 0],
+    factorCost: 2,
+  },
+  24: {
+    name: "Deuterium storage",
+    baseCost: [1000, 1000, 0],
+    factorCost: 2,
+  },
+  // Facilities
+  14: {
+    name: "Robotic Factory",
+    baseCost: [400, 120, 200],
+    factorCost: 2,
+  },
+  15: {
+    name: "Nanite Factory",
+    baseCost: [1000000, 500000, 100000],
+    factorCost: 2,
+  },
+  21: {
+    name: "Shipyard",
+    baseCost: [400, 200, 100],
+    factorCost: 2,
+  },
+  31: {
+    name: "Research Lab",
+    baseCost: [200, 400, 200],
+    factorCost: 2,
+  },
+  33: {
+    name: "Terraformer",
+    baseCost: [0, 50000, 100000, 1000],
+    factorCost: 2,
+    factorEnergy: 2,
+  },
+  34: {
+    name: "Alliance Depot",
+    baseCost: [20000, 40000, 0],
+    factorCost: 2,
+  },
+  36: {
+    name: "Space Dock",
+    baseCost: [200, 0, 50, 50],
+    factorCost: 5,
+    factorEnergy: 2.5,
+  },
+  44: {
+    name: "Missile Silo",
+    baseCost: [20000, 20000, 1000],
+    factorCost: 2,
+  },
+  // Moon
+  41: {
+    name: "Lunar Base",
+    baseCost: [20000, 40000, 20000],
+    factorCost: 2,
+  },
+  42: {
+    name: "Phalanx",
+    baseCost: [20000, 40000, 20000],
+    factorCost: 2,
+  },
+  43: {
+    name: "Star gate",
+    baseCost: [2000000, 4000000, 2000000],
+    factorCost: 2,
+  },
+  // Human
+  11101: {
+    name: "Residental Sector",
+    baseCost: [7, 2, 0],
+    factorCost: 1.2,
+    baseTime: 40,
+    factorTime: 1.21,
+  },
+  11102: {
+    name: "Biosphere Farm",
+    baseCost: [5, 2, 0, 8],
+    factorCost: 1.23,
+    factorEnergy: 1.02,
+    baseTime: 40,
+    factorTime: 1.25,
+  },
+  11103: {
+    name: "Research Centre",
+    baseCost: [20000, 25000, 10000],
+    factorCost: 1.3,
+    baseTime: 16000,
+    factorTime: 1.25,
+    baseCons: 10,
+    factorCons: 1.08,
+  },
+  11104: {
+    name: "Academy of Sciences",
+    baseCost: [5000, 3200, 1500],
+    factorCost: 1.7,
+    baseTime: 16000,
+    factorTime: 1.6,
+    baseCons: 15,
+    factorCons: 1.25,
+    basePop: 20000000,
+    factorPop: 1.1,
+  },
+  11105: {
+    name: "Neuro-Calibration Centre",
+    baseCost: [50000, 40000, 50000],
+    factorCost: 1.7,
+    baseTime: 64000,
+    factorTime: 1.7,
+    baseCons: 30,
+    factorCons: 1.25,
+    basePop: 100000000,
+    factorPop: 1.1,
+  },
+  11106: {
+    name: "High Energy Smelting",
+    baseCost: [9000, 6000, 3000],
+    factorCost: 1.5,
+    baseTime: 2000,
+    factorTime: 1.3,
+    baseCons: 40,
+    factorCons: 1.1,
+  },
+  11107: {
+    name: "Food Silo",
+    baseCost: [25000, 13000, 7000],
+    factorCost: 1.09,
+    baseTime: 12000,
+    factorTime: 1.17,
+  },
+  11108: {
+    name: "Fusion-Powered Production",
+    baseCost: [50000, 25000, 15000],
+    factorCost: 1.5,
+    baseTime: 28000,
+    factorTime: 1.2,
+    baseCons: 80,
+    factorCons: 1.1,
+  },
+  11109: {
+    name: "Skyscraper",
+    baseCost: [75000, 20000, 25000],
+    factorCost: 1.09,
+    baseTime: 40000,
+    factorTime: 1.2,
+    baseCons: 50,
+    factorCons: 1.02,
+  },
+  11110: {
+    name: "Biotech Lab",
+    baseCost: [150000, 30000, 15000],
+    factorCost: 1.12,
+    baseTime: 52000,
+    factorTime: 1.2,
+    baseCons: 60,
+    factorCons: 1.03,
+  },
+  11111: {
+    name: "Metropolis",
+    baseCost: [80000, 35000, 60000],
+    factorCost: 1.5,
+    baseTime: 90000,
+    factorTime: 1.3,
+    baseCons: 90,
+    factorCons: 1.05,
+  },
+  11112: {
+    name: "Planetary Shield",
+    baseCost: [250000, 125000, 125000],
+    factorCost: 1.2,
+    baseTime: 95000,
+    factorTime: 1.2,
+    baseCons: 100,
+    factorCons: 1.02,
+  },
+  // Rock"tal
+  12101: {
+    name: "Meditation Enclave",
+    baseCost: [9, 3, 0],
+    factorCost: 1.2,
+    baseTime: 40,
+    factorTime: 1.21,
+  },
+  12102: {
+    name: "Crystal Farm",
+    baseCost: [7, 2, 0, 10],
+    factorCost: 1.2,
+    factorEnergy: 1.03,
+    baseTime: 40,
+    factorTime: 1.21,
+  },
+  12103: {
+    name: "Rune Technologium",
+    baseCost: [40000, 10000, 15000],
+    factorCost: 1.3,
+    baseTime: 16000,
+    factorTime: 1.25,
+    baseCons: 15,
+    factorCons: 1.1,
+  },
+  12104: {
+    name: "Rune Forge",
+    baseCost: [5000, 3800, 1000],
+    factorCost: 1.7,
+    baseTime: 16000,
+    factorTime: 1.6,
+    baseCons: 20,
+    factorCons: 1.35,
+    basePop: 16000000,
+    factorPop: 1.14,
+  },
+  12105: {
+    name: "Oriktorium",
+    baseCost: [50000, 40000, 50000],
+    factorCost: 1.65,
+    baseTime: 64000,
+    factorTime: 1.7,
+    baseCons: 60,
+    factorCons: 1.3,
+    basePop: 90000000,
+    factorPop: 1.1,
+  },
+  12106: {
+    name: "Magma Forge",
+    baseCost: [10000, 8000, 1000],
+    factorCost: 1.4,
+    baseTime: 2000,
+    factorTime: 1.3,
+    baseCons: 40,
+    factorCons: 1.1,
+  },
+  12107: {
+    name: "Disruption Chamber",
+    baseCost: [20000, 15000, 10000],
+    factorCost: 1.2,
+    baseTime: 16000,
+    factorTime: 1.25,
+  },
+  12108: {
+    name: "Megalith",
+    baseCost: [50000, 35000, 15000],
+    factorCost: 1.5,
+    baseTime: 40000,
+    factorTime: 1.4,
+    baseCons: 80,
+    factorCons: 1.3,
+  },
+  12109: {
+    name: "Crystal Refinery",
+    baseCost: [85000, 44000, 25000],
+    factorCost: 1.4,
+    baseTime: 40000,
+    factorTime: 1.2,
+    baseCons: 90,
+    factorCons: 1.1,
+  },
+  12110: {
+    name: "Deuterium Synthesiser",
+    baseCost: [120000, 50000, 20000],
+    factorCost: 1.4,
+    baseTime: 52000,
+    factorTime: 1.2,
+    baseCons: 90,
+    factorCons: 1.1,
+  },
+  12111: {
+    name: "Mineral Research Centre",
+    baseCost: [250000, 150000, 100000],
+    factorCost: 1.8,
+    baseTime: 90000,
+    factorTime: 1.3,
+    baseCons: 120,
+    factorCons: 1.3,
+  },
+  12112: {
+    name: "Advanced Recycling Plant",
+    baseCost: [250000, 125000, 125000],
+    factorCost: 1.5,
+    baseTime: 95000,
+    factorTime: 1.3,
+    baseCons: 100,
+    factorCons: 1.1,
+  },
+  // Mecha
+  13101: {
+    name: "Assembly Line",
+    baseCost: [6, 2, 0],
+    factorCost: 1.21,
+    baseTime: 40,
+    factorTime: 1.22,
+  },
+  13102: {
+    name: "Fusion Cell Factory",
+    baseCost: [5, 2, 0, 8],
+    factorCost: 1.18,
+    factorEnergy: 1.02,
+    baseTime: 48,
+    factorTime: 1.2,
+  },
+  13103: {
+    name: "Robotics Research Centre",
+    baseCost: [30000, 20000, 10000],
+    factorCost: 1.3,
+    baseTime: 16000,
+    factorTime: 1.25,
+    baseCons: 13,
+    factorCons: 1.08,
+  },
+  13104: {
+    name: "Update Network",
+    baseCost: [5000, 3800, 1000],
+    factorCost: 1.8,
+    baseTime: 16000,
+    factorTime: 1.6,
+    baseCons: 10,
+    factorCons: 1.2,
+    basePop: 40000000,
+    factorPop: 1.1,
+  },
+  13105: {
+    name: "Quantum Computer Centre",
+    baseCost: [50000, 40000, 50000],
+    factorCost: 1.8,
+    baseTime: 64000,
+    factorTime: 1.7,
+    baseCons: 40,
+    factorCons: 1.2,
+    basePop: 130000000,
+    factorPop: 1.1,
+  },
+  13106: {
+    name: "Automatised Assembly Centre",
+    baseCost: [7500, 7000, 1000],
+    factorCost: 1.2,
+    baseTime: 2000,
+    factorTime: 1.3,
+  },
+  13107: {
+    name: "High-Performance Transformer",
+    baseCost: [35000, 15000, 10000],
+    factorCost: 1.5,
+    baseTime: 16000,
+    factorTime: 1.4,
+    baseCons: 40,
+    factorCons: 1.05,
+  },
+  13108: {
+    name: "Microchip Assembly Line",
+    baseCost: [50000, 20000, 30000],
+    factorCost: 1.07,
+    baseTime: 12000,
+    factorTime: 1.17,
+    baseCons: 40,
+    factorCons: 1.01,
+  },
+  13109: {
+    name: "Production Assembly Hall",
+    baseCost: [100000, 10000, 3000],
+    factorCost: 1.14,
+    baseTime: 40000,
+    factorTime: 1.3,
+    baseCons: 80,
+    factorCons: 1.04,
+  },
+  13110: {
+    name: "High-Performance Synthesiser",
+    baseCost: [100000, 40000, 20000],
+    factorCost: 1.5,
+    baseTime: 52000,
+    factorTime: 1.2,
+    baseCons: 60,
+    factorCons: 1.1,
+  },
+  13111: {
+    name: "Chip Mass Production",
+    baseCost: [55000, 50000, 30000],
+    factorCost: 1.5,
+    baseTime: 50000,
+    factorTime: 1.3,
+    baseCons: 70,
+    factorCons: 1.05,
+  },
+  13112: {
+    name: "Nano Repair Bots",
+    baseCost: [250000, 125000, 125000],
+    factorCost: 1.4,
+    baseTime: 95000,
+    factorTime: 1.4,
+    baseCons: 100,
+    factorCons: 1.05,
+  },
+  // Kaelesh
+  14101: {
+    name: "Sanctuary",
+    baseCost: [4, 3, 0],
+    factorCost: 1.21,
+    baseTime: 40,
+    factorTime: 1.22,
+  },
+  14102: {
+    name: "Antimatter Condenser",
+    baseCost: [6, 3, 0, 9],
+    factorCost: 1.21,
+    factorEnergy: 1.02,
+    baseTime: 40,
+    factorTime: 1.22,
+  },
+  14103: {
+    name: "Vortex Chamber",
+    baseCost: [20000, 20000, 30000],
+    factorCost: 1.3,
+    baseTime: 16000,
+    factorTime: 1.25,
+    baseCons: 10,
+    factorCons: 1.08,
+  },
+  14104: {
+    name: "Halls of Realisation",
+    baseCost: [7500, 5000, 800],
+    factorCost: 1.8,
+    baseTime: 16000,
+    factorTime: 1.7,
+    baseCons: 15,
+    factorCons: 1.3,
+    basePop: 30000000,
+    factorPop: 1.1,
+  },
+  14105: {
+    name: "Forum of Transcendence",
+    baseCost: [60000, 30000, 50000],
+    factorCost: 1.8,
+    baseTime: 64000,
+    factorTime: 1.8,
+    baseCons: 30,
+    factorCons: 1.3,
+    basePop: 100000000,
+    factorPop: 1.1,
+  },
+  14106: {
+    name: "Antimatter Convector",
+    baseCost: [8500, 5000, 3000],
+    factorCost: 1.25,
+    baseTime: 2000,
+    factorTime: 1.35,
+  },
+  14107: {
+    name: "Cloning Laboratory",
+    baseCost: [15000, 15000, 20000],
+    factorCost: 1.2,
+    baseTime: 12000,
+    factorTime: 1.2,
+  },
+  14108: {
+    name: "Chrysalis Accelerator",
+    baseCost: [75000, 25000, 30000],
+    factorCost: 1.05,
+    baseTime: 16000,
+    factorTime: 1.18,
+    baseCons: 30,
+    factorCons: 1.03,
+  },
+  14109: {
+    name: "Bio Modifier",
+    baseCost: [87500, 25000, 30000],
+    factorCost: 1.2,
+    baseTime: 40000,
+    factorTime: 1.2,
+    baseCons: 40,
+    factorCons: 1.02,
+  },
+  14110: {
+    name: "Psionic Modulator",
+    baseCost: [150000, 30000, 30000],
+    factorCost: 1.5,
+    baseTime: 52000,
+    factorTime: 1.8,
+    baseCons: 140,
+    factorCons: 1.05,
+  },
+  14111: {
+    name: "Ship Manufacturing Hall",
+    baseCost: [75000, 50000, 55000],
+    factorCost: 1.2,
+    baseTime: 90000,
+    factorTime: 1.3,
+    baseCons: 90,
+    factorCons: 1.04,
+  },
+  14112: {
+    name: "Supra Refractor",
+    baseCost: [500000, 250000, 250000],
+    factorCost: 1.4,
+    baseTime: 95000,
+    factorTime: 1.3,
+    baseCons: 100,
+    factorCons: 1.05,
+  },
+};
+const RESEARCH_INFO = {
+  // research
+  106: {
+    name: "Espionnage Technology",
+    baseCost: [200, 1000, 200],
+    factorCost: 2,
+  },
+  108: {
+    name: "Computer Technology",
+    baseCost: [0, 400, 600],
+    factorCost: 2,
+  },
+  109: {
+    name: "Weapons Technology",
+    baseCost: [800, 200, 0],
+    factorCost: 2,
+  },
+  110: {
+    name: "Shielding Technology",
+    baseCost: [200, 600, 0],
+    factorCost: 2,
+  },
+  111: {
+    name: "Armour Technology",
+    baseCost: [1000, 0, 0],
+    factorCost: 2,
+  },
+  113: {
+    name: "Energy Technology",
+    baseCost: [0, 800, 400],
+    factorCost: 2,
+  },
+  114: {
+    name: "Hyperspace Technology",
+    baseCost: [0, 4000, 2000],
+    factorCost: 2,
+  },
+  115: {
+    name: "Combustion Drive",
+    baseCost: [400, 0, 600],
+    factorCost: 2,
+  },
+  117: {
+    name: "Impulse Drive",
+    baseCost: [2000, 4000, 600],
+    factorCost: 2,
+  },
+  118: {
+    name: "Hyperspace Drive",
+    baseCost: [10000, 20000, 6000],
+    factorCost: 2,
+  },
+  120: {
+    name: "Laser Technology",
+    baseCost: [200, 100, 0],
+    factorCost: 2,
+  },
+  121: {
+    name: "Ion Technology",
+    baseCost: [1000, 300, 100],
+    factorCost: 2,
+  },
+  122: {
+    name: "Plasma Technology",
+    baseCost: [2000, 4000, 1000],
+    factorCost: 2,
+  },
+  123: {
+    name: "Intergalactic Research Network",
+    baseCost: [240000, 400000, 16e4],
+    factorCost: 2,
+  },
+  124: {
+    name: "Astrophysics",
+    baseCost: [4000, 8000, 4000],
+    factorCost: 1.75,
+  },
+  199: {
+    name: "Graviton Technology",
+    baseCost: [0, 0, 0, 300000],
+    factorCost: 2,
+    factorEnergy: 3,
+  },
+  // Human
+  11201: {
+    name: "Intergalactic Envoys",
+    baseCost: [5000, 2500, 500],
+    factorCost: 1.3,
+    baseTime: 1000,
+    factorTime: 1.2,
+  },
+  11202: {
+    name: "High-Performance Extractors",
+    baseCost: [7000, 10000, 5000],
+    factorCost: 1.5,
+    baseTime: 2000,
+    factorTime: 1.3,
+    bonus: [0.06, 0.06, 0.06], // in %
+  },
+  11203: {
+    name: "Fusion Drives",
+    baseCost: [15000, 10000, 5000],
+    factorCost: 1.3,
+    baseTime: 2500,
+    factorTime: 1.3,
+  },
+  11204: {
+    name: "Stealth Field Generator",
+    baseCost: [20000, 15000, 7500],
+    factorCost: 1.3,
+    baseTime: 3500,
+    factorTime: 1.3,
+  },
+  11205: {
+    name: "Orbital Den",
+    baseCost: [25000, 20000, 10000],
+    factorCost: 1.4,
+    baseTime: 4500,
+    factorTime: 1.2,
+  },
+  11206: {
+    name: "Research AI",
+    baseCost: [35000, 25000, 15000],
+    factorCost: 1.5,
+    baseTime: 5000,
+    factorTime: 1.3,
+  },
+  11207: {
+    name: "High-Performance Terraformer",
+    baseCost: [70000, 40000, 20000],
+    factorCost: 1.3,
+    baseTime: 8000,
+    factorTime: 1.3,
+  },
+  11208: {
+    name: "Enhanced Production Technologies",
+    baseCost: [80000, 50000, 20000],
+    factorCost: 1.5,
+    baseTime: 6000,
+    factorTime: 1.3,
+    bonus: [0.06, 0.06, 0.06], // in %
+  },
+  11209: {
+    name: "Light Fighter Mk II",
+    baseCost: [320000, 240000, 10000],
+    factorCost: 1.5,
+    baseTime: 6500,
+    factorTime: 1.4,
+  },
+  11210: {
+    name: "Cruiser Mk II",
+    baseCost: [320000, 240000, 10000],
+    factorCost: 1,
+    baseTime: 7000,
+    factorTime: 1.4,
+  },
+  11211: {
+    name: "Improved Lab Technology",
+    baseCost: [120000, 30000, 25000],
+    factorCost: 1.5,
+    baseTime: 7500,
+    factorTime: 1.3,
+  },
+  11212: {
+    name: "Plasma Terraformer",
+    baseCost: [100000, 40000, 30000],
+    factorCost: 1.3,
+    baseTime: 10000,
+    factorTime: 1.3,
+  },
+  11213: {
+    name: "Low-Temperature Drives",
+    baseCost: [200000, 100000, 100000],
+    factorCost: 1.3,
+    baseTime: 8500,
+    factorTime: 1.3,
+  },
+  11214: {
+    name: "Bomber Mk II",
+    baseCost: [160000, 120000, 50000],
+    factorCost: 1.5,
+    baseTime: 9000,
+    factorTime: 1.4,
+  },
+  11215: {
+    name: "Destroyer Mk II",
+    baseCost: [160000, 120000, 50000],
+    factorCost: 1.5,
+    baseTime: 9500,
+    factorTime: 1.4,
+  },
+  11216: {
+    name: "Battlecruiser Mk II",
+    baseCost: [320000, 240000, 100000],
+    factorCost: 1.5,
+    baseTime: 10000,
+    factorTime: 1.4,
+  },
+  11217: {
+    name: "Robot Assistants",
+    baseCost: [300000, 180000, 120000],
+    factorCost: 1.5,
+    baseTime: 11000,
+    factorTime: 1.3,
+  },
+  11218: {
+    name: "Supercomputer",
+    baseCost: [500000, 300000, 200000],
+    factorCost: 1.3,
+    baseTime: 13000,
+    factorTime: 1.3,
+  },
+  // Rock"tal
+  12201: {
+    name: "Volcanic Batteries",
+    baseCost: [10000, 6000, 1000],
+    factorCost: 1.5,
+    baseTime: 1000,
+    factorTime: 1.3,
+  },
+  12202: {
+    name: "Acoustic Scanning",
+    baseCost: [7500, 12500, 5000],
+    factorCost: 1.5,
+    baseTime: 2000,
+    factorTime: 1.3,
+    bonus: [0, 0.08, 0], // in %
+  },
+  12203: {
+    name: "High Energy Pump Systems",
+    baseCost: [15000, 10000, 5000],
+    factorCost: 1.5,
+    baseTime: 2500,
+    factorTime: 1.3,
+    bonus: [0, 0, 0.08], // in %
+  },
+  12204: {
+    name: "Cargo Hold Expansion (Civilian Ships)",
+    baseCost: [20000, 15000, 7500],
+    factorCost: 1.3,
+    baseTime: 3500,
+    factorTime: 1.4,
+  },
+  12205: {
+    name: "Magma-Powered Production",
+    baseCost: [25000, 20000, 10000],
+    factorCost: 1.5,
+    baseTime: 4500,
+    factorTime: 1.3,
+    bonus: [0.06, 0.06, 0.06], // in %
+  },
+  12206: {
+    name: "Geothermal Power Plants",
+    baseCost: [50000, 50000, 20000],
+    factorCost: 1.5,
+    baseTime: 5000,
+    factorTime: 1.3,
+  },
+  12207: {
+    name: "Depth Sounding",
+    baseCost: [70000, 40000, 20000],
+    factorCost: 1.5,
+    baseTime: 5500,
+    factorTime: 1.3,
+    bonus: [0.08, 0, 0], // in %
+  },
+  12208: {
+    name: "Ion Crystal Enhancement (Heavy Fighter)",
+    baseCost: [160000, 120000, 50000],
+    factorCost: 1.5,
+    baseTime: 6000,
+    factorTime: 1.4,
+  },
+  12209: {
+    name: "Improved Stellarator",
+    baseCost: [75000, 55000, 25000],
+    factorCost: 1.5,
+    baseTime: 6500,
+    factorTime: 1.3,
+  },
+  12210: {
+    name: "Hardened Diamond Drill Heads",
+    baseCost: [85000, 40000, 35000],
+    factorCost: 1.5,
+    baseTime: 7000,
+    factorTime: 1.3,
+    bonus: [0.08, 0, 0], // in %
+  },
+  12211: {
+    name: "Seismic Mining Technology",
+    baseCost: [120000, 30000, 25000],
+    factorCost: 1.5,
+    baseTime: 7500,
+    factorTime: 1.3,
+    bonus: [0, 0.08, 0], // in %
+  },
+  12212: {
+    name: "Magma-Powered Pump Systems",
+    baseCost: [100000, 40000, 30000],
+    factorCost: 1.5,
+    baseTime: 8000,
+    factorTime: 1.3,
+    bonus: [0, 0, 0.08], // in %
+  },
+  12213: {
+    name: "Ion Crystal Modules",
+    baseCost: [200000, 100000, 100000],
+    factorCost: 1.2,
+    baseTime: 8500,
+    factorTime: 1.3,
+    // TO DO: some kind of bonus to get amortisation?
+  },
+  12214: {
+    name: "Optimised Silo Construction Method",
+    baseCost: [220000, 110000, 110000],
+    factorCost: 1.3,
+    baseTime: 9000,
+    factorTime: 1.3,
+  },
+  12215: {
+    name: "Diamond Energy Transmitter",
+    baseCost: [240000, 120000, 120000],
+    factorCost: 1.3,
+    baseTime: 9500,
+    factorTime: 1.3,
+  },
+  12216: {
+    name: "Obsidian Shield Reinforcement",
+    baseCost: [250000, 250000, 250000],
+    factorCost: 1.4,
+    baseTime: 10000,
+    factorTime: 1.4,
+  },
+  12217: {
+    name: "Rune Shields",
+    baseCost: [500000, 300000, 200000],
+    factorCost: 1.5,
+    baseTime: 13000,
+    factorTime: 1.3,
+  },
+  12218: {
+    name: "Rock’tal Collector Enhancement",
+    baseCost: [300000, 180000, 120000],
+    factorCost: 1.7,
+    baseTime: 11000,
+    factorTime: 1.4,
+  },
+  // Mecha
+  13201: {
+    name: "Catalyser Technology",
+    baseCost: [10000, 6000, 1000],
+    factorCost: 1.5,
+    baseTime: 1000,
+    factorTime: 1.3,
+    bonus: [0, 0, 0.08], // in %
+  },
+  13202: {
+    name: "Plasma Drive",
+    baseCost: [7500, 12500, 5000],
+    factorCost: 1.3,
+    baseTime: 2000,
+    factorTime: 1.3,
+  },
+  13203: {
+    name: "Efficiency Module",
+    baseCost: [15000, 10000, 5000],
+    factorCost: 1.5,
+    baseTime: 2500,
+    factorTime: 1.4,
+  },
+  13204: {
+    name: "Depot AI",
+    baseCost: [20000, 15000, 7500],
+    factorCost: 1.3,
+    baseTime: 3500,
+    factorTime: 1.3,
+  },
+  13205: {
+    name: "General Overhaul (Light Fighter)",
+    baseCost: [160000, 120000, 50000],
+    factorCost: 1.5,
+    baseTime: 4500,
+    factorTime: 1.4,
+  },
+  13206: {
+    name: "Automated Transport Lines",
+    baseCost: [50000, 50000, 20000],
+    factorCost: 1.5,
+    baseTime: 5000,
+    factorTime: 1.3,
+    bonus: [0.06, 0.06, 0.06], // in %
+  },
+  13207: {
+    name: "Improved Drone AI",
+    baseCost: [70000, 40000, 20000],
+    factorCost: 1.3,
+    baseTime: 5500,
+    factorTime: 1.3,
+  },
+  13208: {
+    name: "Experimental Recycling Technology",
+    baseCost: [160000, 120000, 50000],
+    factorCost: 1.5,
+    baseTime: 6000,
+    factorTime: 1.4,
+  },
+  13209: {
+    name: "General Overhaul (Cruiser)",
+    baseCost: [160000, 125000, 50000],
+    factorCost: 1.5,
+    baseTime: 6500,
+    factorTime: 1.4,
+  },
+  13210: {
+    name: "Slingshot Autopilot",
+    baseCost: [85000, 40000, 35000],
+    factorCost: 1.2,
+    baseTime: 7000,
+    factorTime: 1.3,
+  },
+  13211: {
+    name: "High-Temperature Superconductors",
+    baseCost: [120000, 30000, 25000],
+    factorCost: 1.3,
+    baseTime: 7500,
+    factorTime: 1.3,
+  },
+  13212: {
+    name: "General Overhaul (Battleship)",
+    baseCost: [160000, 120000, 50000],
+    factorCost: 1.5,
+    baseTime: 8000,
+    factorTime: 1.4,
+  },
+  13213: {
+    name: "Artificial Swarm Intelligence",
+    baseCost: [200000, 100000, 100000],
+    factorCost: 1.5,
+    baseTime: 8500,
+    factorTime: 1.3,
+    bonus: [0.06, 0.06, 0, 0], // %
+  },
+  13214: {
+    name: "General Overhaul (Battlecruiser)",
+    baseCost: [160000, 120000, 50000],
+    factorCost: 1.5,
+    baseTime: 9000,
+    factorTime: 1.4,
+  },
+  13215: {
+    name: "General Overhaul (Bomber)",
+    baseCost: [320000, 240000, 100000],
+    factorCost: 1.2,
+    baseTime: 9500,
+    factorTime: 1.4,
+  },
+  13216: {
+    name: "General Overhaul (Destroyer)",
+    baseCost: [320000, 240000, 100000],
+    factorCost: 1.5,
+    baseTime: 10000,
+    factorTime: 1.4,
+  },
+  13217: {
+    name: "Experimental Weapons Technology",
+    baseCost: [500000, 300000, 200000],
+    factorCost: 1.5,
+    baseTime: 13000,
+    factorTime: 1.3,
+  },
+  13218: {
+    name: "Mechan General Enhancement",
+    baseCost: [300000, 180000, 120000],
+    factorCost: 1.7,
+    baseTime: 11000,
+    factorTime: 1.4,
+  },
+  //Kaelesh
+  14201: {
+    name: "Heat Recovery",
+    baseCost: [10000, 6000, 1000],
+    factorCost: 1.5,
+    baseTime: 1000,
+    factorTime: 1.4,
+  },
+  14202: {
+    name: "Sulphide Process",
+    baseCost: [7500, 12500, 5000],
+    factorCost: 1.5,
+    baseTime: 2000,
+    factorTime: 1.3,
+    bonus: [0, 0, 0.08], // in %
+  },
+  14203: {
+    name: "Psionic Network",
+    baseCost: [15000, 10000, 5000],
+    factorCost: 1.5,
+    baseTime: 2500,
+    factorTime: 1.4,
+  },
+  14204: {
+    name: "Telekinetic Tractor Beam",
+    baseCost: [20000, 15000, 7500],
+    factorCost: 1.5,
+    baseTime: 3500,
+    factorTime: 1.4,
+  },
+  14205: {
+    name: "Enhanced Sensor Technology",
+    baseCost: [25000, 20000, 10000],
+    factorCost: 1.5,
+    baseTime: 4500,
+    factorTime: 1.4,
+  },
+  14206: {
+    name: "Neuromodal Compressor",
+    baseCost: [50000, 50000, 20000],
+    factorCost: 1.3,
+    baseTime: 5000,
+    factorTime: 1.4,
+  },
+  14207: {
+    name: "Neuro-Interface",
+    baseCost: [70000, 40000, 20000],
+    factorCost: 1.5,
+    baseTime: 5500,
+    factorTime: 1.3,
+  },
+  14208: {
+    name: "Interplanetary Analysis Network",
+    baseCost: [80000, 50000, 20000],
+    factorCost: 1.2,
+    baseTime: 6000,
+    factorTime: 1.2,
+  },
+  14209: {
+    name: "Overclocking (Heavy Fighter)",
+    baseCost: [320000, 240000, 100000],
+    factorCost: 1.5,
+    baseTime: 6500,
+    factorTime: 1.4,
+  },
+  14210: {
+    name: "Telekinetic Drive",
+    baseCost: [85000, 40000, 35000],
+    factorCost: 1.2,
+    baseTime: 7000,
+    factorTime: 1.2,
+  },
+  14211: {
+    name: "Sixth Sense",
+    baseCost: [120000, 30000, 25000],
+    factorCost: 1.5,
+    baseTime: 7500,
+    factorTime: 1.4,
+  },
+  14212: {
+    name: "Psychoharmoniser",
+    baseCost: [100000, 40000, 30000],
+    factorCost: 1.5,
+    baseTime: 8000,
+    factorTime: 1.3,
+    bonus: [0.06, 0.06, 0, 0], // %
+  },
+  14213: {
+    name: "Efficient Swarm Intelligence",
+    baseCost: [200000, 100000, 100000],
+    factorCost: 1.5,
+    baseTime: 8500,
+    factorTime: 1.3,
+  },
+  14214: {
+    name: "Overclocking (Large Cargo)",
+    baseCost: [160000, 120000, 50000],
+    factorCost: 1.5,
+    baseTime: 9000,
+    factorTime: 1.4,
+  },
+  14215: {
+    name: "Gravitation Sensors",
+    baseCost: [240000, 120000, 120000],
+    factorCost: 1.5,
+    baseTime: 9500,
+    factorTime: 1.4,
+  },
+  14216: {
+    name: "Overclocking (Battleship)",
+    baseCost: [320000, 240000, 100000],
+    factorCost: 1.5,
+    baseTime: 10000,
+    factorTime: 1.4,
+  },
+  14217: {
+    name: "Psionic Shield Matrix",
+    baseCost: [500000, 300000, 200000],
+    factorCost: 1.5,
+    baseTime: 13000,
+    factorTime: 1.3,
+  },
+  14218: {
+    name: "Kaelesh Discoverer Enhancement",
+    baseCost: [300000, 180000, 120000],
+    factorCost: 1.7,
+    baseTime: 11000,
+    factorTime: 1.4,
+  },
+};
 
 class OGInfinity {
   constructor() {
@@ -181,6 +1435,10 @@ class OGInfinity {
     this.eventAction = this.isMobile ? "touchstart" : "mouseenter";
     this.universe = window.location.host.replace(/\D/g, "");
     this.geologist = document.querySelector(".geologist.on") ? true : false;
+    this.technocrat = document.querySelector(".technocrat.on") ? true : false;
+    this.admiral = document.querySelector(".admiral.on") ? true : false;
+    this.engineer = document.querySelector(".engineer.on") ? true : false;
+    this.allOfficers = document.querySelector("#officers.all") ? true : false;
     this.highlighted = false;
     this.tooltipList = {};
     this.current = {};
@@ -191,6 +1449,7 @@ class OGInfinity {
     document
       .querySelectorAll(".planet-koords")
       .forEach((elem) => (elem.textContent = elem.textContent.slice(1, -1)));
+    this.current.id = parseInt(this.current.planet.id.split("-")[1]);
     this.current.coords =
       this.current.planet.querySelector(".planet-koords").textContent;
     this.current.hasMoon = this.current.planet.querySelector(".moonlink")
@@ -226,20 +1485,14 @@ class OGInfinity {
       crystal: 0,
       deuterium: 0,
       fleet: [],
+      ids: [],
     };
     this.json.coordsHistory = this.json.coordsHistory || [];
     this.json.trashsimSettings = this.json.trashsimSettings || false;
     this.json.topScore = this.json.topScore || 0;
     this.json.shipNames = this.json.shipNames || false;
     this.json.resNames = this.json.resNames || false;
-    this.json.apiTechData = this.json.apiTechData || {};
-    this.json.ptFret = this.json.ptFret || 5e3;
-    this.json.gtFret = this.json.gtFret || 25e3;
-    this.json.pfFret = this.json.pfFret || 1e4;
-    this.json.cyFret = this.json.cyFret || 2e4;
-    this.json.pbFret = this.json.pbFret || 0;
     this.json.autoHarvest = this.json.autoHarvest || ["0:0:0", 3];
-    this.json.myMines = this.json.myMines || {};
     this.json.myActivities = this.json.myActivities || {};
     this.json.sideStalk = this.json.sideStalk || [];
     this.json.markers = this.json.markers || {};
@@ -248,16 +1501,44 @@ class OGInfinity {
     this.json.targetTabs = this.json.targetTabs || { g: 1, s: 0 };
     this.json.spyProbes = this.json.spyProbes || 5;
     this.json.openTooltip = this.json.openTooltip || false;
-    this.json.tech114 = this.json.tech114 || 0;
-    this.json.tech113 = this.json.tech113 || 0;
-    this.json.tech122 = this.json.tech122 || 0;
-    this.json.tech124 = this.json.tech124 || 0;
-    this.json.tech108 = this.json.tech108 || 0;
+    this.json.technology = this.json.technology || {
+      106: 0,
+      108: 0,
+      109: 0,
+      110: 0,
+      111: 0,
+      113: 0,
+      114: 0,
+      115: 0,
+      117: 0,
+      118: 0,
+      120: 0,
+      121: 0,
+      122: 0,
+      123: 0,
+      124: 0,
+      199: 0,
+    };
+    this.json.ships = this.json.ships || {};
+    this.json.allianceClass = this.json.allianceClass || ALLY_CLASS_NONE;
+    this.json.productionProgress = this.json.productionProgress || {};
+    this.json.lfProductionProgress = this.json.lfProductionProgress || {};
+    this.json.researchProgress = this.json.researchProgress || {};
+    this.json.lfResearchProgress = this.json.lfResearchProgress || {};
     this.json.tchat = this.json.tchat || false;
-    this.json.lastResUpdate = this.json.lastResUpdate || new Date();
-    this.json.myRes = this.json.myRes || {};
+    this.json.needSync = this.json.needSync || false;
     this.json.timezoneDiff = this.json.timezoneDiff || 0;
     this.json.options = this.json.options || {};
+    this.json.options.collect = this.json.options.collect || {
+      target: { galaxy: 0, system: 0, position: 0, type: 1 },
+      mission: 3, // 3 = transport, 4 = deployment
+      ship: 202, // 202 = small cargo, 203 = large cargo
+    };
+    this.json.options.maxCrawler = this.json.options.limitCrawler || false;
+    this.json.options.crawlerPercent = this.json.options.crawlerPercent || 1.5;
+    this.json.options.tradeRate = this.json.options.tradeRate || [
+      2.5, 1.5, 1, 0,
+    ];
     this.json.options.dispatcher =
       this.json.options.dispatcher === true ? true : false;
     this.json.options.sideStalkVisible =
@@ -341,33 +1622,22 @@ class OGInfinity {
         resourcesBar.resources.darkmatter.tooltip.split("|")[0];
     }
     if (this.page == "fleetdispatch") {
-      if (!this.json.shipNames) {
-        this.json.shipNames = {};
-        for (let id in fleetDispatcher.fleetHelper.shipsData) {
-          let name = fleetDispatcher.fleetHelper.shipsData[id].name;
-          this.json.shipNames[name] = id;
-        }
+      this.json.shipNames = {};
+      for (let id in fleetDispatcher.fleetHelper.shipsData) {
+        this.json.shipNames[fleetDispatcher.fleetHelper.shipsData[id].name] =
+          id;
+        this.json.ships[id] = {
+          name: fleetDispatcher.fleetHelper.shipsData[id].name,
+          cargoCapacity:
+            fleetDispatcher.fleetHelper.shipsData[id].cargoCapacity,
+          speed: fleetDispatcher.fleetHelper.shipsData[id].speed,
+          fuelConsumption:
+            fleetDispatcher.fleetHelper.shipsData[id].fuelConsumption,
+        };
       }
       fleetDispatcher.apiTechData.forEach((tech) => {
-        this.json.apiTechData[tech[0]] = tech[1];
-        if (tech[0] == 114) this.json.tech114 = tech[1];
+        this.json.technology[tech[0]] = tech[1];
       });
-      this.json.ptFret =
-        fleetDispatcher.fleetHelper.shipsData[202].baseCargoCapacity;
-      this.json.gtFret =
-        fleetDispatcher.fleetHelper.shipsData[203].baseCargoCapacity;
-      this.json.pfFret =
-        fleetDispatcher.fleetHelper.shipsData[219].baseCargoCapacity;
-      this.json.pbFret =
-        fleetDispatcher.fleetHelper.shipsData[210].baseCargoCapacity;
-      this.json.cyFret =
-        fleetDispatcher.fleetHelper.shipsData[209].baseCargoCapacity;
-      this.saveData();
-      this.current.resources = {
-        metal: fleetDispatcher.metalOnPlanet,
-        crystal: fleetDispatcher.crystalOnPlanet,
-        deut: fleetDispatcher.deuteriumOnPlanet,
-      };
     }
     document.querySelectorAll(".moonlink").forEach((elem) => {
       elem.classList.add("tooltipRight");
@@ -377,11 +1647,12 @@ class OGInfinity {
       elem.classList.add("tooltipLeft");
       elem.classList.remove("tooltipRight");
     });
+    this.json.empire.forEach((planet, index) => {
+      if (this.current.id == planet.id) this.current.index = index;
+    });
     this.saveData();
     document.querySelector("#pageContent").style.width = "1200px";
-
     this.listenKeyboard();
-
     this.sideOptions();
     this.minesLevel();
     this.resourceDetail();
@@ -390,6 +1661,7 @@ class OGInfinity {
     this.preselectShips();
     this.harvest();
     this.expedition();
+    this.collect();
     this.expeditionMessages();
     this.cleanupMessages();
     this.quickPlanetList();
@@ -397,7 +1669,6 @@ class OGInfinity {
     this.sideStalk();
     this.checkDebris();
     this.spyTable();
-    this.checkInputs();
     this.keyboardActions();
     this.betterTooltip();
     this.utilities();
@@ -417,8 +1688,15 @@ class OGInfinity {
     this.timeZone();
     this.updateFlyings();
     this.updatePlanets_FleetActivity();
+    this.getAllianceClass()
+    this.checkRedirect();
+    this.updateProductionProgress();
+    this.showStorageTimers();
+    this.showTabTimer();
+    this.markLifeforms();
+    this.navigationArrows();
     this.expedition = false;
-
+    this.collect = false;
     let storage = this.getLocalStorageSize();
     if (storage.total > 4.5) {
       this.purgeLocalStorage();
@@ -431,60 +1709,6 @@ class OGInfinity {
       }
     }
     this.markedPlayers = this.getMarkedPlayers(this.json.markers);
-    let test = this.page;
-
-    sendShips = function (
-      order,
-      galaxy,
-      system,
-      planet,
-      planettype,
-      shipCount
-    ) {
-      if (shipsendingDone == 1) {
-        shipsendingDone = 0;
-        let params = {
-          mission: order,
-          galaxy: galaxy,
-          system: system,
-          position: planet,
-          type: planettype,
-          shipCount: shipCount,
-          token: token,
-        };
-        $.ajax(miniFleetLink, {
-          data: params,
-          dataType: "json",
-          type: "POST",
-          success: function (data) {
-            if (!data.response) {
-              shipsendingDone = 1;
-              addToTable("Error", "error");
-            } else {
-              if (typeof data.newAjaxToken != "undefined") {
-                token = data.newAjaxToken;
-                let rawURL = new URL(window.location.href);
-                let page =
-                  rawURL.searchParams.get("component") ||
-                  this.rawURL.searchParams.get("page");
-                if (page === "galaxy") {
-                  let phalanxElements = document.querySelectorAll(
-                    "#galaxyContent .phalanxlink"
-                  );
-                  for (let i = 0; i < phalanxElements.length; i++) {
-                    $(phalanxElements[i]).data(
-                      "overlay-token",
-                      data.newAjaxToken
-                    );
-                  }
-                }
-              }
-              displayMiniFleetMessage(data.response);
-            }
-          },
-        });
-      }
-    };
     if (this.json.options.pantryKey) {
       this.checkPantrySync(this.json.options.pantryKey);
     }
@@ -512,7 +1736,7 @@ class OGInfinity {
         this.createDOM(
           "span",
           { style: "color: white" },
-          `(${hourDiff > 0 ? "+" : ""}${hourDiff}h) `
+          `(${hourDiff > 0 ? "+" : ""}${toFormatedNumber(hourDiff)}h) `
         )
       );
   }
@@ -548,7 +1772,7 @@ class OGInfinity {
   overviewDates() {
     document
       .querySelectorAll(
-        "#buildingCountdown, #researchCountdown, #shipyardCountdown2"
+        "#buildingCountdown, #researchCountdown, #shipyardCountdown2, #lfbuildingCountdown, #lfResearchCountdown"
       )
       .forEach((timer) => {
         let timeLeft = 0;
@@ -558,6 +1782,10 @@ class OGInfinity {
           timeLeft = restTimeresearch * 1e3;
         } else if (timer.getAttribute("id") == "shipyardCountdown2") {
           timeLeft = restTimeship2 * 1e3;
+        } else if (timer.getAttribute("id") == "lfbuildingCountdown") {
+          timeLeft = restTimelfbuilding * 1e3;
+        } else if (timer.getAttribute("id") == "lfResearchCountdown") {
+          timeLeft = restTimelfresearch * 1e3;
         }
         let newDate = new Date(Date.now() + timeLeft);
         timer.parentNode.appendChild(
@@ -566,7 +1794,7 @@ class OGInfinity {
             { class: "ogl-date" },
             getFormatedDate(
               newDate.getTime(),
-              "<strong> [G]:[i]:[s] </strong> - [d].[m]"
+              "[d].[m].[y] <strong> [G]:[i]:[s] </strong>"
             )
           )
         );
@@ -574,129 +1802,6 @@ class OGInfinity {
   }
 
   minesLevel() {
-    let coords = this.current.coords + (this.current.isMoon ? "M" : "P");
-    if (this.page == "overview") {
-      let maxTemp;
-      let splits = textContent[3].split("°C").join("").split(" ");
-      splits.reverse().forEach((item) => {
-        let parsed = parseInt(item);
-        if (!maxTemp || maxTemp < parsed) maxTemp = parsed;
-      });
-      if (this.json.myMines[this.current.coords]) {
-        this.json.myMines[this.current.coords].temperature = maxTemp;
-        if (!this.current.isMoon) {
-          this.json.myMines[this.current.coords].fieldUsed = textContent[1]
-            .split("<span>")
-            .splice(1, 2)[0]
-            .replace("</span>/", "")
-            .replace("</span>)", "");
-          this.json.myMines[this.current.coords].fieldMax = textContent[1]
-            .split("<span>")
-            .splice(1, 2)[1]
-            .replace("</span>/", "")
-            .replace("</span>)", "");
-        }
-      } else {
-        this.json.myMines[this.current.coords] = { temperature: maxTemp };
-        if (!this.current.isMoon) {
-          this.json.myMines[this.current.coords] = {
-            fieldUsed: textContent[1]
-              .split("<span>")
-              .splice(1, 2)[0]
-              .replace("</span>/", "")
-              .replace("</span>)", ""),
-          };
-          this.json.myMines[this.current.coords] = {
-            fieldMax: textContent[1]
-              .split("<span>")
-              .splice(1, 2)[1]
-              .replace("</span>/", "")
-              .replace("</span>)", ""),
-          };
-        }
-      }
-    }
-    if (!this.json.myRes[coords]) {
-      this.json.myRes[coords] = {};
-    }
-    let tooltips = [
-      resourcesBar.resources.metal.tooltip,
-      resourcesBar.resources.crystal.tooltip,
-      resourcesBar.resources.deuterium.tooltip,
-    ];
-    let metalProd, crystalProd, deuteriumProd;
-    tooltips.forEach((elem, i) => {
-      let tooltip = this.createDOM("div", {});
-      tooltip.html(elem);
-      let lines = tooltip.querySelectorAll("tr");
-      let storage = parseInt(
-        this.removeNumSeparator(lines[1].querySelector("td").innerText)
-      );
-      let res = parseInt(
-        this.removeNumSeparator(lines[0].querySelector("td").innerText)
-      );
-      let prod = parseInt(
-        this.removeNumSeparator(lines[2].querySelector("td").innerText)
-      );
-      if (i == 0) {
-        this.json.myRes[coords].metal = res;
-        this.json.myRes[coords].metalStorage = storage;
-        metalProd = prod;
-      }
-      if (i == 1) {
-        this.json.myRes[coords].crystal = res;
-        this.json.myRes[coords].crystalStorage = storage;
-        crystalProd = prod;
-      }
-      if (i == 2) {
-        this.json.myRes[coords].deuterium = res;
-        this.json.myRes[coords].deuteriumStorage = storage;
-        deuteriumProd = prod;
-      }
-    });
-    this.json.myRes[coords].lastUpdate = new Date();
-    this.json.myRes[coords].invalidate = false;
-    this.saveData();
-    if (this.page == "supplies" && !this.current.isMoon) {
-      let metal = document
-        .querySelector(".technology.metalMine .level")
-        .getAttribute("data-value");
-      let crystal = document
-        .querySelector(".technology.crystalMine .level")
-        .getAttribute("data-value");
-      let deut = document
-        .querySelector(".technology.deuteriumSynthesizer .level")
-        .getAttribute("data-value");
-      let crawlers = document
-        .querySelector(".technology.resbuggy .amount")
-        .getAttribute("data-value");
-      let mines =
-        this.json.myMines && this.current.coords
-          ? this.json.myMines[this.current.coords]
-          : {};
-      mines = {
-        metal: metal,
-        metalProd: metalProd,
-        crystal: crystal,
-        crystalProd: crystalProd,
-        deuterium: deut,
-        deuteriumProd: deuteriumProd,
-        crawlers: crawlers,
-        temperature: mines ? mines.temperature : undefined,
-        energy: parseInt(
-          document
-            .querySelector("#resources_energy")
-            .innerText.replaceAll(".", "")
-        ),
-        fieldUsed: mines.fieldUsed,
-        fieldMax: mines.fieldMax,
-      };
-      this.json.myMines[this.current.coords] = mines;
-      this.saveData();
-      if (!mines.temperature) {
-        document.location = `https://s${this.universe}-${this.gameLang}.ogame.gameforge.com/game/index.php?page=ingame&component=overview`;
-      }
-    }
     this.planetList.forEach((planet) => {
       let coords = planet.querySelector(".planet-koords").textContent;
       let metal = 0,
@@ -710,7 +1815,9 @@ class OGInfinity {
         }
       });
       let div = this.createDOM("div", { class: "ogl-mines" });
-      div.textContent = `${metal}-${crystal}-${deut}`;
+      div.textContent = `${toFormatedNumber(metal)}-${toFormatedNumber(
+        crystal
+      )}-${toFormatedNumber(deut)}`;
       planet.querySelector(".planetlink").appendChild(div);
     });
   }
@@ -729,39 +1836,34 @@ class OGInfinity {
       let robotics = 0;
       let lock;
       let lockListener;
-      if (this.page == "research") {
-        this.json.tech113 = Number(
-          document
-            .querySelector('.technology[data-technology="113"] .level')
-            .getAttribute("data-value")
-        );
-        this.json.tech122 = Number(
-          document
-            .querySelector('.technology[data-technology="122"] .level')
-            .getAttribute("data-value")
-        );
-        this.json.tech124 = Number(
-          document
-            .querySelector('.technology[data-technology="124"] .level')
-            .getAttribute("data-value")
-        );
-        this.json.tech108 = Number(
-          document
-            .querySelector('.technology[data-technology="108"] .level')
-            .getAttribute("data-value")
-        );
+      let currentEnergy = resourcesBar.resources.energy.amount;
+
+      function getTimeFromString(str) {
+        var regexStr = str.match(/[a-z]+|[^a-z]+/gi);
+        let time = 0;
+        for (let i = 0; i < regexStr.length; i++) {
+          let num = Number(regexStr[i]);
+          if (!isNaN(num)) {
+            if (regexStr[i + 1] == "M") num *= 60;
+            if (regexStr[i + 1] == "H") num *= 60 * 60;
+            if (regexStr[i + 1] == "DT") num *= 60 * 60 * 24;
+            time += num;
+            i++;
+          }
+        }
+        return time;
       }
-      let currentEnergy = this.removeNumSeparator(
-        document.querySelector("#resources_energy").innerText
-      );
+
       let currentRes = [
-        document.querySelector("#resources_metal").getAttribute("data-raw"),
-        document.querySelector("#resources_crystal").getAttribute("data-raw"),
-        document.querySelector("#resources_deuterium").getAttribute("data-raw"),
+        resourcesBar.resources.metal.amount,
+        resourcesBar.resources.crystal.amount,
+        resourcesBar.resources.deuterium.amount,
       ];
       let technocrat = document.querySelector(".technocrat.on") ? true : false;
-      let bonus = document.querySelector(".acceleration");
-      bonus = bonus ? (Number(bonus.getAttribute("data-value")) / 100) : 0;
+      let acceleration = document.querySelector(".acceleration")
+        ? document.querySelector(".acceleration").getAttribute("data-value") ==
+          25
+        : false;
       let labs = 0;
       let that = this;
       let updateResearchDetails = (technoId, baselvl, tolvl) => {
@@ -772,55 +1874,161 @@ class OGInfinity {
           durationDiv.appendChild(that.createDOM("time", { class: "ogk-sum" }));
         let resSum = [0, 0, 0, 0];
         let timeSum = 0;
+        let techno;
         for (let i = baselvl; i < tolvl; i++) {
-          let techno;
-          if (that.page == "research") {
+          if (that.page == "research" || that.page == "lfresearch") {
             techno = that.research(
               technoId,
               i,
               labs,
               technocrat,
-              that.playerClass == 3,
-              bonus
+              that.playerClass == PLAYER_CLASS_EXPLORER,
+              acceleration
             );
           } else if (
             that.page == "supplies" ||
             that.page == "facilities" ||
-            that.page == "lfbuildings" ||
-            that.page == "lfresearch"
+            that.page == "lfbuildings"
           ) {
             techno = that.building(technoId, i, robotics, nanites);
           }
           resSum[0] += techno.cost[0];
           resSum[1] += techno.cost[1];
           resSum[2] += techno.cost[2];
-          resSum[3] += techno.cost[3];
+          resSum[3] = techno.cost[3];
           timeSum += techno.time;
         }
-        let techno;
-
-        if (that.page == "research") {
+        if (that.page == "research" || that.page == "lfresearch") {
+          if ((technoId == 124 || technoId == 122) && baselvl <= tolvl) {
+            let roi =
+              technoId == 124
+                ? that.roiAstrophysics(baselvl, tolvl)
+                : that.roiPlasmatechnology(tolvl);
+            let roiDiv =
+              durationDiv.parentNode.querySelector(".roi_duration") ||
+              durationDiv.parentNode.insertBefore(
+                that.createDOM("li", { class: "roi_duration" }),
+                durationDiv.parentNode.children[1]
+              );
+            roiDiv.innerHTML = `<strong>${that.getTranslatedText(
+              50
+            )}:</strong>`;
+            let roiTimeDiv =
+              roiDiv.querySelector(".roi_duration time") ||
+              roiDiv.appendChild(
+                that.createDOM("time", {
+                  class: "value tooltip",
+                  "data-title":
+                    roi === Infinity
+                      ? that.getTranslatedText(118)
+                      : `${that.getTranslatedText(119)}: ${toFormatedNumber(
+                        that.json.options.tradeRate[0]
+                      )}:${toFormatedNumber(
+                        that.json.options.tradeRate[1]
+                      )}:${toFormatedNumber(that.json.options.tradeRate[2])}`,
+                })
+              );
+            roiTimeDiv.innerText =
+              roi === Infinity
+                ? "∞"
+                : formatTimeWrapper(roi, 2, true, " ", false, "");
+          } else if (RESEARCH_INFO[technoId].bonus) {
+            let roi = that.roiLfResearch(technoId, baselvl, tolvl, labs);
+            let roiDiv =
+              durationDiv.parentNode.querySelector(".roi_duration") ||
+              durationDiv.parentNode.insertBefore(
+                that.createDOM("li", { class: "roi_duration" }),
+                durationDiv.parentNode.children[1]
+              );
+            roiDiv.innerHTML = `<strong>${that.getTranslatedText(
+              50
+            )}:</strong>`;
+            let roiTimeDiv =
+              roiDiv.querySelector(".roi_duration time") ||
+              roiDiv.appendChild(
+                that.createDOM("time", {
+                  class: "value tooltip",
+                  "data-title": `${that.getTranslatedText(
+                    119
+                  )}: ${toFormatedNumber(
+                    that.json.options.tradeRate[0]
+                  )}:${toFormatedNumber(
+                    that.json.options.tradeRate[1]
+                  )}:${toFormatedNumber(that.json.options.tradeRate[2])}`,
+                })
+              );
+            roiTimeDiv.innerText = formatTimeWrapper(
+              roi,
+              2,
+              true,
+              " ",
+              false,
+              ""
+            );
+          } else {
+            if (durationDiv.parentNode.querySelector(".roi_duration"))
+              durationDiv.parentNode.querySelector(".roi_duration").innerHTML =
+                "";
+          }
           techno = that.research(
             technoId,
             tolvl,
             labs,
             technocrat,
-            that.playerClass == 3,
-            bonus
+            that.playerClass == PLAYER_CLASS_EXPLORER,
+            acceleration
           );
         } else if (
           that.page == "supplies" ||
           that.page == "facilities" ||
-          that.page == "lfbuildings" ||
-          that.page == "lfresearch"
+          that.page == "lfbuildings"
         ) {
           techno = that.building(technoId, tolvl, robotics, nanites);
         }
         resSum[0] += techno.cost[0];
         resSum[1] += techno.cost[1];
         resSum[2] += techno.cost[2];
-        resSum[3] += techno.cost[3];
+        resSum[3] = techno.cost[3];
         timeSum += techno.time;
+        if (that.page == "lfbuildings") {
+          let consDiv = document.querySelector(
+            ".additional_energy_consumption span"
+          );
+          if (consDiv) {
+            let temp = that.json.empire[that.current.index].db_par2 + 40;
+            let baseCons = that.consumption(technoId, baselvl - 1);
+            let currentCons = that.consumption(technoId, tolvl);
+            let diff = currentEnergy - (currentCons - baseCons);
+            consDiv.html(
+              `<span>${toFormatedNumber(currentCons - baseCons)}<span class="${
+                diff < 0 ? 'overmark' : 'undermark'
+              }"> (${toFormatedNumber(diff)})</span></span>`
+            );
+            if (diff < 0) {
+              let energyBonus =
+                (that.engineer ? 0.1 : 0) +
+                (that.playerClass == 1 ? 0.1 : 0) +
+                (that.allOfficers ? 0.02 : 0) +
+                (that.json.allianceClass == 1 ? 0.05 : 0);
+              let satsNeeded = Math.ceil(
+                -diff / (1 + energyBonus) / Math.floor((temp + 140) / 6)
+              );
+              let link =
+                "https://" +
+                window.location.host +
+                window.location.pathname +
+                `?page=ingame&component=supplies&cp=${that.current.id}&sats=${satsNeeded}`;
+              let satsSpan = that.createDOM(
+                "span",
+                {},
+                `<a href=${link} tech-id="212" class="ogl-option ogl-solar-satellite"></a><span>+${toFormatedNumber(
+                  satsNeeded
+                )}`
+              );
+              consDiv.appendChild(satsSpan);
+            }
+          }
+        }
         if (that.page == "supplies") {
           let consDiv = document.querySelector(
             ".additional_energy_consumption span"
@@ -833,15 +2041,8 @@ class OGInfinity {
               .appendChild(that.createDOM("li", { class: "ogk-production" }));
           let energyDiv = document.querySelector(".energy_production span");
           if (consDiv) {
-            let temp;
-            this.json.empire.forEach((planet) => {
-              if (planet.coordinates.slice(1, -1) == this.current.coords) {
-                let splits = planet.temperature.split(" ");
-                temp = splits[splits.length - 1];
-                temp = temp.replace("°C", "");
-              }
-            });
-            let pos = this.current.coords.split(":")[2];
+            let temp = that.json.empire[that.current.index].db_par2 + 40;
+            let pos = that.current.coords.split(":")[2];
             let currentProd = that.minesProduction(
               technoId,
               baselvl - 1,
@@ -853,54 +2054,174 @@ class OGInfinity {
             let currentCons = that.consumption(technoId, tolvl);
             let diff = currentEnergy - (currentCons - baseCons);
             consDiv.html(
-              `<span>${(currentCons - baseCons).toLocaleString(
-                document
-                  .getElementById("cookiebanner")
-                  .getAttribute("data-locale")
-              )}<span class="${
+              `<span>${toFormatedNumber(currentCons - baseCons)}<span class="${
                 diff < 0 ? "overmark" : "undermark"
-              }"> (${diff.toLocaleString(
-                document
-                  .getElementById("cookiebanner")
-                  .getAttribute("data-locale")
-              )})</span></span>`
+              }"> (${toFormatedNumber(diff)})</span></span>`
             );
+
+            if (diff < 0) {
+              let energyBonus =
+                (that.engineer ? 0.1 : 0) +
+                (that.playerClass == 1 ? 0.1 : 0) +
+                (that.allOfficers ? 0.02 : 0) +
+                (that.json.allianceClass == 1 ? 0.05 : 0);
+              let satsNeeded = Math.ceil(
+                Math.floor(-diff / (1 + energyBonus)) /
+                  Math.floor((temp + 140) / 6)
+              );
+              let satsSpan = that.createDOM(
+                "span",
+                {},
+                `<a tech-id="212" class="ogl-option ogl-solar-satellite"></a><span>+${toFormatedNumber(
+                  satsNeeded
+                )}`
+              );
+              consDiv.appendChild(satsSpan);
+              satsSpan.addEventListener("click", () => {
+                document
+                  .querySelector(".solarSatellite.hasDetails span")
+                  .click();
+                waitForElementToDisplay(
+                  "#technologydetails[data-technology-id='212']",
+                  () => {
+                    let satsInput = document.querySelector("#build_amount");
+                    satsInput.value = satsNeeded;
+                    satsInput.dispatchEvent(
+                      new KeyboardEvent("keyup", { code: "ArrowDown" })
+                    );
+                  },
+                  10,
+                  2000
+                );
+              });
+            }
             prodDiv.html(
-              `<strong>Production :</strong> <span class="value">${parseInt(
-                baseProd
-              ).toLocaleString(
-                document
-                  .getElementById("cookiebanner")
-                  .getAttribute("data-locale")
-              )} <span class="bonus"> (+${parseInt(
-                baseProd - currentProd
-              ).toLocaleString(
-                document
-                  .getElementById("cookiebanner")
-                  .getAttribute("data-locale")
+              `<strong>${that.getTranslatedText(
+                85
+              )}:</strong><span class="value">${toFormatedNumber(
+                parseInt(baseProd)
+              )} <span class="bonus ${
+                parseInt(baseProd - currentProd) < 0 ? "overmark" : "undermark"
+              }"> (${
+                parseInt(baseProd - currentProd) < 0 ? "" : "+"
+              }${toFormatedNumber(
+                parseInt(baseProd - currentProd)
               )})</span></span>`
             );
           }
           if (energyDiv) {
-            let currentProd = that.production(technoId, baselvl - 1, false);
-            let baseProd = that.production(technoId, tolvl, false);
+            let temp = that.json.empire[that.current.index].db_par2 + 40;
+            let pos = that.current.coords.split(":")[2];
+            let currentProd = that.minesProduction(
+              technoId,
+              baselvl - 1,
+              pos,
+              temp
+            );
+            let baseProd = that.minesProduction(technoId, tolvl, pos, temp);
             energyDiv.html(
-              `<span class="value">${parseInt(baseProd).toLocaleString(
-                document
-                  .getElementById("cookiebanner")
-                  .getAttribute("data-locale")
-              )} <span class="bonus"> (+${parseInt(
-                baseProd - currentProd
-              ).toLocaleString(
-                document
-                  .getElementById("cookiebanner")
-                  .getAttribute("data-locale")
+              `<span class="value">${toFormatedNumber(
+                parseInt(baseProd)
+              )} <span class="bonus ${
+                parseInt(baseProd - currentProd) < 0 ? "overmark" : "undermark"
+              }"> (${
+                parseInt(baseProd - currentProd) < 0 ? "" : "+"
+              }${toFormatedNumber(
+                parseInt(baseProd - currentProd)
               )})</span></span>`
             );
           }
+          if ([22, 23, 24].includes(technoId)) {
+            let production =
+              technoId == 22
+                ? resourcesBar.resources.metal.production
+                : technoId == 23
+                  ? resourcesBar.resources.crystal.production
+                  : resourcesBar.resources.deuterium.production;
+            let storageDiv =
+              durationDiv.parentNode.querySelector(".narrow .storage_size") ||
+              durationDiv.parentNode.insertBefore(
+                that.createDOM("li", { class: "storage_size" }),
+                durationDiv.parentNode.children[1]
+              );
+            let oldStorage =
+              5000 * Math.floor(2.5 * Math.exp((20 / 33) * (baselvl - 1)));
+            let newStorage =
+              5000 * Math.floor(2.5 * Math.exp((20 / 33) * tolvl));
+            storageDiv.innerHTML = `<strong>${that.getTranslatedText(
+              131
+            )}:</strong>`;
+            let storageSizeDiv =
+              storageDiv.querySelector(".storage_size size") ||
+              storageDiv.appendChild(
+                that.createDOM("size", {
+                  class: "value tooltip",
+                  "data-title": `${that.getTranslatedText(
+                    132
+                  )}: ${formatTimeWrapper(
+                    newStorage / production,
+                    2,
+                    true,
+                    " ",
+                    false,
+                    ""
+                  )}`,
+                })
+              );
+            storageSizeDiv.html(
+              `<span class="value">${toFormatedNumber(
+                newStorage
+              )} <span class="bonus ${
+                newStorage - oldStorage < 0 ? "overmark" : "undermark"
+              }"> (${newStorage - oldStorage < 0 ? "" : "+"}${toFormatedNumber(
+                newStorage - oldStorage
+              )})</span></span>`
+            );
+          }
+          if (technoId <= 3) {
+            let roiDiv =
+              durationDiv.parentNode.querySelector(".narrow .roi_duration") ||
+              durationDiv.parentNode.insertBefore(
+                that.createDOM("li", { class: "roi_duration" }),
+                durationDiv.parentNode.children[1]
+              );
+
+            if (baselvl <= tolvl) {
+              let roi = that.roiMine(technoId, that.current.index, tolvl);
+              roiDiv.innerHTML = `<strong>${that.getTranslatedText(
+                50
+              )}:</strong>`;
+
+              let roiTimeDiv =
+                roiDiv.querySelector(".roi_duration time") ||
+                roiDiv.appendChild(
+                  that.createDOM("time", {
+                    class: "value tooltip",
+                    "data-title": `${that.getTranslatedText(
+                      119
+                    )}: ${toFormatedNumber(
+                      that.json.options.tradeRate[0]
+                    )}:${toFormatedNumber(
+                      that.json.options.tradeRate[1]
+                    )}:${toFormatedNumber(that.json.options.tradeRate[2])}`,
+                  })
+                );
+
+              roiTimeDiv.innerText = formatTimeWrapper(
+                roi,
+                2,
+                true,
+                " ",
+                false,
+                ""
+              );
+            } else {
+              roiDiv.innerHTML = "";
+            }
+          }
         }
         timeDiv.innerText = formatTimeWrapper(
-          techno.time * 60 * 60,
+          techno.time,
           2,
           true,
           " ",
@@ -908,31 +2229,28 @@ class OGInfinity {
           ""
         );
         let currentDate = new Date();
-        let finishDate = new Date(
-          currentDate.getTime() + techno.time * 60 * 60 * 1e3
-        );
-        timeDiv.appendChild(
-          this.createDOM(
-            "div",
-            { class: "ogl-date" },
-            getFormatedDate(
-              finishDate.getTime(),
-              "<strong>[d].[m]</strong> - [G]:[i]:[s]"
+        let finishDate = new Date(currentDate.getTime() + techno.time * 1e3);
+        if (baselvl <= tolvl)
+          timeDiv.appendChild(
+            this.createDOM(
+              "div",
+              { class: "ogl-date" },
+              getFormatedDate(
+                finishDate.getTime(),
+                "<strong>[d].[m]</strong> - [G]:[i]:[s]"
+              )
             )
-          )
-        );
-        if (baselvl != tolvl) {
+          );
+        if (baselvl < tolvl) {
           timeSumDiv.innerText = formatTimeWrapper(
-            timeSum * 60 * 60,
+            timeSum,
             2,
             true,
             " ",
             false,
             ""
           );
-          finishDate = new Date(
-            currentDate.getTime() + timeSum * 60 * 60 * 1e3
-          );
+          finishDate = new Date(currentDate.getTime() + timeSum * 1e3);
           timeSumDiv.appendChild(
             this.createDOM(
               "div",
@@ -947,111 +2265,212 @@ class OGInfinity {
           timeSumDiv.innerText = "";
         }
         let missing = [];
+        let demolish = [];
+        if (baselvl - 1 > tolvl) {
+          demolish = techno.cost.map((x) =>
+            Math.floor(x * (1 - 0.04 * that.json.technology[121]))
+          );
+        }
         if (techno.cost[0] != 0) {
           let metal = document.querySelector(".costs .metal");
-          metal.innerText = that.formatToUnits(techno.cost[0]);
-          metal.setAttribute(
-            "data-title",
-            parseInt(techno.cost[0]).toLocaleString(
-              document
-                .getElementById("cookiebanner")
-                .getAttribute("data-locale")
+          metal.innerText =
+            tolvl != 0 ? toFormatedNumber(techno.cost[0], null, true) : "";
+          if (tolvl != 0)
+            metal.setAttribute(
+              "data-title",
+              toFormatedNumber(parseInt(techno.cost[0]))
+            );
+          if (
+            baselvl != tolvl &&
+            baselvl - 1 != tolvl &&
+            !(
+              baselvl > tolvl &&
+              (that.page == "research" || that.page == "lfresearch")
             )
-          );
-          if (baselvl != tolvl) {
+          ) {
             metal.appendChild(
               that.createDOM(
                 "li",
-                { class: "ogk-sum" },
-                that.formatToUnits(resSum[0])
+                {
+                  class: "ogk-sum tooltip",
+                  "data-title": toFormatedNumber(
+                    parseInt(baselvl - 1 > tolvl ? demolish[0] : resSum[0])
+                  ),
+                },
+                toFormatedNumber(
+                  baselvl - 1 > tolvl ? demolish[0] : resSum[0],
+                  null,
+                  true
+                )
               )
             );
           }
-          missing[0] = Math.min(0, currentRes[0] - resSum[0]);
-          metal.appendChild(
-            that.createDOM(
-              "li",
-              { class: missing[0] != 0 ? "overmark" : "" },
-              that.formatToUnits(missing[0])
-            )
+          missing[0] = Math.min(
+            0,
+            currentRes[0] - (baselvl - 1 > tolvl ? demolish[0] : resSum[0])
           );
+          if (
+            baselvl - 1 != tolvl &&
+            !(
+              baselvl > tolvl &&
+              (that.page == "research" || that.page == "lfresearch")
+            )
+          )
+            metal.appendChild(
+              that.createDOM(
+                "li",
+                {
+                  class: missing[0] != 0 ? "overmark tooltip" : "tooltip",
+                  "data-title": toFormatedNumber(parseInt(missing[0])),
+                },
+                toFormatedNumber(missing[0], null, true)
+              )
+            );
         }
         if (techno.cost[1] != 0) {
           let crystal = document.querySelector(".costs .crystal");
-          crystal.innerText = that.formatToUnits(techno.cost[1]);
-          crystal.setAttribute(
-            "data-title",
-            parseInt(techno.cost[1]).toLocaleString(
-              document
-                .getElementById("cookiebanner")
-                .getAttribute("data-locale")
+          crystal.innerText =
+            tolvl != 0 ? toFormatedNumber(techno.cost[1], null, true) : "";
+          if (tolvl != 0)
+            crystal.setAttribute(
+              "data-title",
+              toFormatedNumber(parseInt(techno.cost[1]))
+            );
+          if (
+            baselvl != tolvl &&
+            baselvl - 1 != tolvl &&
+            !(
+              baselvl > tolvl &&
+              (that.page == "research" || that.page == "lfresearch")
             )
-          );
-          if (baselvl != tolvl) {
+          ) {
             crystal.appendChild(
               that.createDOM(
                 "li",
-                { class: "ogk-sum" },
-                that.formatToUnits(resSum[1])
+                {
+                  class: "ogk-sum tooltip",
+                  "data-title": toFormatedNumber(
+                    parseInt(baselvl - 1 > tolvl ? demolish[1] : resSum[1])
+                  ),
+                },
+                toFormatedNumber(
+                  baselvl - 1 > tolvl ? demolish[1] : resSum[1],
+                  null,
+                  true
+                )
               )
             );
           }
-          missing[1] = Math.min(0, currentRes[1] - resSum[1]);
-          crystal.appendChild(
-            that.createDOM(
-              "li",
-              { class: missing[1] != 0 ? "overmark" : "" },
-              that.formatToUnits(missing[1])
-            )
+          missing[1] = Math.min(
+            0,
+            currentRes[1] - (baselvl - 1 > tolvl ? demolish[1] : resSum[1])
           );
+          if (
+            baselvl - 1 != tolvl &&
+            !(
+              baselvl > tolvl &&
+              (that.page == "research" || that.page == "lfresearch")
+            )
+          )
+            crystal.appendChild(
+              that.createDOM(
+                "li",
+                {
+                  class: missing[1] != 0 ? "overmark tooltip" : "tooltip",
+                  "data-title": toFormatedNumber(parseInt(missing[1])),
+                },
+                toFormatedNumber(missing[1], null, true)
+              )
+            );
         }
         if (techno.cost[2] != 0) {
           let deuterium = document.querySelector(".costs .deuterium");
-          deuterium.innerText = that.formatToUnits(techno.cost[2]);
-          deuterium.setAttribute(
-            "data-title",
-            parseInt(techno.cost[2]).toLocaleString(
-              document
-                .getElementById("cookiebanner")
-                .getAttribute("data-locale")
+          deuterium.innerText =
+            tolvl != 0 ? toFormatedNumber(techno.cost[2], null, true) : "";
+          if (tolvl != 0)
+            deuterium.setAttribute(
+              "data-title",
+              toFormatedNumber(parseInt(techno.cost[2]))
+            );
+          if (
+            baselvl != tolvl &&
+            baselvl - 1 != tolvl &&
+            !(
+              baselvl > tolvl &&
+              (that.page == "research" || that.page == "lfresearch")
             )
-          );
-          if (baselvl != tolvl) {
+          ) {
             deuterium.appendChild(
               that.createDOM(
                 "li",
-                { class: "ogk-sum" },
-                that.formatToUnits(resSum[2])
+                {
+                  class: "ogk-sum tooltip",
+                  "data-title": toFormatedNumber(
+                    parseInt(baselvl - 1 > tolvl ? demolish[2] : resSum[2])
+                  ),
+                },
+                toFormatedNumber(
+                  baselvl - 1 > tolvl ? demolish[2] : resSum[2],
+                  null,
+                  true
+                )
               )
             );
           }
-          missing[2] = Math.min(0, currentRes[2] - resSum[2]);
-          deuterium.appendChild(
-            that.createDOM(
-              "li",
-              { class: missing[2] != 0 ? "overmark" : "" },
-              that.formatToUnits(missing[2])
-            )
+          missing[2] = Math.min(
+            0,
+            currentRes[2] - (baselvl - 1 > tolvl ? demolish[2] : resSum[2])
           );
+          if (
+            baselvl - 1 != tolvl &&
+            !(
+              baselvl > tolvl &&
+              (that.page == "research" || that.page == "lfresearch")
+            )
+          )
+            deuterium.appendChild(
+              that.createDOM(
+                "li",
+                {
+                  class: missing[2] != 0 ? "overmark tooltip" : "tooltip",
+                  "data-title": toFormatedNumber(parseInt(missing[2])),
+                },
+                toFormatedNumber(missing[2], null, true)
+              )
+            );
         }
         if (techno.cost[3] != 0) {
           let energy = document.querySelector(".costs .energy");
           if (energy) {
-            energy.innerText = that.formatToUnits(techno.cost[3]);
-            energy.setAttribute(
-              "data-title",
-              parseInt(techno.cost[3]).toLocaleString(
-                document
-                  .getElementById("cookiebanner")
-                  .getAttribute("data-locale")
+            energy.innerText =
+              tolvl != 0 ? toFormatedNumber(techno.cost[3], null, true) : "";
+            if (tolvl != 0)
+              energy.setAttribute(
+                "data-title",
+                toFormatedNumber(parseInt(techno.cost[3]))
+              );
+            if (
+              baselvl != tolvl &&
+              baselvl - 1 != tolvl &&
+              !(
+                baselvl > tolvl &&
+                (that.page == "research" || that.page == "lfresearch")
               )
-            );
-            if (baselvl != tolvl) {
+            ) {
               energy.appendChild(
                 that.createDOM(
                   "li",
-                  { class: "ogk-sum" },
-                  that.formatToUnits(resSum[3])
+                  {
+                    class: "ogk-sum tooltip",
+                    "data-title": toFormatedNumber(
+                      parseInt(baselvl - 1 > tolvl ? demolish[3] : resSum[3])
+                    ),
+                  },
+                  toFormatedNumber(
+                    baselvl - 1 > tolvl ? demolish[3] : resSum[3],
+                    null,
+                    true
+                  )
                 )
               );
             }
@@ -1061,15 +2480,113 @@ class OGInfinity {
             let div = that.createDOM("div");
             div.html(tooltip);
             let prod = div.querySelectorAll("span")[1].innerText.substring(1);
-            missing[3] = Math.min(0, that.removeNumSeparator(prod) - resSum[3]);
-            energy.appendChild(
+            missing[3] = Math.min(
+              0,
+              fromFormatedNumber(prod, true) -
+                (baselvl - 1 > tolvl ? demolish[3] : resSum[3])
+            );
+            if (
+              baselvl - 1 != tolvl &&
+              !(
+                baselvl > tolvl &&
+                (that.page == "research" || that.page == "lfresearch")
+              )
+            )
+              energy.appendChild(
+                that.createDOM(
+                  "li",
+                  {
+                    class: missing[3] != 0 ? "overmark tooltip" : "tooltip",
+                    "data-title": toFormatedNumber(parseInt(missing[3])),
+                  },
+                  toFormatedNumber(missing[3], null, true)
+                )
+              );
+            if (missing[3] < 0 && baselvl == tolvl) {
+              let energyBonus =
+                (that.engineer ? 0.1 : 0) +
+                (that.playerClass == PLAYER_CLASS_MINER ? 0.1 : 0) +
+                (that.allOfficers ? 0.02 : 0) +
+                (that.json.allianceClass == ALLY_CLASS_MINER ? 0.05 : 0);
+              let temp = that.json.empire[that.current.index].db_par2 + 40;
+              let satsNeeded = Math.ceil(
+                -missing[3] / (1 + energyBonus) / Math.floor((temp + 140) / 6)
+              );
+              let link =
+                "https://" +
+                window.location.host +
+                window.location.pathname +
+                `?page=ingame&component=supplies&cp=${that.current.id}&sats=${satsNeeded}`;
+              let satsSpan = that.createDOM(
+                "span",
+                {},
+                `<a href=${link} tech-id="212" class="ogl-option ogl-solar-satellite"></a><span>+${toFormatedNumber(
+                  satsNeeded
+                )}`
+              );
+              energy.appendChild(satsSpan);
+            }
+          }
+        }
+        if (techno.pop && techno.pop != 0) {
+          let population = document.querySelector(".costs .population");
+          population.innerText =
+            tolvl != 0 ? toFormatedNumber(techno.pop, null, true) : "";
+          if (tolvl != 0)
+            population.setAttribute(
+              "data-title",
+              toFormatedNumber(parseInt(techno.pop))
+            );
+          let missingPop = Math.min(
+            0,
+            resourcesBar.resources.population.amount - techno.pop
+          );
+          if (
+            baselvl != tolvl &&
+            baselvl - 1 != tolvl &&
+            !(
+              baselvl > tolvl &&
+              (that.page == "research" || that.page == "lfresearch")
+            )
+          ) {
+            population.appendChild(
               that.createDOM(
                 "li",
-                { class: missing[3] != 0 ? "overmark" : "" },
-                that.formatToUnits(missing[3])
+                {
+                  class: "ogk-sum tooltip",
+                  "data-title": toFormatedNumber(parseInt(techno.pop)),
+                },
+                toFormatedNumber(techno.pop, null, true)
               )
             );
           }
+          if (
+            baselvl - 1 != tolvl &&
+            !(
+              baselvl > tolvl &&
+              (that.page == "research" || that.page == "lfresearch")
+            )
+          )
+            population.appendChild(
+              that.createDOM(
+                "li",
+                {
+                  class: missingPop != 0 ? "overmark tooltip" : "tooltip",
+                  "data-title": toFormatedNumber(parseInt(missingPop)),
+                },
+                toFormatedNumber(missingPop, null, true)
+              )
+            );
+        }
+        if (
+          baselvl - 1 == tolvl ||
+          (baselvl > tolvl &&
+            (that.page == "research" || that.page == "lfresearch"))
+        ) {
+          document.querySelector(".ogk-titles").children[2].innerText = "";
+        } else {
+          document.querySelector(".ogk-titles").children[2].innerText =
+            that.getTranslatedText(39);
         }
         lockListener = () => {
           let coords = that.current.coords + (that.current.isMoon ? "M" : "P");
@@ -1078,8 +2595,10 @@ class OGInfinity {
           }
           [0, 1, 2].forEach((i) => {
             if (missing[i]) {
-              that.json.missing[coords][i] =
-                that.json.missing[coords][i] - (parseInt(missing[i]) - 10);
+              that.json.missing[coords][i] +=
+                that.json.missing[coords][i] == 0
+                  ? -Math.ceil(missing[i])
+                  : Math.ceil(resSum[i]);
             }
           });
           that.saveData();
@@ -1134,8 +2653,7 @@ class OGInfinity {
           clone.innerText = "";
           document.querySelector(".description").appendChild(clone);
           let timeDiv = document.querySelector(".build_duration time");
-          let baseTime = that.getTimeFromString(timeDiv
-            .getAttribute("datetime"));
+          let baseTime = getTimeFromString(timeDiv.getAttribute("datetime"));
           if (
             [
               202, 203, 208, 209, 210, 204, 205, 206, 219, 207, 215, 211, 212,
@@ -1155,8 +2673,8 @@ class OGInfinity {
               base = energyDiv.querySelector("span").getAttribute("data-value");
             }
             titleDiv.appendChild(that.createDOM("div", {}, "&#8205;"));
-            titleDiv.appendChild(that.createDOM("div", {}, "Total"));
-            titleDiv.appendChild(that.createDOM("div", {}, "Missing"));
+            titleDiv.appendChild(that.createDOM("div", {}, that.getTranslatedText(40)));
+            titleDiv.appendChild(that.createDOM("div", {}, that.getTranslatedText(39)));
             let resDivs = [
               costDiv.querySelector(".metal"),
               costDiv.querySelector(".crystal"),
@@ -1185,24 +2703,31 @@ class OGInfinity {
             let input = document.querySelector(".build_amount input");
             let updateShipDetails = (value) => {
               let missing = [];
+              let resSum = [];
               resDivs.forEach((div, index) => {
                 if (!div) return;
-                let tot = value * baseCost[index];
-                let min = Math.min(0, currentRes[index] - tot);
+                resSum[index] = value * baseCost[index];
+                let min = Math.min(0, currentRes[index] - resSum[index]);
                 missing[index] = min;
-                div.innerText = that.formatToUnits(baseCost[index]);
+                div.innerText = toFormatedNumber(baseCost[index], null, true);
                 div.appendChild(
                   that.createDOM(
                     "div",
-                    { class: "ogk-sum" },
-                    that.formatToUnits(tot)
+                    {
+                      class: "ogk-sum tooltip",
+                      "data-title": toFormatedNumber(resSum[index], 0),
+                    },
+                    toFormatedNumber(resSum[index], null, true)
                   )
                 );
                 div.appendChild(
                   that.createDOM(
                     "div",
-                    { class: min != 0 ? "overmark" : "" },
-                    that.formatToUnits(min)
+                    {
+                      class: min != 0 ? "overmark tooltip" : "tooltip",
+                      "data-title": toFormatedNumber(min, 0),
+                    },
+                    toFormatedNumber(min, null, true)
                   )
                 );
               });
@@ -1229,37 +2754,87 @@ class OGInfinity {
                 )
               );
               if (technologyId == 212) {
-                let diff = Number(currentEnergy) + value * base;
+                let energyBonus =
+                  (that.engineer ? 0.1 : 0) +
+                  (that.playerClass == PLAYER_CLASS_MINER ? 0.1 : 0) +
+                  (that.allOfficers ? 0.02 : 0) +
+                  (that.json.allianceClass == ALLY_CLASS_MINER ? 0.05 : 0);
+                let diff =
+                  Number(currentEnergy) +
+                  Math.round(value * base * (1 + energyBonus));
                 energyDiv.html(
-                  (value * base).toLocaleString(
-                    document
-                      .getElementById("cookiebanner")
-                      .getAttribute("data-locale")
-                  ) +
+                  toFormatedNumber(value * base) +
                     `<span class="${
                       diff < 0 ? "overmark" : "undermark"
-                    }"> (${diff.toLocaleString(
-                      document
-                        .getElementById("cookiebanner")
-                        .getAttribute("data-locale")
-                    )})</span>`
+                    }"> (${toFormatedNumber(diff)})</span>`
                 );
+                if (Number(currentEnergy) < 0) {
+                  let temp = that.json.empire[that.current.index].db_par2 + 40;
+                  let satsNeeded = Math.ceil(
+                    -Number(currentEnergy) /
+                      (1 + energyBonus) /
+                      Math.floor((temp + 140) / 6)
+                  );
+                  let satsSpan = that.createDOM(
+                    "span",
+                    {},
+                    `<a tech-id="212" class="ogl-option ogl-solar-satellite"></a><span>+${toFormatedNumber(
+                      satsNeeded
+                    )}`
+                  );
+                  energyDiv.appendChild(satsSpan);
+                  satsSpan.addEventListener("click", () => {
+                    let satsInput = document.querySelector("#build_amount");
+                    satsInput.focus();
+                    satsInput.value = satsNeeded;
+                    satsInput.dispatchEvent(
+                      new KeyboardEvent("keyup", { code: "ArrowDown" })
+                    );
+                  });
+                }
               } else if (technologyId == 217) {
                 let diff = Number(currentEnergy) - value * base;
                 energyDiv.html(
-                  (value * base).toLocaleString(
-                    document
-                      .getElementById("cookiebanner")
-                      .getAttribute("data-locale")
-                  ) +
+                  toFormatedNumber(value * base) +
                     `<span class="${
                       diff < 0 ? "overmark" : "undermark"
-                    }"> (${diff.toLocaleString(
-                      document
-                        .getElementById("cookiebanner")
-                        .getAttribute("data-locale")
-                    )})</span>`
+                    }"> (${toFormatedNumber(diff)})</span>`
                 );
+                if (diff < 0) {
+                  let energyBonus =
+                    (that.engineer ? 0.1 : 0) +
+                    (that.playerClass == PLAYER_CLASS_MINER ? 0.1 : 0) +
+                    (that.allOfficers ? 0.02 : 0) +
+                    (that.json.allianceClass == ALLY_CLASS_MINER ? 0.05 : 0);
+                  let temp = that.json.empire[that.current.index].db_par2 + 40;
+                  let satsNeeded = Math.ceil(
+                    -diff / (1 + energyBonus) / Math.floor((temp + 140) / 6)
+                  );
+                  let satsSpan = that.createDOM(
+                    "span",
+                    {},
+                    `<a tech-id="212" class="ogl-option ogl-solar-satellite"></a><span>+${toFormatedNumber(
+                      satsNeeded
+                    )}`
+                  );
+                  energyDiv.appendChild(satsSpan);
+                  satsSpan.addEventListener("click", () => {
+                    document
+                      .querySelector(".solarSatellite.hasDetails span")
+                      .click();
+                    waitForElementToDisplay(
+                      "#technologydetails[data-technology-id='212']",
+                      () => {
+                        let satsInput = document.querySelector("#build_amount");
+                        satsInput.focus();
+                        satsInput.value = satsNeeded;
+                        satsInput.dispatchEvent(
+                          new KeyboardEvent("keyup", { code: "ArrowDown" })
+                        );
+                      }
+                    );
+                  });
+                }
               }
               lockListener = () => {
                 let coords =
@@ -1269,23 +2844,45 @@ class OGInfinity {
                 }
                 [0, 1, 2].forEach((i) => {
                   if (missing[i]) {
-                    that.json.missing[coords][i] =
-                      that.json.missing[coords][i] - parseInt(missing[i]);
+                    that.json.missing[coords][i] +=
+                      that.json.missing[coords][i] == 0
+                        ? -Math.ceil(missing[i])
+                        : Math.ceil(resSum[i]);
                   }
                 });
                 that.saveData();
                 that.sideLock(true);
               };
             };
-            input.onkeyup = () => {
-              let value = 1;
-              if (input.value <= 0 || isNaN(Number(input.value))) {
-                input.value = "";
-              } else {
-                value = input.value;
-              }
-              updateShipDetails(value);
+            let oldValue;
+            input.onkeydown = () => {
+              oldValue = input.value;
             };
+            if (!that.isMobile) {
+              input.onkeyup = (event) => {
+                if (event.code == "KeyK")
+                  input.value = Math.max(oldValue, 1) * 1e3;
+                let value = 1;
+                if (input.value <= 0 || isNaN(Number(input.value))) {
+                  input.value = "";
+                } else {
+                  value = input.value;
+                }
+                updateShipDetails(value);
+              };
+            } else {
+              input.oninput = (event) => {
+                if (event.data.includes("k"))
+                  input.value = Math.max(oldValue, 1) * 1e3;
+                let value = 1;
+                if (input.value <= 0 || isNaN(Number(input.value))) {
+                  input.value = "";
+                } else {
+                  value = input.value;
+                }
+                updateShipDetails(value);
+              };
+            }
             updateShipDetails(1);
             document.querySelector(".maximum") &&
               document
@@ -1294,20 +2891,25 @@ class OGInfinity {
                   updateShipDetails(Number(input.getAttribute("max")));
                 });
           } else {
-            let infoDiv = document
-              .querySelector("#technologydetails .sprite_large")
-              .appendChild(
-                that.createDOM("div", { class: "ogk-tech-controls" })
-              );
+            let infoDiv = (
+              document.querySelector("#technologydetails .sprite") ||
+              document.querySelector("#technologydetails .lifeformsprite")
+            ).appendChild(
+              that.createDOM("div", { class: "ogk-tech-controls" })
+            );
             let baseLvl = Number(
               document.querySelector(".level").getAttribute("data-value")
             );
             let tolvl = baseLvl;
             let lvl = titleDiv.appendChild(
-              that.createDOM("div", {}, `Lvl <strong>${baseLvl}</strong>`)
+              that.createDOM(
+                "div",
+                {},
+                `Lvl <strong>${toFormatedNumber(baseLvl)}</strong>`
+              )
             );
             let lvlFromTo = titleDiv.appendChild(that.createDOM("div", {}, ""));
-            titleDiv.appendChild(that.createDOM("div", {}, "Missing"));
+            titleDiv.appendChild(that.createDOM("div", {}, that.getTranslatedText(39)));
             let helpNode = document
               .querySelector(".txt_box .details")
               .cloneNode(true);
@@ -1317,37 +2919,110 @@ class OGInfinity {
             lock.addEventListener("click", () => {
               lockListener();
             });
-            let initTime = that.getTimeFromString(
+            let initTime = getTimeFromString(
               document
                 .querySelector(".build_duration time")
                 .getAttribute("datetime")
             );
-            initTime = formatTimeWrapper(initTime, 2, true, " ", false, "");
-            if (that.page == "research") {
+            let metalCost = document.querySelector(".costs .metal")
+              ? parseInt(
+                document
+                  .querySelector(".costs .metal")
+                  .getAttribute("data-value")
+              )
+              : 0;
+            let crystalCost = document.querySelector(".costs .crystal")
+              ? parseInt(
+                document
+                  .querySelector(".costs .crystal")
+                  .getAttribute("data-value")
+              )
+              : 0;
+            let deuteriumCost = document.querySelector(".costs .deuterium")
+              ? parseInt(
+                document
+                  .querySelector(".costs .deuterium")
+                  .getAttribute("data-value")
+              )
+              : 0;
+            let baseTechno;
+            if (that.page == "research" || that.page == "lfresearch") {
               labs = that.getLabs(
                 technologyId,
                 baseLvl,
                 initTime,
                 technocrat,
-                that.playerClass == 3,
-                bonus
+                that.playerClass == PLAYER_CLASS_EXPLORER,
+                acceleration
+              );
+              baseTechno = that.research(
+                technologyId,
+                baseLvl,
+                1,
+                technocrat,
+                that.playerClass == PLAYER_CLASS_EXPLORER,
+                acceleration
               );
             } else if (
               that.page == "supplies" ||
               that.page == "facilities" ||
-              that.page == "lfbuildings" ||
-              that.page == "lfresearch"
+              that.page == "lfbuildings"
             ) {
-              let lvls = that.getRobotsNanites(technologyId, baseLvl, initTime);
+              let object = that.current.isMoon
+                ? that.json.empire[that.current.index].moon
+                : that.json.empire[that.current.index];
+              let lvls = that.getRobotsNanites(
+                technologyId,
+                baseLvl,
+                initTime,
+                object
+              );
+              baseTechno = that.building(technologyId, baseLvl, 1, 0);
               robotics = lvls.robotics | undefined;
               nanites = lvls.nanites | undefined;
             }
+
+            if (baseTechno.cost[0] != metalCost)
+              document
+                .querySelector(".costs")
+                .appendChild(
+                  that.createDOM(
+                    "div",
+                    { class: "overmark" },
+                    "metal not correct!"
+                  )
+                );
+            if (baseTechno.cost[1] != crystalCost)
+              document
+                .querySelector(".costs")
+                .appendChild(
+                  that.createDOM(
+                    "div",
+                    { class: "overmark" },
+                    "crystal not correct!"
+                  )
+                );
+            if (baseTechno.cost[2] != deuteriumCost)
+              document
+                .querySelector(".costs")
+                .appendChild(
+                  that.createDOM(
+                    "div",
+                    { class: "overmark" },
+                    "deuterium not correct!"
+                  )
+                );
+
             updateResearchDetails(technologyId, baseLvl, tolvl);
             let previous = infoDiv.appendChild(
               that.createDOM("a", { class: "icon icon_skip_back" })
             );
             let lvlSpan = infoDiv.appendChild(
-              that.createDOM("span", { class: "ogk-lvl" }, tolvl)
+              that.createDOM(
+                "span",
+                { class: "ogk-lvl" },
+                toFormatedNumber(tolvl)
+              )
             );
             let next = infoDiv.appendChild(
               that.createDOM("a", { class: "icon icon_skip" })
@@ -1356,24 +3031,52 @@ class OGInfinity {
             next.addEventListener("click", () => {
               tolvl += 1;
               updateResearchDetails(technologyId, baseLvl, tolvl);
-              lvlSpan.innerText = tolvl;
+              lvlSpan.innerText = toFormatedNumber(tolvl);
               textLvl.innerText = textLvl.innerText.replace(tolvl - 1, tolvl);
-              lvl.html(`Lvl <strong>${tolvl}</strong>`);
+              lvl.html(`Lvl <strong>${toFormatedNumber(tolvl)}</strong>`);
               lvlFromTo.html(
-                `<strong>${baseLvl}</strong>-<strong>${tolvl}</strong>`
+                `<strong>${toFormatedNumber(baseLvl)}</strong>-<strong>${toFormatedNumber(tolvl)}</strong>`
               );
+              if (tolvl <= baseLvl) {
+                lvlFromTo.html("");
+              }
+              if (
+                tolvl < baseLvl - 1 &&
+                that.page != "research" &&
+                that.page != "lfresearch"
+              ) {
+                lvlFromTo.html(`${that.getTranslatedText(129)}`);
+              }
             });
             previous.addEventListener("click", () => {
-              if (tolvl == baseLvl) return;
+              if (
+                (that.page == "research" || that.page == "lfresearch") &&
+                tolvl == 1
+              )
+                return;
+              if (tolvl == 0) return;
               tolvl -= 1;
               updateResearchDetails(technologyId, baseLvl, tolvl);
-              lvlSpan.innerText = tolvl;
-              lvl.html(`Lvl <strong>${tolvl}</strong>`);
-              lvlFromTo.html(
-                `<strong>${baseLvl}</strong>-<strong>${tolvl}</strong>`
+              lvlSpan.innerText = toFormatedNumber(tolvl);
+              lvl.html(
+                tolvl != 0
+                  ? `Lvl <strong>${toFormatedNumber(tolvl)}</strong>`
+                  : ""
               );
-              if (tolvl == baseLvl) {
+              lvlFromTo.html(
+                `<strong>${toFormatedNumber(
+                  baseLvl
+                )}</strong>-<strong>${toFormatedNumber(tolvl)}</strong>`
+              );
+              if (tolvl <= baseLvl) {
                 lvlFromTo.html("");
+              }
+              if (
+                tolvl < baseLvl - 1 &&
+                that.page != "research" &&
+                that.page != "lfresearch"
+              ) {
+                lvlFromTo.html(`${that.getTranslatedText(129)}`);
               }
             });
             infoDiv.appendChild(helpNode);
@@ -1407,10 +3110,10 @@ class OGInfinity {
         token = data?.fleetSendingToken;
         if (data.success === true) {
           fadeBox(data.message, false);
-          callback();
+          let href = callback();
           setTimeout(function () {
             $("#sendFleet").removeAttr("disabled");
-            window.location = data.redirectUrl;
+            window.location = href || data.redirectUrl;
           }, 50);
         } else {
           $("#sendFleet").removeAttr("disabled");
@@ -1455,7 +3158,7 @@ class OGInfinity {
       container.appendChild(this.createDOM("hr"));
     }
     let box = this.createDOM("div", { class: "ogk-keep-dialog" });
-    box.appendChild(this.createDOM("h1", {}, "Resources to keep on planets"));
+    box.appendChild(this.createDOM("h1", {}, this.getTranslatedText(28)));
     let prod = box.appendChild(
       this.createDOM("div", { class: "ogk-adjust-grid" })
     );
@@ -1463,46 +3166,46 @@ class OGInfinity {
       this.createDOM(
         "span",
         {},
-        '<a class="ogl-option resourceIcon metal"></a>'
+        '<a class="resourceIcon metal"></a>'
       )
     );
     let metInput = prod.appendChild(
       this.createDOM("input", {
         class: "ogl-formatInput metal",
         type: "text",
-        value: kept[0] || 0,
+        value: toFormatedNumber(kept[0]) || toFormatedNumber(0),
       })
     );
     prod.appendChild(
       this.createDOM(
         "span",
         {},
-        '<a class="ogl-option resourceIcon crystal"></a>'
+        '<a class="resourceIcon crystal"></a>'
       )
     );
     let criInput = prod.appendChild(
       this.createDOM("input", {
         class: "ogl-formatInput crystal",
         type: "text",
-        value: kept[1] || 0,
+        value: toFormatedNumber(kept[1]) || toFormatedNumber(0),
       })
     );
     prod.appendChild(
       this.createDOM(
         "span",
         {},
-        '<a class="ogl-option resourceIcon deuterium"></a>'
+        '<a class="resourceIcon deuterium"></a>'
       )
     );
     let deutInput = prod.appendChild(
       this.createDOM("input", {
         class: "ogl-formatInput deuterium",
         type: "text",
-        value: kept[2] || 0,
+        value: toFormatedNumber(kept[2]) || toFormatedNumber(0),
       })
     );
     box.appendChild(this.createDOM("hr"));
-    box.appendChild(this.createDOM("h1", {}, "Ships to keep on planets"));
+    box.appendChild(this.createDOM("h1", {}, this.getTranslatedText(29)));
     let fleet = box.appendChild(
       this.createDOM("div", { class: "ogk-bhole-grid" })
     );
@@ -1520,37 +3223,54 @@ class OGInfinity {
           class: "ogl-formatInput",
           type: "text",
           data: id,
-          value: kept[id] || 0,
+          value: toFormatedNumber(kept[id]) || toFormatedNumber(0),
         })
       );
       inputs.push(input);
     });
     if (!btn) {
       btn = box.appendChild(
-        this.createDOM("button", { class: "btn_blue" }, "Save")
+        this.createDOM("button", { class: "btn_blue" }, this.getTranslatedText(27))
       );
     }
     btn.addEventListener("click", () => {
       kept = {};
       inputs.forEach((input) => {
         let id = Number(input.getAttribute("data"));
-        let amount = this.removeNumSeparator(input.value);
+        let amount = fromFormatedNumber(input.value, true);
         if (amount > 0) {
           kept[id] = amount;
         }
       });
-      kept[0] = Number(this.removeNumSeparator(metInput.value));
-      kept[1] = Number(this.removeNumSeparator(criInput.value));
-      kept[2] = Number(this.removeNumSeparator(deutInput.value));
+      kept[0] = fromFormatedNumber(metInput.value, true);
+      kept[1] = fromFormatedNumber(criInput.value, true);
+      kept[2] = fromFormatedNumber(deutInput.value, true);
       if (coords) {
         this.json.options.kept[coords] = kept;
       } else {
         this.json.options.defaultKept = kept;
       }
+      this.json.needSync = true;
       this.saveData();
       document.querySelector(".ogl-dialog .close-tooltip").click();
       location.reload();
     });
+    if (coords) {
+      let resetBtn = box.appendChild(
+        this.createDOM(
+          "button",
+          { class: "btn_blue ogl-btn_red" },
+          this.getTranslatedText(26)
+        )
+      );
+      resetBtn.addEventListener("click", () => {
+        this.json.options.kept.delete(coords);
+        this.json.needSync = true;
+        this.saveData();
+        document.querySelector(".ogl-dialog .close-tooltip").click();
+        location.reload();
+      });
+    }
     container.appendChild(box);
     return container;
   }
@@ -1643,6 +3363,105 @@ class OGInfinity {
         ) {
           coords += "P";
         }
+        let object = this.json.empire[this.current.index];
+        object = this.current.isMoon ? object.moon : object;
+        object.metal =
+          fleetDispatcher.metalOnPlanet - fleetDispatcher.cargoMetal;
+        object.crystal =
+          fleetDispatcher.crystalOnPlanet - fleetDispatcher.cargoCrystal;
+        object.deuterium =
+          fleetDispatcher.deuteriumOnPlanet - fleetDispatcher.cargoDeuterium;
+        object.deuterium -= fuel;
+        if (
+          !this.current.isMoon &&
+          object.metal < object.metalStorage &&
+          object.production.hourly[0] == 0
+        ) {
+          object.production.hourly[0] = Math.floor(
+            (resourcesBar.resources.metal.baseProduction +
+              resourcesBar.techs[1].production.metal *
+                object.production.productionFactor) *
+              3600
+          );
+          object.production.daily[0] =
+            Math.floor(
+              (resourcesBar.resources.metal.baseProduction +
+                resourcesBar.techs[1].production.metal *
+                  object.production.productionFactor) *
+                3600
+            ) * 24;
+          object.production.weekly[0] =
+            Math.floor(
+              (resourcesBar.resources.metal.baseProduction +
+                resourcesBar.techs[1].production.metal *
+                  object.production.productionFactor) *
+                3600
+            ) *
+            24 *
+            7;
+        }
+        if (
+          !this.current.isMoon &&
+          object.crystal < object.crystalStorage &&
+          object.production.hourly[1] == 0
+        ) {
+          object.production.hourly[1] = Math.floor(
+            (resourcesBar.resources.crystal.baseProduction +
+              resourcesBar.techs[2].production.crystal *
+                object.production.productionFactor) *
+              3600
+          );
+          object.production.daily[1] =
+            Math.floor(
+              (resourcesBar.resources.crystal.baseProduction +
+                resourcesBar.techs[2].production.crystal *
+                  object.production.productionFactor) *
+                3600
+            ) * 24;
+          object.production.weekly[1] =
+            Math.floor(
+              (resourcesBar.resources.crystal.baseProduction +
+                resourcesBar.techs[2].production.crystal *
+                  object.production.productionFactor) *
+                3600
+            ) *
+            24 *
+            7;
+        }
+        if (
+          !this.current.isMoon &&
+          object.deuterium < object.deuteriumStorage &&
+          object.production.hourly[2] == 0
+        ) {
+          object.production.hourly[2] = Math.floor(
+            (resourcesBar.resources.deuterium.baseProduction +
+              resourcesBar.techs[3].production.deuterium *
+                object.production.productionFactor -
+              resourcesBar.techs[12].consumption.deuterium) *
+              3600
+          );
+          object.production.daily[2] =
+            Math.floor(
+              (resourcesBar.resources.deuterium.baseProduction +
+                resourcesBar.techs[3].production.deuterium *
+                  object.production.productionFactor -
+                resourcesBar.techs[12].consumption.deuterium) *
+                3600
+            ) * 24;
+          object.production.weekly[2] =
+            Math.floor(
+              (resourcesBar.resources.deuterium.baseProduction +
+                resourcesBar.techs[3].production.deuterium *
+                  object.production.productionFactor -
+                resourcesBar.techs[12].consumption.deuterium) *
+                3600
+            ) *
+            24 *
+            7;
+        }
+        fleetDispatcher.shipsToSend.forEach((ship) => {
+          object[ship.id] -= ship.number;
+        });
         if (this.json.missing[coords]) {
           this.json.missing[coords][0] -= fleetDispatcher.cargoMetal;
           this.json.missing[coords][1] -= fleetDispatcher.cargoCrystal;
@@ -1678,13 +3497,14 @@ class OGInfinity {
           this.json.combatsSums[dateStr].fuel -= fuel;
         }
         this.saveData();
+        return this.json.href;
       });
       $(".send_all").before(this.createDOM("span", { class: "select-most" }));
       $(".allornonewrap .select-most").on("click", () => {
         fleetDispatcher.shipsOnPlanet.forEach((ship) => {
           let kept =
             this.json.options.kept[
-              this.current.coords + this.current.isMoon ? "M" : "P"
+              this.current.coords + (this.current.isMoon ? "M" : "P")
             ] || this.json.options.defaultKept;
           this.selectShips(
             ship.id,
@@ -1716,10 +3536,9 @@ class OGInfinity {
               this.createDOM(
                 "span",
                 { class: "ogi-speed" },
-                fleetDispatcher.fleetHelper.shipsData[id].speed.toLocaleString(
-                  document
-                    .getElementById("cookiebanner")
-                    .getAttribute("data-locale")
+                toFormatedNumber(
+                  fleetDispatcher.fleetHelper.shipsData[id].speed,
+                  0
                 )
               )
             );
@@ -1778,16 +3597,16 @@ class OGInfinity {
       .then((rep) => rep.text())
       .then((str) => new window.DOMParser().parseFromString(str, "text/xml"))
       .then((xml) => {
-        this.json.topScore = xml.querySelector("topScore").innerHTML;
-        this.json.speed = xml.querySelector("speed").innerHTML;
-        this.json.speedFleetWar = xml.querySelector("speedFleetWar").innerHTML;
+        this.json.topScore = Number(xml.querySelector("topScore").innerHTML);
+        this.json.speed = Number(xml.querySelector("speed").innerHTML);
+        this.json.speedFleetWar = Number(xml.querySelector("speedFleetWar").innerHTML);
         this.json.speedFleetPeaceful =
-          xml.querySelector("speedFleetPeaceful").innerHTML;
+          Number(xml.querySelector("speedFleetPeaceful").innerHTML);
         this.json.speedFleetHolding =
-          xml.querySelector("speedFleetHolding").innerHTML;
-        this.json.researchDivisor = xml.querySelector(
+          Number(xml.querySelector("speedFleetHolding").innerHTML);
+        this.json.researchDivisor = Number(xml.querySelector(
           "researchDurationDivisor"
-        ).innerHTML;
+        ).innerHTML);
         this.json.trashsimSettings = {
           speed: xml.querySelector("speedFleetWar").innerHTML,
           speed_fleet: xml.querySelector("speedFleetWar").innerHTML,
@@ -1873,7 +3692,10 @@ class OGInfinity {
       this.createDOM(
         "span",
         { class: "ogk-ping" },
-        `<span class='${colorClass}'>${(ping / 1e3).toFixed(1)}s</span> ping`
+        `<span class='${colorClass}'>${toFormatedNumber(
+          ping / 1e3,
+          1
+        )}s</span> ping`
       )
     );
   }
@@ -1924,34 +3746,57 @@ class OGInfinity {
           });
           gone.forEach((movement) => {
             if (
-              movement.type != 6 ||
-              (movement.metal &&
-                movement.metal + movement.crystal + movement.deuterium != 0)
+              movement.own &&
+              (movement.type == 4 || (movement.type == 3 && movement.back)) &&
+              new Date(movement.arrival) < new Date()
             ) {
-              update = true;
-            }
-            if (this.json.myRes[movement.dest]) {
-              let found = false;
-              this.planetList.forEach((planet) => {
-                let coords = planet.querySelector(".planet-koords").textContent;
-                if (coords == movement.origin.slice(0, -1)) {
-                  found = true;
+              let arrival = movement.back ? movement.origin : movement.dest;
+              let coords = "[" + arrival.slice(0, -1) + "]";
+              this.json.empire.forEach((planet) => {
+                if (
+                  (arrival.slice(-1) == "M" && planet.moon) ||
+                  arrival.slice(-1) != "M"
+                ) {
+                  let object = arrival.slice(-1) == "M" ? planet.moon : planet;
+                  if (object.coordinates == coords) {
+                    for (let id in movement.fleet)
+                      object[id] += movement.fleet[id];
+                    this.saveData();
+                  }
                 }
               });
-              if (found) {
-                this.json.myRes[movement.dest].metal += movement.metal;
-                this.json.myRes[movement.dest].crystal += movement.crystal;
-                this.json.myRes[movement.dest].deuterium += movement.deuterium;
-                this.saveData();
-                this.updateresourceDetail();
-              } else {
-                let tot =
-                  movement.metal + movement.crystal + movement.deuterium;
-                if (movement.metal && tot != 0) {
-                  this.json.myRes[movement.dest].invalidate = true;
+            }
+            if (
+              movement.metal + movement.crystal + movement.deuterium != 0 &&
+              (movement.type != 6 || (movement.type == 6 && movement.back)) &&
+              new Date(movement.arrival) < new Date()
+            ) {
+              let arrival = movement.back ? movement.origin : movement.dest;
+              let coords = "[" + arrival.slice(0, -1) + "]";
+              let current =
+                this.current.coords + (this.current.isMoon ? "M" : "P");
+              this.json.empire.forEach((planet) => {
+                if (
+                  (arrival.slice(-1) == "M" && planet.moon) ||
+                  arrival.slice(-1) != "M"
+                ) {
+                  let object = arrival.slice(-1) == "M" ? planet.moon : planet;
+                  if (object.coordinates == coords) {
+                    object.metal += movement.metal;
+                    object.crystal += movement.crystal;
+                    object.deuterium += movement.deuterium;
+                    if (current != arrival) {
+                      if (this.json.options.autofetchempire) {
+                        update = true;
+                      } else {
+                        object.invalidate = true;
+                        this.updateresourceDetail();
+                      }
+                    }
+                  }
+                  this.saveData();
                 }
-                this.saveData();
-              }
+              });
             }
           });
           this.json.needsUpdate = update;
@@ -1959,9 +3804,11 @@ class OGInfinity {
           if (update) {
             this.updateInfo();
           }
+          this.json.needSync = true;
         }
         this.json.flying = flying;
         this.saveData();
+        this.updateresourceDetail();
       }
     }, 10);
     let addOptions = () => {
@@ -1970,7 +3817,7 @@ class OGInfinity {
       div.appendChild(this.createDOM("span", {}, "Keep"));
       let keep = div.appendChild(this.createDOM("input", { type: "checkbox" }));
       if (this.json.options.eventBoxKeep) keep.checked = true;
-      div.appendChild(this.createDOM("span", {}, "Expeditions"));
+      div.appendChild(this.createDOM("span", {}, this.getTranslatedText(41)));
       let exps = div.appendChild(this.createDOM("input", { type: "checkbox" }));
       if (this.json.options.eventBoxExps) exps.checked = true;
       keep.addEventListener("change", () => {
@@ -2690,7 +4537,7 @@ class OGInfinity {
           $(".select-most").on("click", () => {
             let kept =
               this.json.options.kept[
-                this.current.coords + this.current.isMoon ? "M" : "P"
+                this.current.coords + (this.current.isMoon ? "M" : "P")
               ] || this.json.options.defaultKept;
             document
               .querySelectorAll(".ship_input_row input")
@@ -2743,23 +4590,20 @@ class OGInfinity {
       let id = Number(line.getAttribute("id").split("-")[1]);
       let back = line.getAttribute("data-return-flight");
       let type = line.getAttribute("data-mission-type");
-      if (type == 16) return;
+      let own = false;
+      this.json.empire.forEach((planet) => {
+        if (planet.coordinates == line.children[4].innerText.trim()) own = true;
+      });
+      if (type == 16 || !own) return;
       if (type == 4 || (back && !(id - 1 in uniques) && !(id - 2 in uniques))) {
         uniques[id] = true;
         fleetCount += Number(line.querySelector(".detailsFleet").innerText);
       }
     });
     total = fleetCount;
-    this.json.empire.forEach((planet) => {
-      for (let i = 202; i <= 219; i++) {
-        if (i != 212 && i != 217 && i != 216) {
-          total += Number(planet[i]);
-          if (planet.moon) {
-            total += Number(planet.moon[i]);
-          }
-        }
-      }
-    });
+    total = await dataHelper.getPlayer(playerId);
+    if (!total) return;
+    total = total.military.ships;
     let per = (fleetCount / total) * 100;
     let color = "friendly";
     if (per >= 70) color = "neutral";
@@ -2778,13 +4622,13 @@ class OGInfinity {
             "span",
             {
               class: "ogk-flying-per tooltip",
-              title: "Percentage of fleet currently in flight",
+              title: this.getTranslatedText(37),
             },
-            "Flying: " +
+            `${this.getTranslatedText(38)}: ` +
               '<span class="' +
               color +
               '">' +
-              ((fleetCount / total) * 100).toFixed(0) +
+              toFormatedNumber((fleetCount / total) * 100, 0) +
               "%</span>"
           )
         );
@@ -2966,10 +4810,15 @@ class OGInfinity {
                 title: "Trahsim",
               })
             );
-            let apiTechData = {};
-            for (let id in this.json.apiTechData) {
-              apiTechData[id] = { level: this.json.apiTechData[id] };
-            }
+            let apiTechData = {
+              109: { level: this.json.technology[109] },
+              110: { level: this.json.technology[110] },
+              111: { level: this.json.technology[111] },
+              115: { level: this.json.technology[115] },
+              117: { level: this.json.technology[117] },
+              118: { level: this.json.technology[118] },
+              114: { level: this.json.technology[114] },
+            };
             link.addEventListener("click", () => {
               let coords = this.current.coords.split(":");
               let json = {
@@ -3048,26 +4897,26 @@ class OGInfinity {
     let search = harvestOptions.appendChild(
       this.createDOM("div", {
         class: "ogl-option ogl-search-icon tooltip",
-        title: "Player search",
+        title: this.getTranslatedText(2),
       })
     );
     let statsBtn = harvestOptions.appendChild(
       this.createDOM("div", {
         class: "ogl-option ogl-statistics-icon tooltip",
-        title: "Statistics",
+        title: this.getTranslatedText(3),
       })
     );
     let empireBtn;
     empireBtn = harvestOptions.appendChild(
       this.createDOM("div", {
         class: "ogl-option ogl-empire-icon tooltip",
-        title: "Overview",
+        title: this.getTranslatedText(4),
       })
     );
     let overViewBtn = harvestOptions.appendChild(
       this.createDOM("div", {
         class: "ogl-option ogl-overview-icon tooltip",
-        title: "Planets overview",
+        title: this.getTranslatedText(5),
       })
     );
     if (this.json.options.targetList) {
@@ -3196,9 +5045,10 @@ class OGInfinity {
             "[d].[m].[y]"
           )}</strong> <span class="${
             elem.profit >= 0 ? "undermark" : "overmark"
-          }">${elem.profit >= 0 ? " +" : " -"}${getNumberFormatShort(
+          }">${elem.profit >= 0 ? " +" : " -"}${toFormatedNumber(
             Math.abs(elem.profit),
-            2
+            2,
+            true
           )}</strong></span>`;
           if (elem.start) {
             contentHtml += `<strong>${getFormatedDate(
@@ -3238,7 +5088,12 @@ class OGInfinity {
             borderColor: "#1b232c",
           },
         ],
-        labels: ["Economy", "Research", "Military", "Defense"],
+        labels: [
+          this.getTranslatedText(51),
+          this.getTranslatedText(52),
+          this.getTranslatedText(53),
+          this.getTranslatedText(54),
+        ],
       },
       options: {
         circumference: Math.PI,
@@ -3250,7 +5105,7 @@ class OGInfinity {
           outsidePadding: 20,
           labels: [
             {
-              fontSize: 15,
+              fontSize: 12,
               fontStyle: "bold",
               textMargin: 5,
               render: "label",
@@ -3259,7 +5114,7 @@ class OGInfinity {
               fontColor: "#ccc",
             },
             {
-              fontSize: 15,
+              fontSize: 12,
               fontStyle: "bold",
               fontColor: "#1b232c",
               render: "percentage",
@@ -3292,7 +5147,11 @@ class OGInfinity {
             borderColor: "#1b232c",
           },
         ],
-        labels: ["Win", "Lose", "draw"],
+        labels: [
+          this.getTranslatedText(55),
+          this.getTranslatedText(56),
+          this.getTranslatedText(57),
+        ],
       },
       options: {
         circumference: Math.PI,
@@ -3304,7 +5163,7 @@ class OGInfinity {
           outsidePadding: 20,
           labels: [
             {
-              fontSize: 15,
+              fontSize: 12,
               fontStyle: "bold",
               textMargin: 5,
               render: "label",
@@ -3313,7 +5172,7 @@ class OGInfinity {
               fontColor: "rgb(34, 42, 51)",
             },
             {
-              fontSize: 15,
+              fontSize: 12,
               fontStyle: "bold",
               fontColor: "#1b232c",
               render: "percentage",
@@ -3329,15 +5188,15 @@ class OGInfinity {
 
   APIStringToClipboard(fleet) {
     let str = "";
-    str += `characterClassId;${this.playerClass}|114;${this.json.tech114}|`;
-    for (let id in this.json.apiTechData) {
-      str += id + ";" + this.json.apiTechData[id] + "|";
+    str += `characterClassId;${this.playerClass}|114;${this.json.technology[114]}|`;
+    for (let id in [109, 110, 111, 115, 117, 118]) {
+      str += id + ";" + this.json.technology[id] + "|";
     }
     for (let id in fleet) {
       let count = fleet[id];
       str += `${id};${count}|`;
     }
-    fadeBox("<br/>API Key copied in clipboard");
+    fadeBox(`<br/>${this.getTranslatedText(58)}`);
     navigator.clipboard.writeText(str);
   }
 
@@ -3359,7 +5218,7 @@ class OGInfinity {
       this.createDOM(
         "p",
         { class: honorScore > 0 ? "undermark" : "overmark" },
-        "(" + dotted(honorScore) + ")"
+        "(" + toFormatedNumber(honorScore) + ")"
       )
     );
     let playerClassName;
@@ -3376,14 +5235,34 @@ class OGInfinity {
       default:
         playerClassName = "";
     }
+    let allianceClassName;
+    switch (this.json.allianceClass) {
+      case ALLY_CLASS_MINER:
+        allianceClassName = "trader";
+        break;
+      case ALLY_CLASS_WARRIOR:
+        allianceClassName = "warrior";
+        break;
+      case ALLY_CLASS_EXPLORER:
+        allianceClassName = "explorer";
+        break;
+      default:
+        allianceClassName = "";
+    }
     playerDiv.appendChild(
       this.createDOM("div", {
         class: "characterclass small sprite " + playerClassName,
         style: "margin-top: -2px;margin-left: 10px;",
       })
     );
+    playerDiv.appendChild(
+      this.createDOM("div", {
+        class: "alliance_class small " + allianceClassName,
+        style: "margin-top: 1px;margin-left: 30px;",
+      })
+    );
     let stats = playerDiv.appendChild(
-      this.createDOM("a", { class: "ogl-mmorpgstats tooltip", title: "test" })
+      this.createDOM("a", { class: "ogl-mmorpgstats" })
     );
     stats.addEventListener("click", () => {
       window.open(
@@ -3406,32 +5285,32 @@ class OGInfinity {
         player.def
       )
     );
-    globalInfo.appendChild(this.createDOM("h2", {}, player.points.position));
+    globalInfo.appendChild(this.createDOM("h2", {}, toFormatedNumber(parseInt(player.points.position))));
     globalInfo.appendChild(
       this.createDOM(
         "h3",
         {},
-        dotted(player.points.score) + "<small> pts</small>"
+        toFormatedNumber(parseInt(player.points.score)) + "<small> pts</small>"
       )
     );
     let detailRank = globalInfo.appendChild(
       this.createDOM("div", { class: "ogl-detailRank" })
     );
     detailRank.html(
-      `\n          <div><div class="ogl-ecoIcon"></div>${dotted(
-        player.economy.score
+      `\n          <div><div class="ogl-ecoIcon"></div>${toFormatedNumber(
+        parseInt(player.economy.score)
       )} <small>pts</small><span class="ogl-ranking">#${
-        player.economy.position
-      } </span></div>\n          <div><div class="ogl-techIcon"></div>${dotted(
-        player.research.score
+        parseInt(player.economy.position)
+      } </span></div>\n          <div><div class="ogl-techIcon"></div>${toFormatedNumber(
+        parseInt(player.research.score)
       )} <small>pts</small><span class="ogl-ranking">#${
-        player.research.position
-      } </span></div>\n          <div><div class="ogl-fleetIcon"></div>${dotted(
-        player.military.score
-      )} <small>pts</small><span class="ogl-ranking">#${
-        player.military.position
-      } </span></div>\n          <div><div class="ogl-fleetIcon grey"></div>${dotted(
-        player.def
+        parseInt(player.research.position)
+      } </span></div>\n          <div><div class="ogl-fleetIcon"></div>${toFormatedNumber(
+        parseInt(player.military.score)
+      )} <small>pts</small><span class="ogl-ranking">#${toFormatedNumber(
+        parseInt(player.military.position)
+      )} </span></div>\n          <div><div class="ogl-fleetIcon grey"></div>${toFormatedNumber(
+        parseInt(player.def)
       )} <small>pts</small></div>\n          `
     );
     let details = content.appendChild(
@@ -3446,31 +5325,44 @@ class OGInfinity {
     let div = techDetail.appendChild(
       this.createDOM("div", { class: "ogk-tech" })
     );
-    div.appendChild(this.createDOM("span", {}, "Hyperspace"));
+    div.appendChild(this.createDOM("span", {}, this.getTranslatedText(95)));
     div.appendChild(
       this.createDOM("a", {
         class: "ogl-option ogl-fleet-ship ogl-tech-" + 114,
       })
     );
     div.appendChild(
-      this.createDOM("span", {}, `<strong>${this.json.empire[0][114]}</strong>`)
+      this.createDOM(
+        "span",
+        {},
+        `<strong>${toFormatedNumber(this.json.empire[0][114])}</strong>`
+      )
     );
-    div.appendChild(this.createDOM("span", {}, "Computer"));
+    div.appendChild(this.createDOM("span", {}, this.getTranslatedText(94)));
     div.appendChild(
       this.createDOM("a", {
         class: "ogl-option ogl-fleet-ship ogl-tech-" + 108,
       })
     );
     div.appendChild(
-      this.createDOM("span", {}, `<strong>${this.json.tech108 || 0}</strong>`)
+      this.createDOM(
+        "span",
+        {},
+        `<strong>${toFormatedNumber(this.json.technology[108] || 0)}</strong>`
+      )
     );
     let fleetTech = techDetail.appendChild(
       this.createDOM("div", { class: "ogk-tech" })
     );
     [115, 117, 118, 109, 110, 111].forEach((id) => {
-      if (id == 115) fleetTech.appendChild(this.createDOM("div", {}, "Speed "));
+      if (id == 115)
+        fleetTech.appendChild(
+          this.createDOM("div", {}, this.getTranslatedText(87))
+        );
       if (id == 109)
-        fleetTech.appendChild(this.createDOM("div", {}, "Combat "));
+        fleetTech.appendChild(
+          this.createDOM("div", {}, this.getTranslatedText(86))
+        );
       fleetTech.appendChild(
         this.createDOM("a", {
           class: "ogl-option ogl-fleet-ship ogl-tech-" + id,
@@ -3480,26 +5372,40 @@ class OGInfinity {
         this.createDOM(
           "span",
           {},
-          `<strong>${this.json.empire[0][id]}</strong>`
+          `<strong>${toFormatedNumber(this.json.empire[0][id])}</strong>`
         )
       );
     });
-    let mprod = 0,
-      mlvl = 0,
-      cprod = 0,
+    let mlvl = 0,
       clvl = 0,
-      dprod = 0,
       dlvl = 0,
-      sum = 0;
+      mprodh = 0,
+      mprodd = 0,
+      mprodw = 0,
+      cprodh = 0,
+      cprodd = 0,
+      cprodw = 0,
+      dprodh = 0,
+      dprodd = 0,
+      dprodw = 0;
     this.json.empire.forEach((planet) => {
       mlvl += Number(planet[1]);
-      mprod += Number(planet.production.hourly[0]);
+      mprodh += Number(planet.production.hourly[0]);
+      mprodd += Number(planet.production.daily[0]);
+      mprodw += Number(planet.production.weekly[0]);
       clvl += Number(planet[2]);
-      cprod += Number(planet.production.hourly[1]);
+      cprodh += Number(planet.production.hourly[1]);
+      cprodd += Number(planet.production.daily[1]);
+      cprodw += Number(planet.production.weekly[1]);
       dlvl += Number(planet[3]);
-      dprod += Number(planet.production.hourly[2]);
+      dprodh += Number(planet.production.hourly[2]);
+      dprodd += Number(planet.production.daily[2]);
+      dprodw += Number(planet.production.weekly[2]);
     });
-    sum = this.json.empire.length;
+    let sum = this.json.empire.length;
+    let mStorage = Math.ceil((Math.log(Math.ceil(mprodd / 5000)) * 33) / 22);
+    let cStorage = Math.ceil((Math.log(Math.ceil(cprodd / 5000)) * 33) / 22);
+    let dStorage = Math.ceil((Math.log(Math.ceil(dprodd / 5000)) * 33) / 22);
     mlvl = mlvl / sum;
     clvl = clvl / sum;
     dlvl = dlvl / sum;
@@ -3511,78 +5417,130 @@ class OGInfinity {
       this.createDOM(
         "span",
         { class: "ogk-title ogl-metal" },
-        `<a class="resourceIcon metal ogl-option"></a>${mlvl.toFixed(1)}`
+        `<a class="resourceIcon metal ogl-option"></a>${toFormatedNumber(
+          mlvl,
+          1
+        )}`
       )
     );
     prod.appendChild(
       this.createDOM(
         "span",
         { class: "ogk-title ogl-crystal" },
-        `<a class="resourceIcon crystal ogl-option"></a>${clvl.toFixed(1)}`
+        `<a class="resourceIcon crystal ogl-option"></a>${toFormatedNumber(
+          clvl,
+          1
+        )}`
       )
     );
     prod.appendChild(
       this.createDOM(
         "span",
         { class: "ogk-title ogl-deut" },
-        `<a class="resourceIcon deuterium ogl-option"></a>${dlvl.toFixed(1)}`
+        `<a class="resourceIcon deuterium ogl-option"></a>${toFormatedNumber(
+          dlvl,
+          1
+        )}`
       )
     );
-    prod.appendChild(this.createDOM("p", {}, "<strong>Ratio</strong>"));
+    prod.appendChild(
+      this.createDOM("p", {}, `<strong>${this.getTranslatedText(59)}</strong>`)
+    );
     prod.appendChild(
       this.createDOM(
         "span",
         { class: "ogl-metal" },
-        `<strong>${(mprod / dprod).toFixed(2)}</strong>`
+        `<strong>${toFormatedNumber(mprodh / dprodh, 2)}</strong>`
       )
     );
     prod.appendChild(
       this.createDOM(
         "span",
         { class: "ogl-crystal" },
-        `<strong>${(cprod / dprod).toFixed(2)}</strong>`
+        `<strong>${toFormatedNumber(cprodh / dprodh, 2)}</strong>`
       )
     );
     prod.appendChild(
-      this.createDOM("span", { class: "ogl-deut" }, "<strong>1</strong>")
+      this.createDOM(
+        "span",
+        { class: "ogl-deut" },
+        `<strong>${toFormatedNumber(1)}</strong>`
+      )
     );
-    prod.appendChild(this.createDOM("p", {}, "Hour"));
-    prod.appendChild(
-      this.createDOM("span", { class: "ogl-metal" }, `${dotted(mprod)}`)
-    );
-    prod.appendChild(
-      this.createDOM("span", { class: "ogl-crystal" }, `${dotted(cprod)}`)
-    );
-    prod.appendChild(
-      this.createDOM("span", { class: "ogl-deut" }, `${dotted(dprod)}`)
-    );
-    prod.appendChild(this.createDOM("p", {}, "Day"));
-    prod.appendChild(
-      this.createDOM("span", { class: "ogl-metal" }, `${dotted(mprod * 24)}`)
-    );
-    prod.appendChild(
-      this.createDOM("span", { class: "ogl-crystal" }, `${dotted(cprod * 24)}`)
-    );
-    prod.appendChild(
-      this.createDOM("span", { class: "ogl-deut" }, `${dotted(dprod * 24)}`)
-    );
-    prod.appendChild(this.createDOM("p", {}, "Week"));
+    prod.appendChild(this.createDOM("p", {}, this.getTranslatedText(60)));
     prod.appendChild(
       this.createDOM(
         "span",
         { class: "ogl-metal" },
-        `${dotted(mprod * 24 * 7)}`
+        `${toFormatedNumber(Math.floor(mprodh))}`
       )
     );
     prod.appendChild(
       this.createDOM(
         "span",
         { class: "ogl-crystal" },
-        `${dotted(cprod * 24 * 7)}`
+        `${toFormatedNumber(Math.floor(cprodh))}`
       )
     );
     prod.appendChild(
-      this.createDOM("span", { class: "ogl-deut" }, `${dotted(dprod * 24 * 7)}`)
+      this.createDOM(
+        "span",
+        { class: "ogl-deut" },
+        `${toFormatedNumber(Math.floor(dprodh))}`
+      )
+    );
+    prod.appendChild(this.createDOM("p", {}, this.getTranslatedText(61)));
+    prod.appendChild(
+      this.createDOM(
+        "span",
+        {
+          class: "ogl-metal tooltip",
+          "data-title": `${this.getTranslatedText(22, "tech")} ${mStorage}`,
+        },
+        `${toFormatedNumber(Math.floor(mprodd))}`
+      )
+    );
+    prod.appendChild(
+      this.createDOM(
+        "span",
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": `${this.getTranslatedText(23, "tech")} ${cStorage}`,
+        },
+        `${toFormatedNumber(Math.floor(cprodd))}`
+      )
+    );
+    prod.appendChild(
+      this.createDOM(
+        "span",
+        {
+          class: "ogl-deut tooltip",
+          "data-title": `${this.getTranslatedText(24, "tech")} ${dStorage}`,
+        },
+        `${toFormatedNumber(Math.floor(dprodd))}`
+      )
+    );
+    prod.appendChild(this.createDOM("p", {}, this.getTranslatedText(62)));
+    prod.appendChild(
+      this.createDOM(
+        "span",
+        { class: "ogl-metal" },
+        `${toFormatedNumber(Math.floor(mprodw))}`
+      )
+    );
+    prod.appendChild(
+      this.createDOM(
+        "span",
+        { class: "ogl-crystal" },
+        `${toFormatedNumber(Math.floor(cprodw))}`
+      )
+    );
+    prod.appendChild(
+      this.createDOM(
+        "span",
+        { class: "ogl-deut" },
+        `${toFormatedNumber(Math.floor(dprodw))}`
+      )
     );
     prod.appendChild(this.createDOM("span"));
     let innerAstro = prod.appendChild(
@@ -3591,7 +5549,7 @@ class OGInfinity {
           "display: flex; align-items: center; margin-left: auto; margin-top: 10px;",
       })
     );
-    innerAstro.appendChild(this.createDOM("span", {}, "Astro"));
+    innerAstro.appendChild(this.createDOM("span", {}, this.getTranslatedText(93)));
     innerAstro.appendChild(
       this.createDOM("a", {
         class: "ogl-option ogl-fleet-ship ogl-tech-124",
@@ -3599,7 +5557,13 @@ class OGInfinity {
       })
     );
     innerAstro.appendChild(
-      this.createDOM("span", {}, `<strong>${this.json.tech124 || 0}</strong>`)
+      this.createDOM(
+        "span",
+        {},
+        `<strong>${
+          toFormatedNumber(this.json.technology[124]) || toFormatedNumber(0)
+        }</strong>`
+      )
     );
     let innerEnergy = prod.appendChild(
       this.createDOM("span", {
@@ -3607,7 +5571,7 @@ class OGInfinity {
           "display: flex; align-items: center; margin-left: auto; margin-top: 10px;",
       })
     );
-    innerEnergy.appendChild(this.createDOM("span", {}, "Energy"));
+    innerEnergy.appendChild(this.createDOM("span", {}, this.getTranslatedText(4, "res")));
     innerEnergy.appendChild(
       this.createDOM("a", {
         class: "ogl-option ogl-fleet-ship ogl-tech-113",
@@ -3615,7 +5579,13 @@ class OGInfinity {
       })
     );
     innerEnergy.appendChild(
-      this.createDOM("span", {}, `<strong>${this.json.tech113 || 0}</strong>`)
+      this.createDOM(
+        "span",
+        {},
+        `<strong>${
+          toFormatedNumber(this.json.technology[113]) || toFormatedNumber(0)
+        }</strong>`
+      )
     );
     let innerPlasma = prod.appendChild(
       this.createDOM("span", {
@@ -3623,7 +5593,7 @@ class OGInfinity {
           "display: flex; align-items: center; margin-left: auto; margin-top: 10px;",
       })
     );
-    innerPlasma.appendChild(this.createDOM("span", {}, "Plasma"));
+    innerPlasma.appendChild(this.createDOM("span", {}, this.getTranslatedText(96)));
     innerPlasma.appendChild(
       this.createDOM("a", {
         class: "ogl-option ogl-fleet-ship ogl-tech-122",
@@ -3631,7 +5601,13 @@ class OGInfinity {
       })
     );
     innerPlasma.appendChild(
-      this.createDOM("span", {}, `<strong>${this.json.tech122 || 0}</strong>`)
+      this.createDOM(
+        "span",
+        {},
+        `<strong>${
+          toFormatedNumber(this.json.technology[122]) || toFormatedNumber(0)
+        }</strong>`
+      )
     );
     let fleetDetail = details.appendChild(
       this.createDOM("div", { class: "ogk-box" })
@@ -3643,6 +5619,7 @@ class OGInfinity {
     let totalFleet = {};
     let cyclos = 0;
     let totalSum = 0;
+    let transport = 0;
     [
       202, 203, 208, 209, 210, 204, 205, 206, 219, 207, 215, 211, 213, 218, 214,
     ].forEach((id) => {
@@ -3655,6 +5632,7 @@ class OGInfinity {
           sum += Number(planet.moon[id]);
         }
       });
+      transport += sum * this.json.ships[id].cargoCapacity;
       totalSum += sum;
       let shipDiv = fleet.appendChild(this.createDOM("div"));
       shipDiv.appendChild(
@@ -3665,7 +5643,7 @@ class OGInfinity {
       if (id == 209) {
         cyclos = sum;
       }
-      shipDiv.appendChild(this.createDOM("span", {}, dotted(sum)));
+      shipDiv.appendChild(this.createDOM("span", {}, toFormatedNumber(sum)));
       totalFleet[id] = sum;
     });
     let fleetInfo = fleetDetail.appendChild(
@@ -3681,15 +5659,29 @@ class OGInfinity {
       this.createDOM(
         "span",
         {},
-        `Fleet: <strong>${dotted(totalSum)}</strong> <small>ships</small>`
+        `${this.getTranslatedText(63)}: <strong>${toFormatedNumber(
+          totalSum
+        )}</strong><small> ${this.getTranslatedText(64)}</small>`
       )
     );
-    let rcpower = (((this.json.empire[0][114] * 5) / 100) * 2e4 + 2e4) * cyclos;
     fleetInfo.appendChild(
       this.createDOM(
         "span",
         {},
-        `Recycling: <strong>${dotted(rcpower)}</strong>`
+        `${this.getTranslatedText(47)}: <strong>${toFormatedNumber(
+          transport
+        )}</strong>`
+      )
+    );
+    let rcpower =
+      (((this.json.empire[0][114] * 5) / 100) * 20000 + 20000) * cyclos;
+    fleetInfo.appendChild(
+      this.createDOM(
+        "span",
+        {},
+        `${this.getTranslatedText(65)}: <strong>${toFormatedNumber(
+          rcpower
+        )}</strong>`
       )
     );
     return content;
@@ -3721,12 +5713,16 @@ class OGInfinity {
   async statistics() {
     let showStats = async () => {
       let player = await dataHelper.getPlayer(playerId);
-      let body = this.tabs({
-        General: this.generalStats.bind(this, player),
-        Production: this.minesStats.bind(this),
-        Expeditions: this.expeditionStats.bind(this),
-        Combats: this.combatStats.bind(this),
-      });
+      let tabNames = {};
+      tabNames[this.getTranslatedText(91)] = this.generalStats.bind(
+        this,
+        player
+      );
+      tabNames[this.getTranslatedText(85)] = this.minesStats.bind(this);
+      tabNames[this.getTranslatedText(41)] = this.expeditionStats.bind(this);
+      tabNames[this.getTranslatedText(92)] = this.combatStats.bind(this);
+      tabNames[this.getTranslatedText(120)] = this.roiStats.bind(this);
+      let body = this.tabs(tabNames);
       this.popup(null, body);
     };
     if (typeof Chart === "undefined") {
@@ -3809,7 +5805,6 @@ class OGInfinity {
                                 <li><u>Transparent dot</u>: not enough planet checked</li>
                             </ul>-->
                         `);
-
           ["last24h", "2days", "3days", "week", "2weeks", "month"].forEach(
             (f) => {
               let btn = container
@@ -3964,7 +5959,11 @@ class OGInfinity {
                     this.createDOM(
                       "div",
                       { class: "ogl-unknown-warning" },
-                      "Unknown expedition message... <a href='https://discord.gg/8Y4SWup'> Help me find them all</a>"
+                      `${this.getTranslatedText(
+                        112
+                      )} <a href='https://discord.gg/8Y4SWup'> ${this.getTranslatedText(
+                        113
+                      )}</a>`
                     )
                   );
             } else if (this.json.expeditions[id].busy) {
@@ -3972,8 +5971,7 @@ class OGInfinity {
                 msg.querySelector(".msg_actions").appendChild(
                   this.createDOM("a", {
                     class: "ogl-warning tooltip",
-                    "data-title":
-                      "Warning : expedition position is getting weak...",
+                    "data-title": this.getTranslatedText(114),
                   })
                 );
             }
@@ -4015,7 +6013,7 @@ class OGInfinity {
                 let found = textContent.match(regex);
                 if (found) {
                   type = normalized[i];
-                  sums.found[i] += Number(this.removeNumSeparator(found[0]));
+                  sums.found[i] += fromFormatedNumber(found[0], true);
                 }
               }
             });
@@ -4046,7 +6044,11 @@ class OGInfinity {
                   this.createDOM(
                     "div",
                     { class: "ogl-unknown-warning" },
-                    "Unknown expedition message... <a href='https://discord.gg/8Y4SWup'> Help me find them all</a>"
+                    `${this.getTranslatedText(
+                      112
+                    )} <a href='https://discord.gg/8Y4SWup'> ${this.getTranslatedText(
+                      113
+                    )}</a>`
                   )
                 );
             } else if (this.json.expeditions[id].busy) {
@@ -4054,7 +6056,7 @@ class OGInfinity {
                 this.createDOM("a", {
                   class:
                     "ogl-warning tooltipRight ogl-tooltipReady ogl-tooltipInit",
-                  "data-title": "Warning : Expedition position is weak...",
+                  "data-title": this.getTranslatedText(114),
                 })
               );
             }
@@ -4069,133 +6071,131 @@ class OGInfinity {
         let id = document
           .querySelector("li[id=subtabs-nfFleet21].ui-state-active")
           .getAttribute("aria-controls");
-        document.querySelectorAll(`div[id=${id}] li.msg`).forEach((msg, ix) => {
-          setTimeout(() => {
-            let id = msg.getAttribute("data-msg-id");
-            let isCR = msg.querySelector(".msg_actions .icon_nf_link");
-            if (!isCR) {
-              msg.classList.add("ogk-combat-contact");
+        document.querySelectorAll(`div[id=${id}] li.msg`).forEach((msg) => {
+          let id = msg.getAttribute("data-msg-id");
+          let isCR = msg.querySelector(".msg_actions .icon_nf_link");
+          if (!isCR) {
+            msg.classList.add("ogk-combat-contact");
+          }
+          if (id in this.json.combats) {
+            if (msg.querySelector(".icon_favorited")) {
+              this.json.combats[id].favorited = true;
+              this.json.combats[id].date = new Date();
+            } else {
+              this.json.combats[id].favorited = false;
             }
-            if (id in this.json.combats) {
-              if (msg.querySelector(".icon_favorited")) {
-                this.json.combats[id].favorited = true;
-                this.json.combats[id].date = new Date();
+            if (this.json.combats[id].coordinates.position == 16) {
+              msg.classList.add("ogk-expedition");
+            } else if (this.json.combats[id].isProbes) {
+              msg.classList.add("ogk-combat-probes");
+            } else if (this.json.combats[id].draw) {
+              msg.classList.add("ogk-combat-draw");
+            } else if (this.json.combats[id].win) {
+              msg.classList.add("ogk-combat-win");
+            } else {
+              msg.classList.add("ogk-combat");
+            }
+          } else if (id in this.combats) {
+            return;
+          } else {
+            this.combats[id] = true;
+            this.fetchAndConvertRC(id).then((cr) => {
+              if (cr === null) return;
+              let date = getFormatedDate(cr.timestamp, "[d].[m].[y]");
+              if (cr.coordinates.position == 16) {
+                if (!this.json.expeditionSums[date]) {
+                  this.json.expeditionSums[date] = {
+                    found: [0, 0, 0, 0],
+                    harvest: [0, 0],
+                    fleet: {},
+                    losses: {},
+                    type: {},
+                    fuel: 0,
+                    adjust: [0, 0, 0],
+                  };
+                }
+                for (let [key, value] of Object.entries(cr.losses)) {
+                  if (this.json.expeditionSums[date].losses[key]) {
+                    this.json.expeditionSums[date].losses[key] += value;
+                  } else {
+                    this.json.expeditionSums[date].losses[key] = value;
+                  }
+                }
               } else {
-                this.json.combats[id].favorited = false;
+                if (!this.json.combatsSums[date]) {
+                  this.json.combatsSums[date] = {
+                    loot: [0, 0, 0],
+                    harvest: [0, 0],
+                    losses: {},
+                    fuel: 0,
+                    adjust: [0, 0, 0],
+                    topCombats: [],
+                    count: 0,
+                    wins: 0,
+                    draws: 0,
+                  };
+                }
+                if (!cr.isProbes) {
+                  if (cr.win) this.json.combatsSums[date].wins += 1;
+                  if (cr.draw) this.json.combatsSums[date].draws += 1;
+                  this.json.combatsSums[date].count += 1;
+                  this.json.combatsSums[date].topCombats.push({
+                    debris: cr.debris.metalTotal + cr.debris.crystalTotal,
+                    loot:
+                      (cr.loot.metal + cr.loot.crystal + cr.loot.deuterium) *
+                      (cr.win ? 1 : -1),
+                    ennemi: cr.ennemi.name,
+                    losses: cr.ennemi.losses,
+                  });
+                  this.json.combatsSums[date].topCombats.sort(
+                    (a, b) =>
+                      b.debris +
+                      Math.abs(b.loot) -
+                      (a.debris + Math.abs(a.loot))
+                  );
+                  if (this.json.combatsSums[date].topCombats.length > 3) {
+                    this.json.combatsSums[date].topCombats.pop();
+                  }
+                }
+                if (cr.win) {
+                  this.json.combatsSums[date].loot[0] += cr.loot.metal;
+                  this.json.combatsSums[date].loot[1] += cr.loot.crystal;
+                  this.json.combatsSums[date].loot[2] += cr.loot.deuterium;
+                } else {
+                  this.json.combatsSums[date].loot[0] -= cr.loot.metal;
+                  this.json.combatsSums[date].loot[1] -= cr.loot.crystal;
+                  this.json.combatsSums[date].loot[2] -= cr.loot.deuterium;
+                }
+                for (let [key, value] of Object.entries(cr.losses)) {
+                  if (this.json.combatsSums[date].losses[key]) {
+                    this.json.combatsSums[date].losses[key] += value;
+                  } else {
+                    this.json.combatsSums[date].losses[key] = value;
+                  }
+                }
               }
-              if (this.json.combats[id].coordinates.position == 16) {
+              if (cr.coordinates.position == 16) {
                 msg.classList.add("ogk-expedition");
-              } else if (this.json.combats[id].isProbes) {
+              } else if (cr.isProbes) {
                 msg.classList.add("ogk-combat-probes");
-              } else if (this.json.combats[id].draw) {
+              } else if (cr.draw) {
                 msg.classList.add("ogk-combat-draw");
-              } else if (this.json.combats[id].win) {
+              } else if (cr.win) {
                 msg.classList.add("ogk-combat-win");
               } else {
                 msg.classList.add("ogk-combat");
               }
-            } else if (id in this.combats) {
-              return;
-            } else {
-              this.combats[id] = true;
-              this.fetchAndConvertRC(id).then((cr) => {
-                if (cr === null) return;
-                let date = getFormatedDate(cr.timestamp, "[d].[m].[y]");
-                if (cr.coordinates.position == 16) {
-                  if (!this.json.expeditionSums[date]) {
-                    this.json.expeditionSums[date] = {
-                      found: [0, 0, 0, 0],
-                      harvest: [0, 0],
-                      fleet: {},
-                      losses: {},
-                      type: {},
-                      fuel: 0,
-                      adjust: [0, 0, 0],
-                    };
-                  }
-                  for (let [key, value] of Object.entries(cr.losses)) {
-                    if (this.json.expeditionSums[date].losses[key]) {
-                      this.json.expeditionSums[date].losses[key] += value;
-                    } else {
-                      this.json.expeditionSums[date].losses[key] = value;
-                    }
-                  }
-                } else {
-                  if (!this.json.combatsSums[date]) {
-                    this.json.combatsSums[date] = {
-                      loot: [0, 0, 0],
-                      harvest: [0, 0],
-                      losses: {},
-                      fuel: 0,
-                      adjust: [0, 0, 0],
-                      topCombats: [],
-                      count: 0,
-                      wins: 0,
-                      draws: 0,
-                    };
-                  }
-                  if (!cr.isProbes) {
-                    if (cr.win) this.json.combatsSums[date].wins += 1;
-                    if (cr.draw) this.json.combatsSums[date].draws += 1;
-                    this.json.combatsSums[date].count += 1;
-                    this.json.combatsSums[date].topCombats.push({
-                      debris: cr.debris.metalTotal + cr.debris.crystalTotal,
-                      loot:
-                        (cr.loot.metal + cr.loot.crystal + cr.loot.deuterium) *
-                        (cr.win ? 1 : -1),
-                      ennemi: cr.ennemi.name,
-                      losses: cr.ennemi.losses,
-                    });
-                    this.json.combatsSums[date].topCombats.sort(
-                      (a, b) =>
-                        b.debris +
-                        Math.abs(b.loot) -
-                        (a.debris + Math.abs(a.loot))
-                    );
-                    if (this.json.combatsSums[date].topCombats.length > 3) {
-                      this.json.combatsSums[date].topCombats.pop();
-                    }
-                  }
-                  if (cr.win) {
-                    this.json.combatsSums[date].loot[0] += cr.loot.metal;
-                    this.json.combatsSums[date].loot[1] += cr.loot.crystal;
-                    this.json.combatsSums[date].loot[2] += cr.loot.deuterium;
-                  } else {
-                    this.json.combatsSums[date].loot[0] -= cr.loot.metal;
-                    this.json.combatsSums[date].loot[1] -= cr.loot.crystal;
-                    this.json.combatsSums[date].loot[2] -= cr.loot.deuterium;
-                  }
-                  for (let [key, value] of Object.entries(cr.losses)) {
-                    if (this.json.combatsSums[date].losses[key]) {
-                      this.json.combatsSums[date].losses[key] += value;
-                    } else {
-                      this.json.combatsSums[date].losses[key] = value;
-                    }
-                  }
-                }
-                if (cr.coordinates.position == 16) {
-                  msg.classList.add("ogk-expedition");
-                } else if (cr.isProbes) {
-                  msg.classList.add("ogk-combat-probes");
-                } else if (cr.draw) {
-                  msg.classList.add("ogk-combat-draw");
-                } else if (cr.win) {
-                  msg.classList.add("ogk-combat-win");
-                } else {
-                  msg.classList.add("ogk-combat");
-                }
-                this.json.combats[id] = {
-                  timestamp: cr.timestamp,
-                  favorited: msg.querySelector(".icon_favorited") ? true : false,
-                  coordinates: cr.coordinates,
-                  win: cr.win,
-                  draw: cr.draw,
-                  isProbes: cr.isProbes,
-                };
-                this.saveData();
-              });
-            }
-          }, ix * 50);
+              this.json.combats[id] = {
+                timestamp: cr.timestamp,
+                favorited: msg.querySelector(".icon_favorited") ? true : false,
+                coordinates: cr.coordinates,
+                win: cr.win,
+                draw: cr.draw,
+                isProbes: cr.isProbes,
+              };
+              this.saveData();
+            });
+          }
         });
       }
       if (document.querySelector("li[id=subtabs-nfFleet24].ui-state-active")) {
@@ -4223,12 +6223,8 @@ class OGInfinity {
             let content = msg.querySelector(".msg_content").innerText;
             coords = coords.innerText.slice(1, -1);
             let matches = content.match(/[0-9.,]*[0-9]/gm);
-            let met = Number(
-              this.removeNumSeparator(matches[matches.length - 2])
-            );
-            let cri = Number(
-              this.removeNumSeparator(matches[matches.length - 1])
-            );
+            let met = fromFormatedNumber(matches[matches.length - 2]);
+            let cri = fromFormatedNumber(matches[matches.length - 1]);
             let combat = false;
             if (coords.split(":")[2] == 16) {
               msg.classList.add("ogk-expedition");
@@ -4299,27 +6295,27 @@ class OGInfinity {
 
   overview(forcePlanetView = false) {
     let header = this.createDOM("div", { class: "ogl-tabs" });
+    let minesBtn = header.appendChild(
+      this.createDOM("span", { class: "ogl-tab ogl-active" }, this.getTranslatedText(90))
+    );
     let fleetBtn = header.appendChild(
-      this.createDOM("span", { class: "ogl-tab ogl-active" }, "Fleet")
+      this.createDOM("span", { class: "ogl-tab" }, this.getTranslatedText(63))
     );
     let defBtn = header.appendChild(
-      this.createDOM("span", { class: "ogl-tab" }, "Defense")
-    );
-    let minesBtn = header.appendChild(
-      this.createDOM("span", { class: "ogl-tab" }, "Mines")
+      this.createDOM("span", { class: "ogl-tab" }, this.getTranslatedText(89))
     );
     let body = this.createDOM("div");
     body.appendChild(header);
-    body.appendChild(this.fleetOverview(true));
+    body.appendChild(this.minesOverview());
     let tabListener = (e) => {
+      minesBtn.classList.remove("ogl-active");
       fleetBtn.classList.remove("ogl-active");
       defBtn.classList.remove("ogl-active");
-      minesBtn.classList.remove("ogl-active");
       body.children[1].remove();
-      if (e.target.innerText == "Fleet") {
+      if (e.target.innerText == this.getTranslatedText(63)) {
         fleetBtn.classList.add("ogl-active");
         body.appendChild(this.fleetOverview());
-      } else if (e.target.innerText == "Defense") {
+      } else if (e.target.innerText == this.getTranslatedText(89)) {
         defBtn.classList.add("ogl-active");
         body.appendChild(this.defenseOverview());
       } else {
@@ -4327,9 +6323,9 @@ class OGInfinity {
         body.appendChild(this.minesOverview());
       }
     };
+    minesBtn.addEventListener("click", tabListener);
     fleetBtn.addEventListener("click", tabListener);
     defBtn.addEventListener("click", tabListener);
-    minesBtn.addEventListener("click", tabListener);
     this.popup(null, body);
 
     // Force the planet view to be displayed instead of the moon view.
@@ -4483,38 +6479,38 @@ class OGInfinity {
       let box = this.resourceBox(
         [
           {
-            title: "Found",
+            title: this.getTranslatedText(67),
             metal: sums.found[0],
             crystal: sums.found[1],
             deuterium: sums.found[2],
             am: sums.found[3],
           },
           {
-            title: "Fleet",
+            title: this.getTranslatedText(63),
             metal: fleetRes[0],
             crystal: fleetRes[1],
             deuterium: fleetRes[2],
           },
           {
-            title: "Recycled",
+            title: this.getTranslatedText(68),
             metal: sums.harvest[0],
             crystal: sums.harvest[1],
             deuterium: 0,
           },
           {
-            title: "Losses",
+            title: this.getTranslatedText(69),
             metal: -losses[0],
             crystal: -losses[1],
             deuterium: -losses[2],
           },
           {
-            title: "Fuel",
+            title: this.getTranslatedText(70),
             metal: 0,
             crystal: 0,
             deuterium: sums.fuel,
           },
           {
-            title: "B. Hole",
+            title: this.getTranslatedText(71),
             metal: sums.adjust[0],
             crystal: sums.adjust[1],
             deuterium: sums.adjust[2],
@@ -4640,193 +6636,193 @@ class OGInfinity {
       }
       document.querySelector(".ogk-stats-content .ogl-tab.ogl-active").click();
     };
-    content.appendChild(
-      this.tabs({
-        D: () => {
-          let date = new Date();
-          let sum = {
-            found: [0, 0, 0, 0],
-            harvest: [0, 0],
-            losses: {
-              202: 0,
-              203: 0,
-              210: 0,
-              204: 0,
-              205: 0,
-              206: 0,
-              219: 0,
-              207: 0,
-              215: 0,
-              211: 0,
-              213: 0,
-              218: 0,
-            },
-            fleet: {
-              202: 0,
-              203: 0,
-              210: 0,
-              204: 0,
-              205: 0,
-              206: 0,
-              219: 0,
-              207: 0,
-              215: 0,
-              211: 0,
-              213: 0,
-              218: 0,
-            },
-            type: {},
-            fuel: 0,
-            adjust: [0, 0, 0],
-          };
-          let profits = [];
-          let max = 0;
-          for (let i = 0; i < 12; i++) {
-            let dateStr = getFormatedDate(date.getTime(), "[d].[m].[y]");
-            let sums = this.json.expeditionSums[dateStr] || sum;
-            let profit = sums ? getTotal(sums) : 0;
-            if (Math.abs(profit) > max) max = profit;
-            profits.push({
-              date: new Date(date.getTime()),
-              range: sums,
-              profit: profit,
-            });
-            date.setDate(date.getDate() - 1);
-          }
-          let div = this.createDOM("div");
-          let details = renderDetails(
-            computeRangeSums(this.json.expeditionSums, new Date(), new Date()),
-            () => refresh()
-          );
-          div.appendChild(
-            this.profitGraph(profits, max, (range, index) => {
-              details.remove();
-              details = renderDetails(range, () => {
-                refresh(index);
-              });
-              div.appendChild(details);
-            })
-          );
+    let tabNames = {};
+    tabNames[LocalizationStrings.timeunits.short.day] = () => {
+      let date = new Date();
+      let sum = {
+        found: [0, 0, 0, 0],
+        harvest: [0, 0],
+        losses: {
+          202: 0,
+          203: 0,
+          210: 0,
+          204: 0,
+          205: 0,
+          206: 0,
+          219: 0,
+          207: 0,
+          215: 0,
+          211: 0,
+          213: 0,
+          218: 0,
+        },
+        fleet: {
+          202: 0,
+          203: 0,
+          210: 0,
+          204: 0,
+          205: 0,
+          206: 0,
+          219: 0,
+          207: 0,
+          215: 0,
+          211: 0,
+          213: 0,
+          218: 0,
+        },
+        type: {},
+        fuel: 0,
+        adjust: [0, 0, 0],
+      };
+      let profits = [];
+      let max = 0;
+      for (let i = 0; i < 12; i++) {
+        let dateStr = getFormatedDate(date.getTime(), "[d].[m].[y]");
+        let sums = this.json.expeditionSums[dateStr] || sum;
+        let profit = sums ? getTotal(sums) : 0;
+        if (Math.abs(profit) > max) max = profit;
+        profits.push({
+          date: new Date(date.getTime()),
+          range: sums,
+          profit: profit,
+        });
+        date.setDate(date.getDate() - 1);
+      }
+      let div = this.createDOM("div");
+      let details = renderDetails(
+        computeRangeSums(this.json.expeditionSums, new Date(), new Date()),
+        () => refresh()
+      );
+      div.appendChild(
+        this.profitGraph(profits, max, (range, index) => {
+          details.remove();
+          details = renderDetails(range, () => {
+            refresh(index);
+          });
           div.appendChild(details);
-          return div;
-        },
-        W: () => {
-          let renderHeader = () => {};
-          let weeks = [];
-          let totals = [];
-          let start = new Date();
-          var prevMonday = new Date();
-          let max = -Infinity;
-          prevMonday.setDate(
-            prevMonday.getDate() - ((prevMonday.getDay() + 6) % 7)
-          );
-          for (let i = 0; i < 12; i++) {
-            let range = computeRangeSums(
-              this.json.expeditionSums,
-              start,
-              prevMonday
-            );
-            weeks.push(range);
-            let total = getTotal(range);
-            totals.push({
-              profit: total,
-              range: range,
-              date: prevMonday,
-              start: start,
-            });
-            if (total > max) max = total;
-            start = new Date(prevMonday);
-            start.setDate(start.getDate() - 1);
-            prevMonday = new Date(start);
-            prevMonday.setDate(
-              prevMonday.getDate() - ((prevMonday.getDay() + 6) % 7)
-            );
-          }
-          let div = this.createDOM("div");
-          let details = renderDetails(weeks[0]);
-          div.appendChild(
-            this.profitGraph(totals, max, (range, index) => {
-              details.remove();
-              details = renderDetails(range);
-              div.appendChild(details);
-            })
-          );
+        })
+      );
+      div.appendChild(details);
+      return div;
+    };
+    tabNames[LocalizationStrings.timeunits.short.week] = () => {
+      let renderHeader = () => { };
+      let weeks = [];
+      let totals = [];
+      let start = new Date();
+      var prevMonday = new Date();
+      let max = -Infinity;
+      prevMonday.setDate(
+        prevMonday.getDate() - ((prevMonday.getDay() + 6) % 7)
+      );
+      for (let i = 0; i < 12; i++) {
+        let range = computeRangeSums(
+          this.json.expeditionSums,
+          start,
+          prevMonday
+        );
+        weeks.push(range);
+        let total = getTotal(range);
+        totals.push({
+          profit: total,
+          range: range,
+          date: prevMonday,
+          start: start,
+        });
+        if (total > max) max = total;
+        start = new Date(prevMonday);
+        start.setDate(start.getDate() - 1);
+        prevMonday = new Date(start);
+        prevMonday.setDate(
+          prevMonday.getDate() - ((prevMonday.getDay() + 6) % 7)
+        );
+      }
+      let div = this.createDOM("div");
+      let details = renderDetails(weeks[0]);
+      div.appendChild(
+        this.profitGraph(totals, max, (range, index) => {
+          details.remove();
+          details = renderDetails(range);
           div.appendChild(details);
-          return div;
-        },
-        M: () => {
-          var lastDay = new Date();
-          var firstDay = new Date(lastDay.getFullYear(), lastDay.getMonth(), 1);
-          let max = -Infinity;
-          let months = [];
-          let totals = [];
-          for (let i = 0; i < 12; i++) {
-            let range = computeRangeSums(
-              this.json.expeditionSums,
-              lastDay,
-              firstDay
-            );
-            months.push(range);
-            let total = getTotal(range);
-            totals.push({
-              profit: total,
-              range: range,
-              date: firstDay,
-              start: lastDay,
-            });
-            if (total > max) max = total;
-            lastDay = new Date(lastDay.getFullYear(), lastDay.getMonth(), 0);
-            firstDay = new Date(lastDay.getFullYear(), lastDay.getMonth(), 1);
-          }
-          let div = this.createDOM("div");
-          let details = renderDetails(months[0]);
-          div.appendChild(
-            this.profitGraph(totals, max, (range, index) => {
-              details.remove();
-              details = renderDetails(range);
-              div.appendChild(details);
-            })
-          );
+        })
+      );
+      div.appendChild(details);
+      return div;
+    };
+    tabNames[LocalizationStrings.timeunits.short.month] = () => {
+      var lastDay = new Date();
+      var firstDay = new Date(lastDay.getFullYear(), lastDay.getMonth(), 1);
+      let max = -Infinity;
+      let months = [];
+      let totals = [];
+      for (let i = 0; i < 12; i++) {
+        let range = computeRangeSums(
+          this.json.expeditionSums,
+          lastDay,
+          firstDay
+        );
+        months.push(range);
+        let total = getTotal(range);
+        totals.push({
+          profit: total,
+          range: range,
+          date: firstDay,
+          start: lastDay,
+        });
+        if (total > max) max = total;
+        lastDay = new Date(lastDay.getFullYear(), lastDay.getMonth(), 0);
+        firstDay = new Date(lastDay.getFullYear(), lastDay.getMonth(), 1);
+      }
+      let div = this.createDOM("div");
+      let details = renderDetails(months[0]);
+      div.appendChild(
+        this.profitGraph(totals, max, (range, index) => {
+          details.remove();
+          details = renderDetails(range);
           div.appendChild(details);
-          return div;
-        },
-        All: () => {
-          let keys = Object.keys(this.json.expeditionSums).sort(
-            (a, b) => this.dateStrToDate(a) - this.dateStrToDate(b)
-          );
-          let minDate = keys[0];
-          let maxDate = keys[keys.length - 1];
-          let range = computeRangeSums(
-            this.json.expeditionSums,
-            this.dateStrToDate(maxDate),
-            this.dateStrToDate(minDate)
-          );
-          let total = getTotal(range);
-          let content = this.createDOM("div", { class: "ogk-profit" });
-          let title = content.appendChild(
-            this.createDOM("div", { class: "ogk-date" })
-          );
-          content.appendChild(
-            this.createDOM("div", { class: "ogk-scroll-wrapper" })
-          );
-          let contentHtml = `<strong>${getFormatedDate(
-            this.dateStrToDate(minDate).getTime(),
-            "[d].[m].[y]"
-          )}</strong> <span class="${total > 0 ? "undermark" : "overmark"}">${
-            total > 0 ? " +" : " -"
-          }${getNumberFormatShort(Math.abs(total), 2)}</strong></span>`;
-          contentHtml += `<strong>${getFormatedDate(
-            this.dateStrToDate(maxDate).getTime(),
-            "[d].[m].[y]"
-          )}</strong>`;
-          title.html(contentHtml);
-          let div = this.createDOM("div");
-          div.appendChild(content);
-          div.appendChild(renderDetails(range));
-          return div;
-        },
-      })
-    );
+        })
+      );
+      div.appendChild(details);
+      return div;
+    };
+    tabNames["∞"] = () => {
+      let keys = Object.keys(this.json.expeditionSums).sort(
+        (a, b) => this.dateStrToDate(a) - this.dateStrToDate(b)
+      );
+      let minDate = keys[0];
+      let maxDate = keys[keys.length - 1];
+      let range = computeRangeSums(
+        this.json.expeditionSums,
+        this.dateStrToDate(maxDate),
+        this.dateStrToDate(minDate)
+      );
+      let total = getTotal(range);
+      let content = this.createDOM("div", { class: "ogk-profit" });
+      let title = content.appendChild(
+        this.createDOM("div", { class: "ogk-date" })
+      );
+      content.appendChild(
+        this.createDOM("div", { class: "ogk-scroll-wrapper" })
+      );
+      let contentHtml = `<strong>${getFormatedDate(
+        this.dateStrToDate(minDate).getTime(),
+        "[d].[m].[y]"
+      )}</strong> <span class="tooltip ${
+        total > 0 ? "undermark" : "overmark"
+      }" data-title=${toFormatedNumber(Math.abs(total), 0)}>${
+        total > 0 ? " + " : " - "
+      }${toFormatedNumber(Math.abs(total), 2, true)}</strong></span>`;
+      contentHtml += `<strong>${getFormatedDate(
+        this.dateStrToDate(maxDate).getTime(),
+        "[d].[m].[y]"
+      )}</strong>`;
+      title.html(contentHtml);
+      let div = this.createDOM("div");
+      div.appendChild(content);
+      div.appendChild(renderDetails(range));
+      return div;
+    };
+    content.appendChild(this.tabs(tabNames));
     return content;
   }
 
@@ -4843,20 +6839,22 @@ class OGInfinity {
         this.createDOM("span", { class: "ogk-center" }, sums.count)
       );
       globalDiv.appendChild(
-        this.createDOM("h1", { class: "ogk-top-title" }, "Best combats")
+        this.createDOM("h1", { class: "ogk-top-title" }, this.getTranslatedText(72))
       );
       let topDiv = globalDiv.appendChild(
         this.createDOM("div", { class: "ogk-top" })
       );
       topDiv.appendChild(
-        this.createDOM("p", { style: "margin-bottom: 5px" }, "Name")
-      );
-      topDiv.appendChild(this.createDOM("div", { class: "ogk-head" }, "Loot"));
-      topDiv.appendChild(
-        this.createDOM("div", { class: "ogk-head" }, "Damages")
+        this.createDOM("p", { style: "margin-bottom: 5px" }, this.getTranslatedText(73))
       );
       topDiv.appendChild(
-        this.createDOM("div", { class: "ogk-head" }, "Debris")
+        this.createDOM("div", { class: "ogk-head" }, this.getTranslatedText(74))
+      );
+      topDiv.appendChild(
+        this.createDOM("div", { class: "ogk-head" }, this.getTranslatedText(75))
+      );
+      topDiv.appendChild(
+        this.createDOM("div", { class: "ogk-head" }, this.getTranslatedText(76))
       );
       sums.topCombats.forEach(async (top) => {
         if (!top.loot) top.loot = 0;
@@ -4865,22 +6863,31 @@ class OGInfinity {
         topDiv.appendChild(
           this.createDOM(
             "div",
-            { class: top.loot > 0 ? "undermark" : "overmark" },
-            this.formatToUnits(top.loot)
+            {
+              class: top.loot > 0 ? "undermark tooltip" : "overmark tooltip",
+              "data-title": toFormatedNumber(top.loot, 0),
+            },
+            toFormatedNumber(top.loot, null, true)
           )
         );
         topDiv.appendChild(
           this.createDOM(
             "div",
-            { class: "overmark" },
-            "-" + this.formatToUnits(top.losses)
+            {
+              class: "overmark tooltip",
+              "data-title": toFormatedNumber(top.losses, 0),
+            },
+            "-" + toFormatedNumber(top.losses, null, true)
           )
         );
         topDiv.appendChild(
           this.createDOM(
             "div",
-            { class: "debris" },
-            this.formatToUnits(top.debris)
+            {
+              class: "debris tooltip",
+              "data-title": toFormatedNumber(top.debris, 0),
+            },
+            toFormatedNumber(top.debris, null, true)
           )
         );
       });
@@ -4891,31 +6898,31 @@ class OGInfinity {
       let box = this.resourceBox(
         [
           {
-            title: "Loot",
+            title: this.getTranslatedText(74),
             metal: sums.loot[0],
             crystal: sums.loot[1],
             deuterium: sums.loot[2],
           },
           {
-            title: "Recycled",
+            title: this.getTranslatedText(68),
             metal: sums.harvest[0],
             crystal: sums.harvest[1],
             deuterium: 0,
           },
           {
-            title: "Losses",
+            title: this.getTranslatedText(69),
             metal: -losses[0],
             crystal: -losses[1],
             deuterium: -losses[2],
           },
           {
-            title: "Fuel",
+            title: this.getTranslatedText(70),
             metal: 0,
             crystal: 0,
             deuterium: sums.fuel,
           },
           {
-            title: "Adjust",
+            title: this.getTranslatedText(77),
             metal: sums.adjust[0],
             crystal: sums.adjust[1],
             deuterium: sums.adjust[2],
@@ -5041,184 +7048,184 @@ class OGInfinity {
       }
       document.querySelector(".ogk-stats-content .ogl-tab.ogl-active").click();
     };
-    content.appendChild(
-      this.tabs({
-        D: () => {
-          let date = new Date();
-          let sum = {
-            loot: [0, 0, 0],
-            harvest: [0, 0],
-            losses: {
-              202: 0,
-              203: 0,
-              210: 0,
-              204: 0,
-              205: 0,
-              206: 0,
-              219: 0,
-              207: 0,
-              215: 0,
-              211: 0,
-              213: 0,
-              218: 0,
-            },
-            adjust: [0, 0, 0],
-            fuel: 0,
-            topCombats: [],
-            count: 0,
-            wins: 0,
-            draws: 0,
-          };
-          let profits = [];
-          let max = 0;
-          for (let i = 0; i < 12; i++) {
-            let dateStr = getFormatedDate(date.getTime(), "[d].[m].[y]");
-            let sums = this.json.combatsSums[dateStr] || sum;
-            let profit = sums ? getTotal(sums) : 0;
-            if (Math.abs(profit) > max) max = profit;
-            profits.push({
-              date: new Date(date.getTime()),
-              range: sums,
-              profit: profit,
-            });
-            date.setDate(date.getDate() - 1);
-          }
-          let div = this.createDOM("div");
-          let details = renderDetails(
-            computeRangeSums(this.json.combatsSums, new Date(), new Date()),
-            () => {
-              refresh();
-            }
-          );
-          div.appendChild(
-            this.profitGraph(profits, max, (range, index) => {
-              details.remove();
-              details = renderDetails(range, () => {
-                refresh(index);
-              });
-              div.appendChild(details);
-            })
-          );
+    let tabNames = {};
+    tabNames[LocalizationStrings.timeunits.short.day] = () => {
+      let date = new Date();
+      let sum = {
+        loot: [0, 0, 0],
+        harvest: [0, 0],
+        losses: {
+          202: 0,
+          203: 0,
+          210: 0,
+          204: 0,
+          205: 0,
+          206: 0,
+          219: 0,
+          207: 0,
+          215: 0,
+          211: 0,
+          213: 0,
+          218: 0,
+        },
+        adjust: [0, 0, 0],
+        fuel: 0,
+        topCombats: [],
+        count: 0,
+        wins: 0,
+        draws: 0,
+      };
+      let profits = [];
+      let max = 0;
+      for (let i = 0; i < 12; i++) {
+        let dateStr = getFormatedDate(date.getTime(), "[d].[m].[y]");
+        let sums = this.json.combatsSums[dateStr] || sum;
+        let profit = sums ? getTotal(sums) : 0;
+        if (Math.abs(profit) > max) max = profit;
+        profits.push({
+          date: new Date(date.getTime()),
+          range: sums,
+          profit: profit,
+        });
+        date.setDate(date.getDate() - 1);
+      }
+      let div = this.createDOM("div");
+      let details = renderDetails(
+        computeRangeSums(this.json.combatsSums, new Date(), new Date()),
+        () => {
+          refresh();
+        }
+      );
+      div.appendChild(
+        this.profitGraph(profits, max, (range, index) => {
+          details.remove();
+          details = renderDetails(range, () => {
+            refresh(index);
+          });
           div.appendChild(details);
-          return div;
-        },
-        W: () => {
-          let renderHeader = () => {};
-          let weeks = [];
-          let totals = [];
-          let start = new Date();
-          var prevMonday = new Date();
-          let max = -Infinity;
-          prevMonday.setDate(
-            prevMonday.getDate() - ((prevMonday.getDay() + 6) % 7)
-          );
-          for (let i = 0; i < 12; i++) {
-            let range = computeRangeSums(
-              this.json.combatsSums,
-              start,
-              prevMonday
-            );
-            weeks.push(range);
-            let total = getTotal(range);
-            totals.push({
-              profit: total,
-              range: range,
-              date: prevMonday,
-              start: start,
-            });
-            if (total > max) max = total;
-            start = new Date(prevMonday);
-            start.setDate(start.getDate() - 1);
-            prevMonday = new Date(start);
-            prevMonday.setDate(
-              prevMonday.getDate() - ((prevMonday.getDay() + 6) % 7)
-            );
-          }
-          let div = this.createDOM("div");
-          let details = renderDetails(weeks[0]);
-          div.appendChild(
-            this.profitGraph(totals, max, (range, index) => {
-              details.remove();
-              details = renderDetails(range);
-              div.appendChild(details);
-            })
-          );
+        })
+      );
+      div.appendChild(details);
+      return div;
+    };
+    tabNames[LocalizationStrings.timeunits.short.week] = () => {
+      let renderHeader = () => { };
+      let weeks = [];
+      let totals = [];
+      let start = new Date();
+      var prevMonday = new Date();
+      let max = -Infinity;
+      prevMonday.setDate(
+        prevMonday.getDate() - ((prevMonday.getDay() + 6) % 7)
+      );
+      for (let i = 0; i < 12; i++) {
+        let range = computeRangeSums(
+          this.json.combatsSums,
+          start,
+          prevMonday
+        );
+        weeks.push(range);
+        let total = getTotal(range);
+        totals.push({
+          profit: total,
+          range: range,
+          date: prevMonday,
+          start: start,
+        });
+        if (total > max) max = total;
+        start = new Date(prevMonday);
+        start.setDate(start.getDate() - 1);
+        prevMonday = new Date(start);
+        prevMonday.setDate(
+          prevMonday.getDate() - ((prevMonday.getDay() + 6) % 7)
+        );
+      }
+      let div = this.createDOM("div");
+      let details = renderDetails(weeks[0]);
+      div.appendChild(
+        this.profitGraph(totals, max, (range, index) => {
+          details.remove();
+          details = renderDetails(range);
           div.appendChild(details);
-          return div;
-        },
-        M: () => {
-          var lastDay = new Date();
-          var firstDay = new Date(lastDay.getFullYear(), lastDay.getMonth(), 1);
-          let max = -Infinity;
-          let months = [];
-          let totals = [];
-          for (let i = 0; i < 12; i++) {
-            let range = computeRangeSums(
-              this.json.combatsSums,
-              lastDay,
-              firstDay
-            );
-            months.push(range);
-            let total = getTotal(range);
-            totals.push({
-              profit: total,
-              range: range,
-              date: firstDay,
-              start: lastDay,
-            });
-            if (total > max) max = total;
-            lastDay = new Date(lastDay.getFullYear(), lastDay.getMonth(), 0);
-            firstDay = new Date(lastDay.getFullYear(), lastDay.getMonth(), 1);
-          }
-          let div = this.createDOM("div");
-          let details = renderDetails(months[0]);
-          div.appendChild(
-            this.profitGraph(totals, max, (range, index) => {
-              details.remove();
-              details = renderDetails(range);
-              div.appendChild(details);
-            })
-          );
+        })
+      );
+      div.appendChild(details);
+      return div;
+    };
+    tabNames[LocalizationStrings.timeunits.short.month] = () => {
+      var lastDay = new Date();
+      var firstDay = new Date(lastDay.getFullYear(), lastDay.getMonth(), 1);
+      let max = -Infinity;
+      let months = [];
+      let totals = [];
+      for (let i = 0; i < 12; i++) {
+        let range = computeRangeSums(
+          this.json.combatsSums,
+          lastDay,
+          firstDay
+        );
+        months.push(range);
+        let total = getTotal(range);
+        totals.push({
+          profit: total,
+          range: range,
+          date: firstDay,
+          start: lastDay,
+        });
+        if (total > max) max = total;
+        lastDay = new Date(lastDay.getFullYear(), lastDay.getMonth(), 0);
+        firstDay = new Date(lastDay.getFullYear(), lastDay.getMonth(), 1);
+      }
+      let div = this.createDOM("div");
+      let details = renderDetails(months[0]);
+      div.appendChild(
+        this.profitGraph(totals, max, (range, index) => {
+          details.remove();
+          details = renderDetails(range);
           div.appendChild(details);
-          return div;
-        },
-        All: () => {
-          let keys = Object.keys(this.json.combatsSums).sort(
-            (a, b) => this.dateStrToDate(a) - this.dateStrToDate(b)
-          );
-          let minDate = keys[0];
-          let maxDate = keys[keys.length - 1];
-          let range = computeRangeSums(
-            this.json.combatsSums,
-            this.dateStrToDate(maxDate),
-            this.dateStrToDate(minDate)
-          );
-          let total = getTotal(range);
-          let content = this.createDOM("div", { class: "ogk-profit" });
-          let title = content.appendChild(
-            this.createDOM("div", { class: "ogk-date" })
-          );
-          content.appendChild(
-            this.createDOM("div", { class: "ogk-scroll-wrapper" })
-          );
-          let contentHtml = `<strong>${getFormatedDate(
-            this.dateStrToDate(minDate).getTime(),
-            "[d].[m].[y]"
-          )}</strong> <span class="${total > 0 ? "undermark" : "overmark"}">${
-            total > 0 ? " +" : " -"
-          }${getNumberFormatShort(Math.abs(total), 2)}</strong></span>`;
-          contentHtml += `<strong>${getFormatedDate(
-            this.dateStrToDate(maxDate).getTime(),
-            "[d].[m].[y]"
-          )}</strong>`;
-          title.html(contentHtml);
-          let div = this.createDOM("div");
-          div.appendChild(content);
-          div.appendChild(renderDetails(range));
-          return div;
-        },
-      })
-    );
+        })
+      );
+      div.appendChild(details);
+      return div;
+    };
+    tabNames["∞"] = () => {
+      let keys = Object.keys(this.json.combatsSums).sort(
+        (a, b) => this.dateStrToDate(a) - this.dateStrToDate(b)
+      );
+      let minDate = keys[0];
+      let maxDate = keys[keys.length - 1];
+      let range = computeRangeSums(
+        this.json.combatsSums,
+        this.dateStrToDate(maxDate),
+        this.dateStrToDate(minDate)
+      );
+      let total = getTotal(range);
+      let content = this.createDOM("div", { class: "ogk-profit" });
+      let title = content.appendChild(
+        this.createDOM("div", { class: "ogk-date" })
+      );
+      content.appendChild(
+        this.createDOM("div", { class: "ogk-scroll-wrapper" })
+      );
+      let contentHtml = `<strong>${getFormatedDate(
+        this.dateStrToDate(minDate).getTime(),
+        "[d].[m].[y]"
+        )}</strong> <span class="${
+          total > 0 ? "tooltip undermark" : "tooltip overmark"
+        }" data-title=${toFormatedNumber(Math.abs(total), 0)}>${
+          total > 0 ? " + " : " - "
+        }${toFormatedNumber(Math.abs(total), 2, true)}</strong></span>`;
+      contentHtml += `<strong>${getFormatedDate(
+        this.dateStrToDate(maxDate).getTime(),
+        "[d].[m].[y]"
+      )}</strong>`;
+      title.html(contentHtml);
+      let div = this.createDOM("div");
+      div.appendChild(content);
+      div.appendChild(renderDetails(range));
+      return div;
+    };
+    content.appendChild(this.tabs(tabNames));
     return content;
   }
 
@@ -5254,7 +7261,7 @@ class OGInfinity {
         let fleet = {};
         inputs.forEach((input) => {
           let id = Number(input.getAttribute("data"));
-          fleet[id] = this.removeNumSeparator(input.value);
+          fleet[id] = fromFormatedNumber(input.value, true);
         });
         let cost = this.getFleetCost(fleet);
         onValidate(cost);
@@ -5280,7 +7287,7 @@ class OGInfinity {
           this.createDOM(
             "span",
             { class: ships[id] && minus ? "overmark" : "" },
-            ships[id] ? dotted(ships[id]) : "-"
+            ships[id] ? toFormatedNumber(ships[id]) : "-"
           )
         );
       }
@@ -5304,7 +7311,7 @@ class OGInfinity {
       this.createDOM("input", {
         class: "ogl-formatInput metal",
         type: "text",
-        value: adjustments[0],
+        value: toFormatedNumber(adjustments[0]),
       })
     );
     prod.appendChild(
@@ -5318,7 +7325,7 @@ class OGInfinity {
       this.createDOM("input", {
         class: "ogl-formatInput crystal",
         type: "text",
-        value: adjustments[1],
+        value: toFormatedNumber(adjustments[1]),
       })
     );
     prod.appendChild(
@@ -5332,7 +7339,7 @@ class OGInfinity {
       this.createDOM("input", {
         class: "ogl-formatInput deuterium",
         type: "text",
-        value: adjustments[2],
+        value: toFormatedNumber(adjustments[2]),
       })
     );
     if (onValidate) {
@@ -5341,9 +7348,9 @@ class OGInfinity {
       );
       btn.addEventListener("click", () => {
         onValidate([
-          Number(this.removeNumSeparator(metInput.value)),
-          Number(this.removeNumSeparator(criInput.value)),
-          Number(this.removeNumSeparator(deutInput.value)),
+          fromFormatedNumber(metInput.value, true),
+          fromFormatedNumber(criInput.value, true),
+          fromFormatedNumber(deutInput.value, true),
         ]);
       });
     }
@@ -5405,29 +7412,48 @@ class OGInfinity {
       prod.appendChild(
         this.createDOM(
           "span",
-          { class: "ogl-metal" + (row.metal < 0 ? " overmark" : "") },
-          `${row.metal == 0 ? "-" : this.formatToUnits(row.metal)}`
+          {
+            class: "ogl-metal tooltip" + (row.metal < 0 ? " overmark" : ""),
+            "data-title": toFormatedNumber(row.metal, 0),
+          },
+          `${row.metal == 0 ? "-" : toFormatedNumber(row.metal, null, true)}`
         )
       );
       prod.appendChild(
         this.createDOM(
           "span",
-          { class: "ogl-crystal" + (row.crystal < 0 ? " overmark" : "") },
-          `${row.crystal == 0 ? "-" : this.formatToUnits(row.crystal)}`
+          {
+            class: "ogl-crystal tooltip" + (row.crystal < 0 ? " overmark" : ""),
+            "data-title": toFormatedNumber(row.crystal, 0),
+          },
+          `${
+            row.crystal == 0 ? "-" : toFormatedNumber(row.crystal, null, true)
+          }`
         )
       );
       prod.appendChild(
         this.createDOM(
           "span",
-          { class: "ogl-deut" + (row.deuterium < 0 ? " overmark" : "") },
-          `${row.deuterium == 0 ? "-" : this.formatToUnits(row.deuterium)}`
+          {
+            class: "ogl-deut tooltip" + (row.deuterium < 0 ? " overmark" : ""),
+            "data-title": toFormatedNumber(row.deuterium, 0),
+          },
+          `${
+            row.deuterium == 0
+              ? "-"
+              : toFormatedNumber(row.deuterium, null, true)
+          }`
         )
       );
       if (am) {
         if (row.am) {
           totAm = row.am;
           prod.appendChild(
-            this.createDOM("span", {}, `${this.formatToUnits(row.am)}`)
+            this.createDOM(
+              "span",
+              { class: "tootltip", "data-title": toFormatedNumber(row.am, 0) },
+              `${toFormatedNumber(row.am, null, true)}`
+            )
           );
         } else {
           prod.appendChild(this.createDOM("span", {}, "-"));
@@ -5437,34 +7463,51 @@ class OGInfinity {
       sums[1] += row.crystal;
       sums[2] += row.deuterium;
     });
-    prod.appendChild(this.createDOM("p", { class: "ogk-total" }, "Total"));
+    prod.appendChild(
+      this.createDOM("p", { class: "ogk-total" }, this.getTranslatedText(40))
+    );
     prod.appendChild(
       this.createDOM(
         "span",
-        { class: "ogl-metal ogk-total" + (sums[0] < 0 ? " overmark" : "") },
-        `${this.formatToUnits(sums[0])}`
+        {
+          class:
+            "ogl-metal ogk-total tooltip" + (sums[0] < 0 ? " overmark" : ""),
+          "data-title": toFormatedNumber(sums[0], 0),
+        },
+        `${toFormatedNumber(sums[0], null, true)}`
       )
     );
     prod.appendChild(
       this.createDOM(
         "span",
-        { class: "ogl-crystal ogk-total" + (sums[1] < 0 ? " overmark" : "") },
-        `${this.formatToUnits(sums[1])}`
+        {
+          class:
+            "ogl-crystal ogk-total tooltip" + (sums[1] < 0 ? " overmark" : ""),
+          "data-title": toFormatedNumber(sums[1], 0),
+        },
+        `${toFormatedNumber(sums[1], null, true)}`
       )
     );
     prod.appendChild(
       this.createDOM(
         "span",
-        { class: "ogl-deut ogk-total" + (sums[2] < 0 ? " overmark" : "") },
-        `${this.formatToUnits(sums[2])}`
+        {
+          class:
+            "ogl-deut ogk-total tooltip" + (sums[2] < 0 ? " overmark" : ""),
+          "data-title": toFormatedNumber(sums[2], 0),
+        },
+        `${toFormatedNumber(sums[2], null, true)}`
       )
     );
     if (am) {
       prod.appendChild(
         this.createDOM(
           "span",
-          { class: "ogk-total" },
-          `${this.formatToUnits(totAm)}`
+          {
+            class: "ogk-total tooltip",
+            "data-title": toFormatedNumber(totAm, 0),
+          },
+          `${toFormatedNumber(totAm, null, true)}`
         )
       );
     }
@@ -5520,19 +7563,19 @@ class OGInfinity {
           },
         ],
         labels: [
-          "Metal",
-          "Crystal",
-          "Deut",
-          "D. Matter",
-          "Objects",
-          "Fleet",
-          "Aliens",
-          "Pirates",
-          "Late",
-          "Early",
-          "B. Hole",
-          "Empty",
-          "Merchant",
+          this.getTranslatedText(0, "res"),
+          this.getTranslatedText(1, "res"),
+          this.getTranslatedText(2, "res"),
+          this.getTranslatedText(3, "res"),
+          this.getTranslatedText(78),
+          this.getTranslatedText(63),
+          this.getTranslatedText(79),
+          this.getTranslatedText(80),
+          this.getTranslatedText(81),
+          this.getTranslatedText(82),
+          this.getTranslatedText(71),
+          this.getTranslatedText(83),
+          this.getTranslatedText(84),
         ],
       },
       options: {
@@ -5542,7 +7585,7 @@ class OGInfinity {
         plugins: {
           labels: [
             {
-              fontSize: 15,
+              fontSize: 12,
               fontStyle: "bold",
               textMargin: 10,
               render: "label",
@@ -5550,7 +7593,7 @@ class OGInfinity {
               position: "outside",
             },
             {
-              fontSize: 15,
+              fontSize: 12,
               fontStyle: "bold",
               fontColor: "#0d1117",
               render: "percentage",
@@ -5681,20 +7724,19 @@ class OGInfinity {
       let detailRank = planetsColumn.appendChild(
         this.createDOM("div", { class: "ogl-detailRank" })
       );
-      let dotted = (value) => parseInt(value).toLocaleString(separatorLang);
       detailRank.html(
-        `\n          <div><div class="ogl-totalIcon"></div> ${this.formatToUnits(
-          player.points.score
-        )} <small>pts</small></div>\n          <div><div class="ogl-ecoIcon"></div> ${this.formatToUnits(
-          player.economy.score
-        )} <small>pts</small></div>\n          <div><div class="ogl-techIcon"></div> ${this.formatToUnits(
-          player.research.score
-        )} <small>pts</small></div>\n          <div><div class="ogl-fleetIcon"></div> ${this.formatToUnits(
-          player.military.score
-        )} <small>pts</small></div>\n          <div><div class="ogl-fleetIcon grey"></div> ${this.formatToUnits(
-          player.def
-        )} <small>pts</small></div>\n          <div><div class="ogl-fleetIcon orange"></div> ${this.formatToUnits(
-          player.military.ships
+        `\n          <div><div class="ogl-totalIcon"></div> ${toFormatedNumber(
+          Number(player.points.score),null,true
+        )} <small>pts</small></div>\n          <div><div class="ogl-ecoIcon"></div> ${toFormatedNumber(
+          Number(player.economy.score),null,true
+        )} <small>pts</small></div>\n          <div><div class="ogl-techIcon"></div> ${toFormatedNumber(
+          Number(player.research.score),null,true
+        )} <small>pts</small></div>\n          <div><div class="ogl-fleetIcon"></div> ${toFormatedNumber(
+          Number(player.military.score),null,true
+        )} <small>pts</small></div>\n          <div><div class="ogl-fleetIcon grey"></div> ${toFormatedNumber(
+          Number(player.def),null,true
+        )} <small>pts</small></div>\n          <div><div class="ogl-fleetIcon orange"></div> ${toFormatedNumber(
+          Number(player.military.ships),null,true
         )} <small>ships</small></div>\n          `
       );
       let stalkPlanets = this.createDOM("div", {
@@ -5750,7 +7792,7 @@ class OGInfinity {
               href: this.generateHiscoreLink(player.id),
               class: "ogl-ranking",
             },
-            `#${player.points.position || "b"}`
+            `#${toFormatedNumber(Number(player.points.position)) || "b"}`
           )
         );
         let alliance = "";
@@ -5876,125 +7918,256 @@ class OGInfinity {
       this.createDOM(
         "td",
         {},
-        '<div class="ogl-option resourceIcon metal"></div>'
+        '<div class="resourceIcon metal"></div>'
       )
     );
     crystalRow.appendChild(
       this.createDOM(
         "td",
         {},
-        '<div class="ogl-option resourceIcon crystal"></div>'
+        '<div class="resourceIcon crystal"></div>'
       )
     );
     deutRow.appendChild(
       this.createDOM(
         "td",
         {},
-        '<div class="ogl-option resourceIcon deuterium"></div>'
+        '<div class="resourceIcon deuterium"></div>'
       )
     );
     nrjRow.appendChild(
       this.createDOM(
         "td",
         {},
-        '<div class="ogl-option resourceIcon energy"></div>'
+        '<div class="resourceIcon energy"></div>'
       )
     );
+    let minTimeMetal = 1e20;
+    let minTimeCrystal = 1e20;
+    let minTimeDeuterium = 1e20;
+    let minLocMetal = "";
+    let minLocCrystal = "";
+    let minLocDeuterium = "";
     this.json.empire.forEach((planet) => {
       let current = false;
       if (planet.coordinates.slice(1, -1) == this.current.coords) {
         current = true;
+      }
+      let mfilltime =
+        ((5000 * Math.floor(2.5 * Math.exp((20 / 33) * planet[22]))) /
+          planet.production.hourly[0]) *
+        3600;
+      let cfilltime =
+        ((5000 * Math.floor(2.5 * Math.exp((20 / 33) * planet[23]))) /
+          planet.production.hourly[1]) *
+        3600;
+      let dfilltime =
+        ((5000 * Math.floor(2.5 * Math.exp((20 / 33) * planet[24]))) /
+          planet.production.hourly[2]) *
+        3600;
+      if (mfilltime < minTimeMetal) {
+        minTimeMetal = mfilltime;
+        minLocMetal = planet.coordinates;
+      }
+      if (cfilltime < minTimeCrystal) {
+        minTimeCrystal = cfilltime;
+        minLocCrystal = planet.coordinates;
+      }
+      if (dfilltime < minTimeDeuterium) {
+        minTimeDeuterium = dfilltime;
+        minLocDeuterium = planet.coordinates;
       }
       let link = `?page=ingame&component=supplies&cp=${planet.id}`;
       header.appendChild(
         this.createDOM(
           "th",
           {},
-          `<p>${planet.name}</p> <a href="${link}" class="ogl-fleet-coords">${planet.coordinates}</a> <span class="ogl-planet-fields">${planet.fieldUsed} / ${planet.fieldMax}</span>`
+          `<div>${
+            planet.name
+          }</div> <a href="${link}" class="ogl-fleet-coords">${
+            planet.coordinates
+          }</a> <span class="ogl-planet-fields">${toFormatedNumber(
+            planet.fieldUsed
+          )} / ${toFormatedNumber(
+            planet.fieldMax
+          )}</span><div>${toFormatedNumber(planet.db_par2 + 40)}°C</div>`
         )
       );
       let td = metalRow.appendChild(this.createDOM("td"));
-      td.appendChild(this.createDOM("div", { class: "ogl-metal" }, planet[1]));
       td.appendChild(
         this.createDOM(
           "div",
-          { class: "ogl-metal" },
-          this.formatToUnits(planet.production.hourly[0])
+          {
+            class: "ogl-metal tooltip",
+            "data-title": `${this.getTranslatedText(132)}: ${formatTimeWrapper(
+              mfilltime,
+              2,
+              true,
+              " ",
+              false,
+              ""
+            )}`,
+          },
+          toFormatedNumber(planet[1])
         )
       );
       td.appendChild(
         this.createDOM(
           "div",
-          { class: "ogl-metal" },
-          this.formatToUnits(planet.production.daily[0])
+          {
+            class: "ogl-metal tooltip",
+            "data-title": toFormatedNumber(
+              Math.floor(planet.production.hourly[0])
+            ),
+          },
+          toFormatedNumber(Math.floor(planet.production.hourly[0]), null, true)
         )
       );
       td.appendChild(
         this.createDOM(
           "div",
-          { class: "ogl-metal" },
-          this.formatToUnits(planet.production.weekly[0])
+          {
+            class: "ogl-metal tooltip",
+            "data-title": toFormatedNumber(
+              Math.floor(planet.production.daily[0])
+            ),
+          },
+          toFormatedNumber(Math.floor(planet.production.daily[0]), null, true)
+        )
+      );
+      td.appendChild(
+        this.createDOM(
+          "div",
+          {
+            class: "ogl-metal tooltip",
+            "data-title": toFormatedNumber(
+              Math.floor(planet.production.weekly[0])
+            ),
+          },
+          toFormatedNumber(Math.floor(planet.production.weekly[0]), null, true)
         )
       );
       if (current) td.classList.add("ogl-current");
       td = crystalRow.appendChild(this.createDOM("td"));
       td.appendChild(
-        this.createDOM("div", { class: "ogl-crystal" }, planet[2])
-      );
-      td.appendChild(
         this.createDOM(
           "div",
-          { class: "ogl-crystal" },
-          this.formatToUnits(planet.production.hourly[1])
+          {
+            class: "ogl-crystal tooltip",
+            "data-title": `${this.getTranslatedText(132)}: ${formatTimeWrapper(
+              cfilltime,
+              2,
+              true,
+              " ",
+              false,
+              ""
+            )}`,
+          },
+          toFormatedNumber(planet[2])
         )
       );
       td.appendChild(
         this.createDOM(
           "div",
-          { class: "ogl-crystal" },
-          this.formatToUnits(planet.production.daily[1])
+          {
+            class: "ogl-crystal tooltip",
+            "data-title": toFormatedNumber(
+              Math.floor(planet.production.hourly[1])
+            ),
+          },
+          toFormatedNumber(Math.floor(planet.production.hourly[1]), null, true)
         )
       );
       td.appendChild(
         this.createDOM(
           "div",
-          { class: "ogl-crystal" },
-          this.formatToUnits(planet.production.weekly[1])
+          {
+            class: "ogl-crystal tooltip",
+            "data-title": toFormatedNumber(
+              Math.floor(planet.production.daily[1])
+            ),
+          },
+          toFormatedNumber(Math.floor(planet.production.daily[1]), null, true)
+        )
+      );
+      td.appendChild(
+        this.createDOM(
+          "div",
+          {
+            class: "ogl-crystal tooltip",
+            "data-title": toFormatedNumber(
+              Math.floor(planet.production.weekly[1])
+            ),
+          },
+          toFormatedNumber(Math.floor(planet.production.weekly[1]), null, true)
         )
       );
       if (current) td.classList.add("ogl-current");
       td = deutRow.appendChild(this.createDOM("td"));
-      td.appendChild(this.createDOM("div", { class: "ogl-deut" }, planet[3]));
       td.appendChild(
         this.createDOM(
           "div",
-          { class: "ogl-deut" },
-          this.formatToUnits(planet.production.hourly[2])
+          {
+            class: "ogl-deut tooltip",
+            "data-title": `${this.getTranslatedText(132)}: ${formatTimeWrapper(
+              dfilltime,
+              2,
+              true,
+              " ",
+              false,
+              ""
+            )}`,
+          },
+          toFormatedNumber(planet[3])
         )
       );
       td.appendChild(
         this.createDOM(
           "div",
-          { class: "ogl-deut" },
-          this.formatToUnits(planet.production.daily[2])
+          {
+            class: "ogl-deut tooltip",
+            "data-title": toFormatedNumber(
+              Math.floor(planet.production.hourly[2])
+            ),
+          },
+          toFormatedNumber(Math.floor(planet.production.hourly[2]), null, true)
         )
       );
       td.appendChild(
         this.createDOM(
           "div",
-          { class: "ogl-deut" },
-          this.formatToUnits(planet.production.weekly[2])
+          {
+            class: "ogl-deut tooltip",
+            "data-title": toFormatedNumber(
+              Math.floor(planet.production.daily[2])
+            ),
+          },
+          toFormatedNumber(Math.floor(planet.production.daily[2]), null, true)
+        )
+      );
+      td.appendChild(
+        this.createDOM(
+          "div",
+          {
+            class: "ogl-deut tooltip",
+            "data-title": toFormatedNumber(
+              Math.floor(planet.production.weekly[2])
+            ),
+          },
+          toFormatedNumber(Math.floor(planet.production.weekly[2]), null, true)
         )
       );
       if (current) td.classList.add("ogl-current");
       td = nrjRow.appendChild(this.createDOM("td"));
-      td.appendChild(this.createDOM("div", { class: "ogl-energy" }, planet[4]));
       let diff = planet.production.hourly[3];
       td.appendChild(
         this.createDOM(
           "div",
-          { class: "ogl-energy " + (diff >= 0 ? "undermark" : "overmark") },
-          this.formatToUnits(diff)
+          {
+            class: "ogl-energy tooltip " + (diff >= 0 ? "undermark" : "overmark"),
+            "data-title": toFormatedNumber(diff, 0),
+          },
+          toFormatedNumber(diff, null, true)
         )
       );
       if (current) td.classList.add("ogl-current");
@@ -6018,95 +8191,552 @@ class OGInfinity {
     td.appendChild(
       this.createDOM(
         "div",
-        { class: "ogl-metal" },
-        (sumlvl(1) / this.json.empire.length).toFixed(1)
+        {
+          class: "ogl-metal tooltip",
+          "data-title": `${this.getTranslatedText(132)}: ${formatTimeWrapper(
+            minTimeMetal,
+            2,
+            true,
+            " ",
+            false,
+            ""
+          )} ${minLocMetal}`,
+        },
+        toFormatedNumber(sumlvl(1) / this.json.empire.length, 1)
       )
     );
     td.appendChild(
       this.createDOM(
         "div",
-        { class: "ogl-metal" },
-        this.formatToUnits(sumhour(0))
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(Math.floor(sumhour(0))),
+        },
+        toFormatedNumber(Math.floor(sumhour(0)), null, true)
       )
     );
     td.appendChild(
       this.createDOM(
         "div",
-        { class: "ogl-metal" },
-        this.formatToUnits(sumday(0))
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(Math.floor(sumday(0))),
+        },
+        toFormatedNumber(Math.floor(sumday(0)), null, true)
       )
     );
     td.appendChild(
       this.createDOM(
         "div",
-        { class: "ogl-metal" },
-        this.formatToUnits(sumweek(0))
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(Math.floor(sumweek(0))),
+        },
+        toFormatedNumber(Math.floor(sumweek(0)), null, true)
       )
     );
     td = crystalRow.appendChild(this.createDOM("td"));
     td.appendChild(
       this.createDOM(
         "div",
-        { class: "ogl-crystal" },
-        (sumlvl(2) / this.json.empire.length).toFixed(1)
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": `${this.getTranslatedText(132)}: ${formatTimeWrapper(
+            minTimeCrystal,
+            2,
+            true,
+            " ",
+            false,
+            ""
+          )} ${minLocCrystal}`,
+        },
+        toFormatedNumber(sumlvl(2) / this.json.empire.length, 1)
       )
     );
     td.appendChild(
       this.createDOM(
         "div",
-        { class: "ogl-crystal" },
-        this.formatToUnits(sumhour(1))
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(Math.floor(sumhour(1))),
+        },
+        toFormatedNumber(Math.floor(sumhour(1)), null, true)
       )
     );
     td.appendChild(
       this.createDOM(
         "div",
-        { class: "ogl-crystal" },
-        this.formatToUnits(sumday(1))
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(Math.floor(sumday(1))),
+        },
+        toFormatedNumber(Math.floor(sumday(1)), null, true)
       )
     );
     td.appendChild(
       this.createDOM(
         "div",
-        { class: "ogl-crystal" },
-        this.formatToUnits(sumweek(1))
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(Math.floor(sumweek(1))),
+        },
+        toFormatedNumber(Math.floor(sumweek(1)), null, true)
       )
     );
     td = deutRow.appendChild(this.createDOM("td"));
     td.appendChild(
       this.createDOM(
         "div",
-        { class: "ogl-deut" },
-        (sumlvl(3) / this.json.empire.length).toFixed(1)
+        {
+          class: "ogl-deut tooltip",
+          "data-title": `${this.getTranslatedText(132)}: ${formatTimeWrapper(
+            minTimeDeuterium,
+            2,
+            true,
+            " ",
+            false,
+            ""
+          )} ${minLocDeuterium}`,
+        },
+        toFormatedNumber(sumlvl(3) / this.json.empire.length, 1)
       )
     );
     td.appendChild(
       this.createDOM(
         "div",
-        { class: "ogl-deut" },
-        this.formatToUnits(sumhour(2))
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(Math.floor(sumhour(2))),
+        },
+        toFormatedNumber(Math.floor(sumhour(2)), null, true)
       )
     );
     td.appendChild(
       this.createDOM(
         "div",
-        { class: "ogl-deut" },
-        this.formatToUnits(sumday(2))
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(Math.floor(sumday(2))),
+        },
+        toFormatedNumber(Math.floor(sumday(2)), null, true)
       )
     );
     td.appendChild(
       this.createDOM(
         "div",
-        { class: "ogl-deut" },
-        this.formatToUnits(sumweek(2))
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(Math.floor(sumweek(2))),
+        },
+        toFormatedNumber(Math.floor(sumweek(2)), null, true)
       )
     );
     td = nrjRow.appendChild(this.createDOM("td"));
     return content;
   }
 
+  roiStats() {
+    let that = this;
+    let content = this.createDOM("div", { class: "ogk-stats" });
+    let details = content.appendChild(
+      this.createDOM("div", { class: "ogk-roi-details" })
+    );
+    let settings = details.appendChild(
+      this.createDOM("div", { class: "ogk-settings-box" })
+    );
+    let tradeRateBox = settings.appendChild(
+      this.createDOM("div", { class: "ogk-tradeRate-box" })
+    );
+    let crawler = settings.appendChild(
+      this.createDOM("div", { class: "ogk-crawler-box" })
+    );
+    let filter = settings.appendChild(
+      this.createDOM("div", { class: "ogk-filter-box" })
+    );
+    let header = details.appendChild(this.createDOM("h1"));
+    header.appendChild(this.createDOM("p", {}, this.getTranslatedText(88)));
+    let tradeRateText = this.createDOM(
+      "p",
+      { class: "ogk-tradeRate-text" },
+      this.getTranslatedText(119)
+    );
+    let tradeRateGrid = this.createDOM("div", { class: "ogk-tradeRate-grid" });
+    let box = details.appendChild(this.createDOM("div", { class: "ogk-box" }));
+    tradeRateBox.appendChild(tradeRateText);
+    tradeRateBox.appendChild(tradeRateGrid);
+
+    let filterOptions = `<option value="1">${this.getTranslatedText(
+      1,
+      "tech"
+    )}</option><option  value="2">${this.getTranslatedText(
+      2,
+      "tech"
+    )}</option><option  value="3">${this.getTranslatedText(
+      3,
+      "tech"
+    )}</option><option  value="0">${this.getTranslatedText(52)}</option>`;
+    this.json.empire.forEach(
+      (planet) =>
+        (filterOptions += `<option  value="${planet.id}">${planet.coordinates}\t${planet.name}</option>`)
+    );
+
+    filter.appendChild(
+      this.createDOM(
+        "p",
+        { class: "ogk-filter-text" },
+        this.getTranslatedText(130)
+      )
+    );
+    filter.appendChild(
+      this.createDOM(
+        "div",
+        { class: "ogk-filter-grid" },
+        `<select id="filterRoi" size="1"><option value="-1" selected="selected">-</option>${filterOptions}</select><input id="reverseFilter" type="checkbox"
+      title='<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-left-right" viewBox="0 0 16 16"> <path fill-rule="evenodd" d="M1 11.5a.5.5 0 0 0 .5.5h11.793l-3.147 3.146a.5.5 0 0 0 .708.708l4-4a.5.5 0 0 0 0-.708l-4-4a.5.5 0 0 0-.708.708L13.293 11H1.5a.5.5 0 0 0-.5.5zm14-7a.5.5 0 0 1-.5.5H2.707l3.147 3.146a.5.5 0 1 1-.708.708l-4-4a.5.5 0 0 1 0-.708l4-4a.5.5 0 1 1 .708.708L2.707 4H14.5a.5.5 0 0 1 .5.5z"/> </svg>' class="tooltip"></input>`
+      )
+    );
+    filter
+      .querySelector("#filterRoi")
+      .addEventListener("change", () => updateRoi());
+    filter.querySelector("#reverseFilter").checked =
+      this.json.options.reverseFilter;
+
+    filter.querySelector("#reverseFilter").addEventListener("change", () => {
+      this.json.options.reverseFilter =
+        filter.querySelector("#reverseFilter").checked;
+      this.saveData();
+      updateRoi();
+    });
+
+    let crawlerPercent = Math.min(
+      that.json.options.crawlerPercent,
+      this.playerClass == PLAYER_CLASS_MINER ? 1.5 : 1
+    );
+    function crawlerClass(crawlerPercent) {
+      let selectClass = "undermark";
+      if (crawlerPercent <= 0.3) {
+        selectClass = "overmark";
+      } else if (crawlerPercent <= 0.6) {
+        selectClass = "middlemark";
+      } else if (crawlerPercent > 1) {
+        selectClass = "overcharge";
+      }
+      return selectClass;
+    }
+    let options;
+    if (this.playerClass == PLAYER_CLASS_MINER) {
+      options = `<option class="overcharge" value="150">${toFormatedNumber(
+        150
+      )}%</option><option class="overcharge" value="140">${toFormatedNumber(
+        140
+      )}%</option><option class="overcharge" value="130">${toFormatedNumber(
+        130
+      )}%</option><option class="overcharge" value="120">${toFormatedNumber(
+        120
+      )}%</option><option class="overcharge" value="110">${toFormatedNumber(
+        110
+      )}%</option><option class="undermark" value="100">${toFormatedNumber(
+        100
+      )}%</option><option class="undermark" value="90">${toFormatedNumber(
+        90
+      )}%</option><option class="undermark" value="80">${toFormatedNumber(
+        80
+      )}%</option><option class="undermark" value="70">${toFormatedNumber(
+        70
+      )}%</option><option class="middlemark" value="60">${toFormatedNumber(
+        60
+      )}%</option><option class="middlemark" value="50">${toFormatedNumber(
+        50
+      )}%</option><option class="middlemark" value="40">${toFormatedNumber(
+        40
+      )}%</option><option class="overmark" value="30">${toFormatedNumber(
+        30
+      )}%</option><option class="overmark" value="20">${toFormatedNumber(
+        20
+      )}%</option><option class="overmark" value="10">${toFormatedNumber(
+        10
+      )}%</option><option class="overmark" value="0" >0%</option>`;
+    } else {
+      options = `<option class="undermark" value="100">${toFormatedNumber(
+        100
+      )}%</option><option class="undermark" value="90">${toFormatedNumber(
+        90
+      )}%</option><option class="undermark" value="80">${toFormatedNumber(
+        80
+      )}%</option><option class="undermark" value="70">${toFormatedNumber(
+        70
+      )}%</option><option class="middlemark" value="60">${toFormatedNumber(
+        60
+      )}%</option><option class="middlemark" value="50">${toFormatedNumber(
+        50
+      )}%</option><option class="middlemark" value="40">${toFormatedNumber(
+        40
+      )}%</option><option class="overmark" value="30">${toFormatedNumber(
+        30
+      )}%</option><option class="overmark" value="20">${toFormatedNumber(
+        20
+      )}%</option><option class="overmark" value="10">${toFormatedNumber(
+        10
+      )}%</option><option class="overmark" value="0" >0%</option>`;
+    }
+
+    crawler.appendChild(
+      this.createDOM(
+        "p",
+        { class: "ogk-crawler-text" },
+        this.getTranslatedText(217, "tech")
+      )
+    );
+    crawler.appendChild(
+      this.createDOM(
+        "div",
+        { class: "ogk-crawler-grid" },
+        `<select id="crawlerPercent" size="1" class="${crawlerClass(
+          crawlerPercent
+        )} tooltip" title="${this.getTranslatedText(126)}"><option value="${
+          crawlerPercent * 100
+        }" selected="selected" hidden="hidden">${toFormatedNumber(
+          crawlerPercent * 100
+        )}%</option>${options}</select><input id="optLimitCrawler" type="checkbox" class="tooltip" title="${this.getTranslatedText(
+          125
+        )}"> </input>`
+      )
+    );
+    crawler.querySelector("#optLimitCrawler").checked =
+      this.json.options.limitCrawler;
+
+    crawler.querySelector("#optLimitCrawler").addEventListener("change", () => {
+      this.json.options.limitCrawler =
+        crawler.querySelector("#optLimitCrawler").checked;
+      this.saveData();
+      updateRoi();
+    });
+
+    crawler.querySelector("#crawlerPercent").addEventListener("change", () => {
+      this.json.options.crawlerPercent =
+        crawler.querySelector("#crawlerPercent").value / 100;
+      crawler
+        .querySelector("#crawlerPercent")
+        .classList.remove("overcharge", "undermark", "middlemark", "overmark");
+      crawler
+        .querySelector("#crawlerPercent")
+        .classList.add(crawlerClass(this.json.options.crawlerPercent));
+      this.saveData();
+      updateRoi();
+    });
+
+    tradeRateGrid.appendChild(
+      this.createDOM("a", { class: "ogl-option resourceIcon metal" })
+    );
+    let metalTradeRate = tradeRateGrid.appendChild(
+      this.createDOM("input", {
+        class: "ogl-tradeRate-input metal",
+        type: "text",
+        value: toFormatedNumber(this.json.options.tradeRate[0]),
+      })
+    );
+    metalTradeRate.addEventListener("keyup", (e) => {
+      setTimeout(() => {
+        if (e.key == "Enter") metalTradeRate.blur();
+        if (e.key == "." || e.key == ",") return;
+        let input = metalTradeRate.value.replace(",", ".");
+        if (input === "") return;
+        input = Math.round(parseFloat(input) * 100) / 100;
+        if (e.key == "ArrowUp") input += 0.1;
+        if (e.key == "ArrowDown") input -= 0.1;
+        if (input < 1) {
+          input = 1;
+          fadeBox(this.getTranslatedText(122), true);
+        }
+        if (!input) input = his.json.options.tradeRate[0];
+        metalTradeRate.value = toFormatedNumber(input);
+        this.json.options.tradeRate[0] = input;
+        this.saveData();
+        updateRoi();
+      }, 100);
+    });
+    metalTradeRate.addEventListener("blur", () => {
+      let input = metalTradeRate.value.replace(",", ".");
+      if (input === "") input = this.json.options.tradeRate[0];
+      input = Math.round(parseFloat(input) * 100) / 100;
+      metalTradeRate.value = toFormatedNumber(input);
+      this.json.options.tradeRate[0] = input;
+      this.saveData();
+      updateRoi();
+    });
+    tradeRateGrid.appendChild(
+      this.createDOM("a", { class: "ogl-option resourceIcon crystal" })
+    );
+    let crystalTradeRate = tradeRateGrid.appendChild(
+      this.createDOM("input", {
+        class: "ogl-tradeRate-input crystal",
+        type: "text",
+        value: toFormatedNumber(this.json.options.tradeRate[1]),
+      })
+    );
+    crystalTradeRate.addEventListener("keyup", (e) => {
+      setTimeout(() => {
+        if (e.key == "Enter") crystalTradeRate.blur();
+        if (e.key == "." || e.key == ",") return;
+        let input = crystalTradeRate.value.replace(",", ".");
+        if (input === "") return;
+        input = Math.round(parseFloat(input) * 100) / 100;
+        if (e.key == "ArrowUp") input += 0.1;
+        if (e.key == "ArrowDown") input -= 0.1;
+        if (input < 1) {
+          input = 1;
+          fadeBox(this.getTranslatedText(122), true);
+        }
+        if (!input) input = his.json.options.tradeRate[1];
+        crystalTradeRate.value = toFormatedNumber(input);
+        this.json.options.tradeRate[1] = input;
+        this.saveData();
+        updateRoi();
+      }, 100);
+    });
+    crystalTradeRate.addEventListener("blur", () => {
+      let input = crystalTradeRate.value.replace(",", ".");
+      if (input === "") input = this.json.options.tradeRate[1];
+      input = Math.round(parseFloat(input) * 100) / 100;
+      crystalTradeRate.value = toFormatedNumber(input);
+      this.json.options.tradeRate[1] = input;
+      this.saveData();
+      updateRoi();
+    });
+    tradeRateGrid.appendChild(
+      this.createDOM("a", { class: "ogl-option resourceIcon deuterium" })
+    );
+    let deuteriumTradeRate = tradeRateGrid.appendChild(
+      this.createDOM("input", {
+        class: "ogl-tradeRate-input deuterium",
+        type: "text",
+        value: toFormatedNumber(this.json.options.tradeRate[2]),
+      })
+    );
+    deuteriumTradeRate.addEventListener("keyup", (e) => {
+      setTimeout(() => {
+        if (e.key == "Enter") deuteriumTradeRate.blur();
+        if (e.key == "." || e.key == ",") return;
+        let input = deuteriumTradeRate.value.replace(",", ".");
+        if (input === "") return;
+        input = Math.round(parseFloat(input) * 100) / 100;
+        if (e.key == "ArrowUp") input += 0.1;
+        if (e.key == "ArrowDown") input -= 0.1;
+        if (input < 1) {
+          input = 1;
+          fadeBox(this.getTranslatedText(122), true);
+        }
+        if (!input) input = his.json.options.tradeRate[2];
+        deuteriumTradeRate.value = toFormatedNumber(input);
+        this.json.options.tradeRate[2] = input;
+        this.saveData();
+        updateRoi();
+      }, 100);
+    });
+    deuteriumTradeRate.addEventListener("blur", () => {
+      let input = deuteriumTradeRate.value.replace(",", ".");
+      if (input === "") input = this.json.options.tradeRate[2];
+      input = Math.round(parseFloat(input) * 100) / 100;
+      deuteriumTradeRate.value = toFormatedNumber(input);
+      this.json.options.tradeRate[2] = input;
+      this.saveData();
+      updateRoi();
+    });
+
+    let updateRoi = () => {
+      let roi = document.querySelector(".ogk-roi");
+      if (roi) roi.remove();
+      roi = box.appendChild(this.createDOM("div", { class: "ogk-roi" }));
+      let bestRoi = this.getBestRoi();
+      let filter = document.querySelector("#filterRoi")
+        ? document.querySelector("#filterRoi").value
+        : -1;
+      let rev = document.querySelector("#reverseFilter")
+        ? document.querySelector("#reverseFilter").checked
+        : false;
+
+      if (filter > 0 && filter <= 3)
+        bestRoi = rev
+          ? bestRoi.filter((roi) => roi.technoId != filter)
+          : bestRoi.filter((roi) => roi.technoId == filter);
+      if (filter == 0)
+        bestRoi = rev
+          ? bestRoi.filter((roi) => roi.technoId <= 100)
+          : bestRoi.filter((roi) => roi.technoId > 100);
+      if (filter > 5000)
+        bestRoi = rev
+          ? bestRoi.filter((roi) => roi.planetId != filter)
+          : bestRoi.filter((roi) => roi.planetId == filter);
+
+      for (let n = 0; n < Math.min(20, Object.keys(bestRoi).length); n++) {
+        let cons = bestRoi[n];
+        let component = cons.technoId <= 3 ? "supplies" : "research";
+        let planetList = document.querySelectorAll('[id^="planet-"]');
+        let currentId =
+          planetList.length == 1
+            ? planetList[0]
+            : document.querySelector("#planetList .hightlightPlanet") ||
+              document.querySelector("#planetList .moonlink.active")
+                .parentElement;
+        currentId = currentId.getAttribute("id").split("-")[1];
+        let link = `?page=ingame&component=${component}&cp=${
+          cons.planetId || currentId
+        }&technoDetails=${cons.technoId}`;
+        link =
+          "https://" + window.location.host + window.location.pathname + link;
+        roi.appendChild(
+          this.createDOM(
+            "div",
+            {
+              class: "value tooltip",
+              "data-title": `${formatTimeWrapper(
+                Math.max(
+                  0,
+                  (new Date(cons.endDate).getTime() - new Date().getTime()) /
+                    1000
+                ),
+                2,
+                true,
+                " ",
+                false,
+                ""
+              )}`,
+            },
+            `<a href=${link} class="ogl-option ogl-roi-tech ogl-tech-${
+              cons.technoId
+            } ${
+              cons.inConstruction
+                ? 'inConstruction'
+                : cons.construction
+                  ? 'construction'
+                  : ' '
+            }"><div><span>${toFormatedNumber(cons.lvl)}</span></div><div><p>${
+              cons.coords ? '[' + cons.coords + ']' : ' '
+            }</p></div><div><p>${formatTimeWrapper(
+              cons.time,
+              2,
+              true,
+              " ",
+              false,
+              ""
+            )}</p></div></a>`
+          )
+        );
+      }
+    };
+    updateRoi();
+    details.appendChild(
+      this.createDOM(
+        "p",
+        { class: "ogk-roi-desc" },
+        this.getTranslatedText(121)
+      )
+    );
+    return content;
+  }
+
   minesStats() {
-    let content = this.createDOM("div", { class: "ogl-mines-content" });
+    let content = this.createDOM("div", { class: "ogl-prodOverview-content" });
     let table = content.appendChild(
       this.createDOM("table", { class: "ogl-fleet-table" })
     );
@@ -6115,293 +8745,1307 @@ class OGInfinity {
     let metalRow = table.appendChild(this.createDOM("tr"));
     let crystalRow = table.appendChild(this.createDOM("tr"));
     let deutRow = table.appendChild(this.createDOM("tr"));
-    let nrjRow = table.appendChild(this.createDOM("tr"));
     metalRow.appendChild(
       this.createDOM(
         "td",
         {},
-        '<div class="ogl-option resourceIcon metal"></div>'
+        '<div class="resourceIcon metal"></div>'
       )
     );
     crystalRow.appendChild(
       this.createDOM(
         "td",
         {},
-        '<div class="ogl-option resourceIcon crystal"></div>'
+        '<div class="resourceIcon crystal"></div>'
       )
     );
     deutRow.appendChild(
       this.createDOM(
         "td",
         {},
-        '<div class="ogl-option resourceIcon deuterium"></div>'
+        '<div class="resourceIcon deuterium"></div>'
       )
     );
-    nrjRow.appendChild(
+    header.appendChild(
       this.createDOM(
-        "td",
+        "th",
         {},
-        '<div class="ogl-option resourceIcon energy"></div>'
+        '<div class="ogl-prodOverview-icon mines"></div>'
       )
     );
-    let sum = 0;
-    let mlvl = 0;
-    let clvl = 0;
-    let dlvl = 0;
-    let mprod = 0;
-    let cprod = 0;
-    let dprod = 0;
-    this.planetList.forEach((planet) => {
-      sum += 1;
-      let coords = planet.querySelector(".planet-koords").textContent;
-      let current = false;
-      if (coords == this.current.coords) {
-        current = true;
-      }
-      this.json.myMines[coords] = this.json.myMines[coords] || {};
-      this.json.myMines[coords].metal = this.json.myMines[coords].metal || 0;
-      this.json.myMines[coords].crystal =
-        this.json.myMines[coords].crystal || 0;
-      this.json.myMines[coords].deuterium =
-        this.json.myMines[coords].deuterium || 0;
-      this.json.myMines[coords].metalProd =
-        this.json.myMines[coords].metalProd || 0;
-      this.json.myMines[coords].crystalProd =
-        this.json.myMines[coords].crystalProd || 0;
-      this.json.myMines[coords].deuteriumProd =
-        this.json.myMines[coords].deuteriumProd || 0;
-      this.json.myMines[coords].energy = this.json.myMines[coords].energy || 0;
-      mlvl += Number(this.json.myMines[coords].metal);
-      clvl += Number(this.json.myMines[coords].crystal);
-      dlvl += Number(this.json.myMines[coords].deuterium);
-      mprod +=
-        this.json.myMines[coords].metalProd ||
-        this.production(1, this.json.myMines[coords].metal, true);
-      cprod +=
-        this.json.myMines[coords].crystalProd ||
-        this.production(2, this.json.myMines[coords].crystal, true);
-      dprod +=
-        this.json.myMines[coords].deuteriumProd ||
-        this.production(3, this.json.myMines[coords].deuterium, true);
-      planet.name = planet.querySelector(".planet-name").textContent;
-      planet.coordinates = coords;
-      planet.fieldUsed = this.json.myMines[coords].fieldUsed || 0;
-      planet.fieldMax = this.json.myMines[coords].fieldMax || 0;
-      planet.temperature = this.json.myMines[coords].temperature || 0;
-      let link = `?page=ingame&component=supplies&cp=${planet.id}`;
+    header.appendChild(
+      this.createDOM(
+        "th",
+        {},
+        '<div class="ogl-prodOverview-icon plasma"></div>'
+      )
+    );
+    header.appendChild(
+      this.createDOM(
+        "th",
+        {},
+        '<div class="ogl-prodOverview-icon crawler"></div>'
+      )
+    );
+    header.appendChild(
+      this.createDOM(
+        "th",
+        {},
+        '<div class="ogl-prodOverview-icon items"></div>'
+      )
+    );
+    header.appendChild(
+      this.createDOM(
+        "th",
+        {},
+        '<div class="officers100 allOfficers prodOverview"></div>'
+      )
+    );
+    header.appendChild(
+      this.createDOM(
+        "th",
+        {},
+        '<div class="sprite characterclass medium miner prodOverview"></div>'
+      )
+    );
+    header.appendChild(
+      this.createDOM(
+        "th",
+        {},
+        '<div class="sprite allianceclass medium trader prodOverview"></div>'
+      )
+    );
+    if (document.querySelector(".lifeform") != null)
       header.appendChild(
         this.createDOM(
           "th",
-          {},
-          `<p>${planet.name}</p> <a href="${link}" class="ogl-fleet-coords">${planet.coordinates}</a> <span class="ogl-planet-fields">${planet.fieldUsed} / ${planet.fieldMax}</span><br><span class="ogl-planet-temperature">${planet.temperature}ºC</span>`
+          { class: "menu_icon" },
+          '<div class="ogl-prodOverview-icon lifeform"></div>'
         )
       );
-      let td = metalRow.appendChild(this.createDOM("td"));
-      td.appendChild(
-        this.createDOM(
-          "div",
-          { class: "ogl-metal" },
-          this.json.myMines[coords].metal
-        )
-      );
-      td.appendChild(
-        this.createDOM(
-          "div",
-          { class: "ogl-metal" },
-          this.formatToUnits(
-            this.json.myMines[coords].metalProd ||
-              this.production(1, this.json.myMines[coords].metal, true)
-          )
-        )
-      );
-      td.appendChild(
-        this.createDOM(
-          "div",
-          { class: "ogl-metal" },
-          this.formatToUnits(
-            (this.json.myMines[coords].metalProd ||
-              this.production(1, this.json.myMines[coords].metal, true)) * 24
-          )
-        )
-      );
-      td.appendChild(
-        this.createDOM(
-          "div",
-          { class: "ogl-metal" },
-          this.formatToUnits(
-            (this.json.myMines[coords].metalProd ||
-              this.production(1, this.json.myMines[coords].metal, true)) *
-              24 *
-              7
-          )
-        )
-      );
-      if (current) td.classList.add("ogl-current");
-      td = crystalRow.appendChild(this.createDOM("td"));
-      td.appendChild(
-        this.createDOM(
-          "div",
-          { class: "ogl-crystal" },
-          this.json.myMines[coords].crystal
-        )
-      );
-      td.appendChild(
-        this.createDOM(
-          "div",
-          { class: "ogl-crystal" },
-          this.formatToUnits(
-            this.json.myMines[coords].crystalProd ||
-              this.production(2, this.json.myMines[coords].crystal, true)
-          )
-        )
-      );
-      td.appendChild(
-        this.createDOM(
-          "div",
-          { class: "ogl-crystal" },
-          this.formatToUnits(
-            (this.json.myMines[coords].crystalProd ||
-              this.production(2, this.json.myMines[coords].crystal, true)) * 24
-          )
-        )
-      );
-      td.appendChild(
-        this.createDOM(
-          "div",
-          { class: "ogl-crystal" },
-          this.formatToUnits(
-            (this.json.myMines[coords].crystalProd ||
-              this.production(2, this.json.myMines[coords].crystal, true)) *
-              24 *
-              7
-          )
-        )
-      );
-      if (current) td.classList.add("ogl-current");
-      td = deutRow.appendChild(this.createDOM("td"));
-      td.appendChild(
-        this.createDOM(
-          "div",
-          { class: "ogl-deut" },
-          this.json.myMines[coords].deuterium
-        )
-      );
-      td.appendChild(
-        this.createDOM(
-          "div",
-          { class: "ogl-deut" },
-          this.formatToUnits(
-            this.json.myMines[coords].deuteriumProd ||
-              this.production(3, this.json.myMines[coords].deuterium, true)
-          )
-        )
-      );
-      td.appendChild(
-        this.createDOM(
-          "div",
-          { class: "ogl-deut" },
-          this.formatToUnits(
-            (this.json.myMines[coords].deuteriumProd ||
-              this.production(3, this.json.myMines[coords].deuterium, true)) *
-              24
-          )
-        )
-      );
-      td.appendChild(
-        this.createDOM(
-          "div",
-          { class: "ogl-deut" },
-          this.formatToUnits(
-            (this.json.myMines[coords].deuteriumProd ||
-              this.production(3, this.json.myMines[coords].deuterium, true)) *
-              24 *
-              7
-          )
-        )
-      );
-      if (current) td.classList.add("ogl-current");
-      td = nrjRow.appendChild(this.createDOM("td"));
-      let diff = this.json.myMines[coords].energy;
-      td.appendChild(
-        this.createDOM(
-          "div",
-          {
-            class: "ogl-energy " + (diff >= 0 ? "undermark" : "overmark"),
-            style: "font-size: 18px;",
-          },
-          this.formatToUnits(diff)
-        )
-      );
-      if (current) td.classList.add("ogl-current");
+    header.appendChild(
+      this.createDOM(
+        "th",
+        {},
+        '<div class="ogl-prodOverview-icon energy"></div>'
+      )
+    );
+    let mines = [0, 0, 0];
+    let plasma = [0, 0, 0];
+    let crawler = [0, 0, 0];
+    let items = [0, 0, 0];
+    let officers = [0, 0, 0];
+    let player = [0, 0, 0];
+    let alliance = [0, 0, 0];
+    let energy = [0, 0, 0];
+    let lifeform =
+      document.querySelector(".lifeform") != null ? [0, 0, 0] : undefined;
+    this.json.empire.forEach((planet) => {
+      for (let i = 0; i < 3; i++) {
+        mines[i] +=
+          planet.production.production[1][i] +
+          planet.production.production[2][i] +
+          planet.production.production[3][i] +
+          planet.production.generalIncoming[i];
+        plasma[i] += planet.production.production[122][i];
+        crawler[i] += planet.production.production[217][i];
+        items[i] += planet.production.production[1000][i];
+        officers[i] +=
+          planet.production.production[1001][i] +
+          planet.production.production[1003][i];
+        player[i] += planet.production.production[1004][i];
+        alliance[i] += planet.production.production[1005][i];
+        energy[i] -= planet.production.production[12][i];
+        if (lifeform) lifeform[i] += planet.production.production[1006][i];
+      }
     });
-    mlvl = mlvl / sum;
-    clvl = clvl / sum;
-    dlvl = dlvl / sum;
     header.appendChild(this.createDOM("th", { class: "ogl-sum-symbol" }, "Σ"));
+
     let td = metalRow.appendChild(this.createDOM("td"));
-    td.appendChild(
-      this.createDOM("div", { class: "ogl-metal" }, mlvl.toFixed(1))
-    );
-    td.appendChild(
-      this.createDOM("div", { class: "ogl-metal" }, this.formatToUnits(mprod))
-    );
     td.appendChild(
       this.createDOM(
         "div",
-        { class: "ogl-metal" },
-        this.formatToUnits(mprod * 24)
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(Math.round(mines[0])),
+        },
+        toFormatedNumber(Math.round(mines[0]), null, true)
       )
     );
     td.appendChild(
       this.createDOM(
         "div",
-        { class: "ogl-metal" },
-        this.formatToUnits(mprod * 24 * 7)
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(Math.round(mines[0] * 24)),
+        },
+        toFormatedNumber(Math.round(mines[0] * 24), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(Math.round(mines[0] * 24 * 7)),
+        },
+        toFormatedNumber(Math.round(mines[0] * 24 * 7), null, true)
       )
     );
     td = crystalRow.appendChild(this.createDOM("td"));
     td.appendChild(
-      this.createDOM("div", { class: "ogl-crystal" }, clvl.toFixed(1))
-    );
-    td.appendChild(
-      this.createDOM("div", { class: "ogl-crystal" }, this.formatToUnits(cprod))
-    );
-    td.appendChild(
       this.createDOM(
         "div",
-        { class: "ogl-crystal" },
-        this.formatToUnits(cprod * 24)
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(Math.round(mines[1])),
+        },
+        toFormatedNumber(Math.round(mines[1]), null, true)
       )
     );
     td.appendChild(
       this.createDOM(
         "div",
-        { class: "ogl-crystal" },
-        this.formatToUnits(cprod * 24 * 7)
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(Math.round(mines[1] * 24)),
+        },
+        toFormatedNumber(Math.round(mines[1] * 24), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(Math.round(mines[1] * 24 * 7)),
+        },
+        toFormatedNumber(Math.round(mines[1] * 24 * 7), null, true)
+      )
+    );
+
+    td = deutRow.appendChild(this.createDOM("td"));
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(Math.round(mines[2])),
+        },
+        toFormatedNumber(Math.round(mines[2]), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(Math.round(mines[2] * 24)),
+        },
+        toFormatedNumber(Math.round(mines[2] * 24), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(Math.round(mines[2] * 24 * 7)),
+        },
+        toFormatedNumber(Math.round(mines[2] * 24 * 7), null, true)
+      )
+    );
+    td = metalRow.appendChild(this.createDOM("td"));
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(Math.round(plasma[0])),
+        },
+        toFormatedNumber(Math.round(plasma[0]), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(Math.round(plasma[0] * 24)),
+        },
+        toFormatedNumber(Math.round(plasma[0] * 24), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(Math.round(plasma[0] * 24 * 7)),
+        },
+        toFormatedNumber(Math.round(plasma[0] * 24 * 7), null, true)
+      )
+    );
+    td = crystalRow.appendChild(this.createDOM("td"));
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(Math.round(plasma[1])),
+        },
+        toFormatedNumber(Math.round(plasma[1]), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(Math.round(plasma[1] * 24)),
+        },
+        toFormatedNumber(Math.round(plasma[1] * 24), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(Math.round(plasma[1] * 24 * 7)),
+        },
+        toFormatedNumber(Math.round(plasma[1] * 24 * 7), null, true)
       )
     );
     td = deutRow.appendChild(this.createDOM("td"));
     td.appendChild(
-      this.createDOM("div", { class: "ogl-deut" }, dlvl.toFixed(1))
-    );
-    td.appendChild(
-      this.createDOM("div", { class: "ogl-deut" }, this.formatToUnits(dprod))
-    );
-    td.appendChild(
       this.createDOM(
         "div",
-        { class: "ogl-deut" },
-        this.formatToUnits(dprod * 24)
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(Math.round(plasma[2])),
+        },
+        toFormatedNumber(Math.round(plasma[2]), null, true)
       )
     );
     td.appendChild(
       this.createDOM(
         "div",
-        { class: "ogl-deut" },
-        this.formatToUnits(dprod * 24 * 7)
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(Math.round(plasma[2] * 24)),
+        },
+        toFormatedNumber(Math.round(plasma[2] * 24), null, true)
       )
     );
-    td = nrjRow.appendChild(this.createDOM("td"));
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(Math.round(plasma[2] * 24 * 7)),
+        },
+        toFormatedNumber(Math.round(plasma[2] * 24 * 7), null, true)
+      )
+    );
+    td = metalRow.appendChild(this.createDOM("td"));
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(Math.round(crawler[0])),
+        },
+        toFormatedNumber(Math.round(crawler[0]), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(Math.round(crawler[0] * 24)),
+        },
+        toFormatedNumber(Math.round(crawler[0] * 24), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(Math.round(crawler[0] * 24 * 7)),
+        },
+        toFormatedNumber(Math.round(crawler[0] * 24 * 7), null, true)
+      )
+    );
+    td = crystalRow.appendChild(this.createDOM("td"));
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(Math.round(crawler[1])),
+        },
+        toFormatedNumber(Math.round(crawler[1]), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(Math.round(crawler[1] * 24)),
+        },
+        toFormatedNumber(Math.round(crawler[1] * 24), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(Math.round(crawler[1] * 24 * 7)),
+        },
+        toFormatedNumber(Math.round(crawler[1] * 24 * 7), null, true)
+      )
+    );
+    td = deutRow.appendChild(this.createDOM("td"));
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(Math.round(crawler[2])),
+        },
+        toFormatedNumber(Math.round(crawler[2]), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(Math.round(crawler[2] * 24)),
+        },
+        toFormatedNumber(Math.round(crawler[2] * 24), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(Math.round(crawler[2] * 24 * 7)),
+        },
+        toFormatedNumber(Math.round(crawler[2] * 24 * 7), null, true)
+      )
+    );
+    td = metalRow.appendChild(this.createDOM("td"));
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(Math.round(items[0])),
+        },
+        toFormatedNumber(Math.round(items[0]), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(Math.round(items[0] * 24)),
+        },
+        toFormatedNumber(Math.round(items[0] * 24), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(Math.round(items[0] * 24 * 7)),
+        },
+        toFormatedNumber(Math.round(items[0] * 24 * 7), null, true)
+      )
+    );
+    td = crystalRow.appendChild(this.createDOM("td"));
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(Math.round(items[1])),
+        },
+        toFormatedNumber(Math.round(items[1]), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(Math.round(items[1] * 24)),
+        },
+        toFormatedNumber(Math.round(items[1] * 24), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(Math.round(items[1] * 24 * 7)),
+        },
+        toFormatedNumber(Math.round(items[1] * 24 * 7), null, true)
+      )
+    );
+    td = deutRow.appendChild(this.createDOM("td"));
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(Math.round(items[2])),
+        },
+        toFormatedNumber(Math.round(items[2]), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(Math.round(items[2] * 24)),
+        },
+        toFormatedNumber(Math.round(items[2] * 24), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(Math.round(items[2] * 24 * 7)),
+        },
+        toFormatedNumber(Math.round(items[2] * 24 * 7), null, true)
+      )
+    );
+    td = metalRow.appendChild(this.createDOM("td"));
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(Math.round(officers[0])),
+        },
+        toFormatedNumber(Math.round(officers[0]), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(Math.round(officers[0] * 24)),
+        },
+        toFormatedNumber(Math.round(officers[0] * 24), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(Math.round(officers[0] * 24 * 7)),
+        },
+        toFormatedNumber(Math.round(officers[0] * 24 * 7), null, true)
+      )
+    );
+    td = crystalRow.appendChild(this.createDOM("td"));
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(Math.round(officers[1])),
+        },
+        toFormatedNumber(Math.round(officers[1]), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(Math.round(officers[1] * 24)),
+        },
+        toFormatedNumber(Math.round(officers[1] * 24), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(Math.round(officers[1] * 24 * 7)),
+        },
+        toFormatedNumber(Math.round(officers[1] * 24 * 7), null, true)
+      )
+    );
+    td = deutRow.appendChild(this.createDOM("td"));
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(Math.round(officers[2])),
+        },
+        toFormatedNumber(Math.round(officers[2]), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(Math.round(officers[2] * 24)),
+        },
+        toFormatedNumber(Math.round(officers[2] * 24), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(Math.round(officers[2] * 24 * 7)),
+        },
+        toFormatedNumber(Math.round(officers[2] * 24 * 7), null, true)
+      )
+    );
+    td = metalRow.appendChild(this.createDOM("td"));
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(Math.round(player[0])),
+        },
+        toFormatedNumber(Math.round(player[0]), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(Math.round(player[0] * 24)),
+        },
+        toFormatedNumber(Math.round(player[0] * 24), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(Math.round(player[0] * 24 * 7)),
+        },
+        toFormatedNumber(Math.round(player[0] * 24 * 7), null, true)
+      )
+    );
+    td = crystalRow.appendChild(this.createDOM("td"));
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(Math.round(player[1])),
+        },
+        toFormatedNumber(Math.round(player[1]), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(Math.round(player[1] * 24)),
+        },
+        toFormatedNumber(Math.round(player[1] * 24), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(Math.round(player[1])),
+        },
+        toFormatedNumber(Math.round(player[1] * 24 * 7), null, true)
+      )
+    );
+    td = deutRow.appendChild(this.createDOM("td"));
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(Math.round(player[2])),
+        },
+        toFormatedNumber(Math.round(player[2]), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(Math.round(player[2] * 24)),
+        },
+        toFormatedNumber(Math.round(player[2] * 24), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(Math.round(player[2] * 24 * 7)),
+        },
+        toFormatedNumber(Math.round(player[2] * 24 * 7), null, true)
+      )
+    );
+    td = metalRow.appendChild(this.createDOM("td"));
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(Math.round(alliance[0])),
+        },
+        toFormatedNumber(Math.round(alliance[0]), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(Math.round(alliance[0] * 24)),
+        },
+        toFormatedNumber(Math.round(alliance[0] * 24), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(Math.round(alliance[0])),
+        },
+        toFormatedNumber(Math.round(alliance[0] * 24 * 7), null, true)
+      )
+    );
+    td = crystalRow.appendChild(this.createDOM("td"));
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(Math.round(alliance[1])),
+        },
+        toFormatedNumber(Math.round(alliance[1]), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(Math.round(alliance[1] * 24)),
+        },
+        toFormatedNumber(Math.round(alliance[1] * 24), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(Math.round(alliance[1])),
+        },
+        toFormatedNumber(Math.round(alliance[1] * 24 * 7), null, true)
+      )
+    );
+    td = deutRow.appendChild(this.createDOM("td"));
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(Math.round(alliance[2])),
+        },
+        toFormatedNumber(Math.round(alliance[2]), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(Math.round(alliance[2] * 24)),
+        },
+        toFormatedNumber(Math.round(alliance[2] * 24), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(Math.round(alliance[2] * 24 * 7)),
+        },
+        toFormatedNumber(Math.round(alliance[2] * 24 * 7), null, true)
+      )
+    );
+    if (lifeform) {
+      td = metalRow.appendChild(this.createDOM("td"));
+      td.appendChild(
+        this.createDOM(
+          "div",
+          {
+            class: "ogl-metal tooltip",
+            "data-title": toFormatedNumber(Math.round(lifeform[0])),
+          },
+          toFormatedNumber(Math.round(lifeform[0]), null, true)
+        )
+      );
+      td.appendChild(
+        this.createDOM(
+          "div",
+          {
+            class: "ogl-metal tooltip",
+            "data-title": toFormatedNumber(Math.round(lifeform[0] * 24)),
+          },
+          toFormatedNumber(Math.round(lifeform[0] * 24), null, true)
+        )
+      );
+      td.appendChild(
+        this.createDOM(
+          "div",
+          {
+            class: "ogl-metal tooltip",
+            "data-title": toFormatedNumber(Math.round(lifeform[0] * 24 * 7)),
+          },
+          toFormatedNumber(Math.round(lifeform[0] * 24 * 7), null, true)
+        )
+      );
+      td = crystalRow.appendChild(this.createDOM("td"));
+      td.appendChild(
+        this.createDOM(
+          "div",
+          {
+            class: "ogl-crystal tooltip",
+            "data-title": toFormatedNumber(Math.round(lifeform[1])),
+          },
+          toFormatedNumber(Math.round(lifeform[1]), null, true)
+        )
+      );
+      td.appendChild(
+        this.createDOM(
+          "div",
+          {
+            class: "ogl-crystal tooltip",
+            "data-title": toFormatedNumber(Math.round(lifeform[1] * 24)),
+          },
+          toFormatedNumber(Math.round(lifeform[1] * 24), null, true)
+        )
+      );
+      td.appendChild(
+        this.createDOM(
+          "div",
+          {
+            class: "ogl-crystal tooltip",
+            "data-title": toFormatedNumber(Math.round(lifeform[1] * 24 * 7)),
+          },
+          toFormatedNumber(Math.round(lifeform[1] * 24 * 7), null, true)
+        )
+      );
+      td = deutRow.appendChild(this.createDOM("td"));
+      td.appendChild(
+        this.createDOM(
+          "div",
+          {
+            class: "ogl-deut tooltip",
+            "data-title": toFormatedNumber(Math.round(lifeform[2])),
+          },
+          toFormatedNumber(Math.round(lifeform[2]), null, true)
+        )
+      );
+      td.appendChild(
+        this.createDOM(
+          "div",
+          {
+            class: "ogl-deut tooltip",
+            "data-title": toFormatedNumber(Math.round(lifeform[2] * 24)),
+          },
+          toFormatedNumber(Math.round(lifeform[2] * 24), null, true)
+        )
+      );
+      td.appendChild(
+        this.createDOM(
+          "div",
+          {
+            class: "ogl-deut tooltip",
+            "data-title": toFormatedNumber(Math.round(lifeform[2] * 24 * 7)),
+          },
+          toFormatedNumber(Math.round(lifeform[2] * 24 * 7), null, true)
+        )
+      );
+    }
+    td = metalRow.appendChild(this.createDOM("td"));
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(Math.round(energy[0])),
+        },
+        toFormatedNumber(Math.round(energy[0]), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(Math.round(energy[0] * 24)),
+        },
+        toFormatedNumber(Math.round(energy[0] * 24), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(Math.round(energy[0] * 24 * 7)),
+        },
+        toFormatedNumber(Math.round(energy[0] * 24 * 7), null, true)
+      )
+    );
+    td = crystalRow.appendChild(this.createDOM("td"));
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(Math.round(energy[1])),
+        },
+        toFormatedNumber(Math.round(energy[1]), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(Math.round(energy[1] * 24)),
+        },
+        toFormatedNumber(Math.round(energy[1] * 24), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(Math.round(energy[1])),
+        },
+        toFormatedNumber(Math.round(energy[1] * 24 * 7), null, true)
+      )
+    );
+    td = deutRow.appendChild(this.createDOM("td"));
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(Math.round(energy[2])),
+        },
+        toFormatedNumber(Math.round(energy[2]), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(Math.round(energy[2] * 24)),
+        },
+        toFormatedNumber(Math.round(energy[2] * 24), null, true)
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(Math.round(energy[2] * 24 * 7)),
+        },
+        toFormatedNumber(Math.round(energy[2] * 24 * 7), null, true)
+      )
+    );
+    td = metalRow.appendChild(this.createDOM("td"));
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(
+            Math.round(
+              mines[0] +
+                plasma[0] +
+                crawler[0] +
+                items[0] +
+                officers[0] +
+                player[0] +
+                alliance[0] +
+                energy[0] +
+                (lifeform ? lifeform[0] : 0)
+            )
+          ),
+        },
+        toFormatedNumber(
+          Math.round(
+            mines[0] +
+              plasma[0] +
+              crawler[0] +
+              items[0] +
+              officers[0] +
+              player[0] +
+              alliance[0] +
+              energy[0] +
+              (lifeform ? lifeform[0] : 0)
+          ),
+          null,
+          true
+        )
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(
+            Math.round(
+              (mines[0] +
+                plasma[0] +
+                crawler[0] +
+                items[0] +
+                officers[0] +
+                player[0] +
+                alliance[0] +
+                energy[0] +
+                (lifeform ? lifeform[0] : 0)) *
+                24
+            )
+          ),
+        },
+        toFormatedNumber(
+          Math.round(
+            (mines[0] +
+              plasma[0] +
+              crawler[0] +
+              items[0] +
+              officers[0] +
+              player[0] +
+              alliance[0] +
+              energy[0] +
+              (lifeform ? lifeform[0] : 0)) *
+              24
+          ),
+          null,
+          true
+        )
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-metal tooltip",
+          "data-title": toFormatedNumber(
+            Math.round(
+              (mines[0] +
+                plasma[0] +
+                crawler[0] +
+                items[0] +
+                officers[0] +
+                player[0] +
+                alliance[0] +
+                energy[0] +
+                (lifeform ? lifeform[0] : 0)) *
+                24 *
+                7
+            )
+          ),
+        },
+        toFormatedNumber(
+          Math.round(
+            (mines[0] +
+              plasma[0] +
+              crawler[0] +
+              items[0] +
+              officers[0] +
+              player[0] +
+              alliance[0] +
+              energy[0] +
+              (lifeform ? lifeform[0] : 0)) *
+              24 *
+              7
+          ),
+          null,
+          true
+        )
+      )
+    );
+    td = crystalRow.appendChild(this.createDOM("td"));
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(
+            Math.round(
+              mines[1] +
+                plasma[1] +
+                crawler[1] +
+                items[1] +
+                officers[1] +
+                player[1] +
+                alliance[1] +
+                energy[1] +
+                (lifeform ? lifeform[1] : 0)
+            )
+          ),
+        },
+        toFormatedNumber(
+          Math.round(
+            mines[1] +
+              plasma[1] +
+              crawler[1] +
+              items[1] +
+              officers[1] +
+              player[1] +
+              alliance[1] +
+              energy[1] +
+              (lifeform ? lifeform[1] : 0)
+          ),
+          null,
+          true
+        )
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(
+            Math.round(
+              (mines[1] +
+                plasma[1] +
+                crawler[1] +
+                items[1] +
+                officers[1] +
+                player[1] +
+                alliance[1] +
+                energy[1] +
+                (lifeform ? lifeform[1] : 0)) *
+                24
+            )
+          ),
+        },
+        toFormatedNumber(
+          Math.round(
+            (mines[1] +
+              plasma[1] +
+              crawler[1] +
+              items[1] +
+              officers[1] +
+              player[1] +
+              alliance[1] +
+              energy[1] +
+              (lifeform ? lifeform[1] : 0)) *
+              24
+          ),
+          null,
+          true
+        )
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-crystal tooltip",
+          "data-title": toFormatedNumber(
+            Math.round(
+              (mines[1] +
+                plasma[1] +
+                crawler[1] +
+                items[1] +
+                officers[1] +
+                player[1] +
+                alliance[1] +
+                energy[1] +
+                (lifeform ? lifeform[1] : 0)) *
+                24 *
+                7
+            )
+          ),
+        },
+        toFormatedNumber(
+          Math.round(
+            (mines[1] +
+              plasma[1] +
+              crawler[1] +
+              items[1] +
+              officers[1] +
+              player[1] +
+              alliance[1] +
+              energy[1] +
+              (lifeform ? lifeform[1] : 0)) *
+              24 *
+              7
+          ),
+          null,
+          true
+        )
+      )
+    );
+    td = deutRow.appendChild(this.createDOM("td"));
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(
+            Math.round(
+              mines[2] +
+                plasma[2] +
+                crawler[2] +
+                items[2] +
+                officers[2] +
+                player[2] +
+                alliance[2] +
+                energy[2] +
+                (lifeform ? lifeform[2] : 0)
+            )
+          ),
+        },
+        toFormatedNumber(
+          Math.round(
+            mines[2] +
+              plasma[2] +
+              crawler[2] +
+              items[2] +
+              officers[2] +
+              player[2] +
+              alliance[2] +
+              energy[2] +
+              (lifeform ? lifeform[2] : 0)
+          ),
+          null,
+          true
+        )
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(
+            Math.round(
+              (mines[2] +
+                plasma[2] +
+                crawler[2] +
+                items[2] +
+                officers[2] +
+                player[2] +
+                alliance[2] +
+                energy[2] +
+                (lifeform ? lifeform[2] : 0)) *
+                24
+            )
+          ),
+        },
+        toFormatedNumber(
+          Math.round(
+            (mines[2] +
+              plasma[2] +
+              crawler[2] +
+              items[2] +
+              officers[2] +
+              player[2] +
+              alliance[2] +
+              energy[2] +
+              (lifeform ? lifeform[2] : 0)) *
+              24
+          ),
+          null,
+          true
+        )
+      )
+    );
+    td.appendChild(
+      this.createDOM(
+        "div",
+        {
+          class: "ogl-deut tooltip",
+          "data-title": toFormatedNumber(
+            Math.round(
+              (mines[2] +
+                plasma[2] +
+                crawler[2] +
+                items[2] +
+                officers[2] +
+                player[2] +
+                alliance[2] +
+                energy[2] +
+                (lifeform ? lifeform[2] : 0)) *
+                24 *
+                7
+            )
+          ),
+        },
+        toFormatedNumber(
+          Math.round(
+            (mines[2] +
+              plasma[2] +
+              crawler[2] +
+              items[2] +
+              officers[2] +
+              player[2] +
+              alliance[2] +
+              energy[2] +
+              (lifeform ? lifeform[2] : 0)) *
+              24 *
+              7
+          ),
+          null,
+          true
+        )
+      )
+    );
     return content;
   }
 
@@ -6437,14 +10081,15 @@ class OGInfinity {
     td.appendChild(moonIcon);
     row.appendChild(td);
     this.json.empire.forEach((planet) => {
-      let link = `?page=ingame&component=fleetdispatch&cp=${
-        planet.moon ? planet.moon.id : planet.id
-      }`;
+      let name = moon ? (planet.moon ? planet.moon.name : "-") : planet.name;
+      let link = `?page=ingame&component=fleetdispatch&cp=${planet.id}`;
+      if (moon && planet.moon)
+        link = `?page=ingame&component=fleetdispatch&cp=${planet.moon.id}`;
       row.appendChild(
         this.createDOM(
           "th",
           {},
-          `<p>${planet.name}</p> <a class="ogl-fleet-coords" href="${link}">${planet.coordinates}</span> `
+          `<p>${name}</p> <a class="ogl-fleet-coords" href="${link}">${planet.coordinates}</span> `
         )
       );
     });
@@ -6465,8 +10110,8 @@ class OGInfinity {
       td.appendChild(
         this.createDOM(
           "span",
-          {},
-          shipCount ? this.formatToUnits(shipCount) : "-"
+          { class: "tooltip", "data-title": toFormatedNumber(shipCount) },
+          shipCount ? toFormatedNumber(shipCount, null, true) : "-"
         )
       );
       row.appendChild(td);
@@ -6484,21 +10129,45 @@ class OGInfinity {
         }
         sum +=
           moon && planet.moon ? Number(planet.moon[id]) : Number(planet[id]);
-        let valuePLa = planet[id] == 0 ? "-" : this.formatToUnits(planet[id]);
+        let valuePLa =
+          planet[id] == 0 ? "-" : toFormatedNumber(planet[id], null, true);
         let valueMooon = "-";
         if (planet.moon) {
           valueMooon =
-            planet.moon[id] == 0 ? "-" : this.formatToUnits(planet.moon[id]);
+            planet.moon[id] == 0
+              ? "-"
+              : toFormatedNumber(planet.moon[id], null, true);
         }
         let td = this.createDOM("td", {
           class: valuePLa == "-" ? "ogl-fleet-empty" : "",
         });
-        td.appendChild(this.createDOM("span", {}, valuePLa));
+        td.appendChild(
+          this.createDOM(
+            "span",
+            {
+              class: planet[id] > 0 ? "tooltip" : "",
+              "data-title": toFormatedNumber(planet[id], 0),
+            },
+            valuePLa
+          )
+        );
         if (moon) {
           td = this.createDOM("td", {
             class: valueMooon == "-" ? "ogl-fleet-empty" : "",
           });
-          td.appendChild(this.createDOM("span", {}, valueMooon));
+          td.appendChild(
+            this.createDOM(
+              "span",
+              {
+                class: planet.moon && planet.moon[id] > 0 ? "tooltip" : "",
+                "data-title": toFormatedNumber(
+                  planet.moon ? planet.moon[id] : 0,
+                  0
+                ),
+              },
+              valueMooon
+            )
+          );
         }
         if (current) {
           td.classList.add("ogl-current");
@@ -6507,7 +10176,11 @@ class OGInfinity {
       });
       td = this.createDOM("td", { class: sum == "-" ? "ogl-fleet-empty" : "" });
       td.appendChild(
-        this.createDOM("span", {}, sum == 0 ? "-" : this.formatToUnits(sum))
+        this.createDOM(
+          "span",
+          { class: "tooltip", "data-title": toFormatedNumber(sum, 0) },
+          sum == 0 ? "-" : toFormatedNumber(sum, null, true)
+        )
       );
       row.appendChild(td);
       table.appendChild(row);
@@ -6545,14 +10218,15 @@ class OGInfinity {
     td.appendChild(moonIcon);
     row.appendChild(td);
     this.json.empire.forEach((planet) => {
-      let link = `?page=ingame&component=defenses&cp=${
-        moon && planet.moon ? planet.moon.id : planet.id
-      }`;
+      let name = moon ? (planet.moon ? planet.moon.name : "-") : planet.name;
+      let link = `?page=ingame&component=defenses&cp=${planet.id}`;
+      if (moon && planet.moon)
+        link = `?page=ingame&component=defenses&cp=${planet.moon.id}`;
       row.appendChild(
         this.createDOM(
           "th",
           {},
-          `<p>${planet.name}</p> <a class="ogl-fleet-coords" href="${link}">${planet.coordinates}</span>`
+          `<p>${name}</p> <a class="ogl-fleet-coords" href="${link}">${planet.coordinates}</span>`
         )
       );
     });
@@ -6577,21 +10251,33 @@ class OGInfinity {
         }
         sum +=
           moon && planet.moon ? Number(planet.moon[id]) : Number(planet[id]);
-        let valuePLa = planet[id] == 0 ? "-" : this.formatToUnits(planet[id]);
+        let valuePLa =
+          planet[id] == 0 ? "-" : toFormatedNumber(planet[id], null, true);
         let valueMooon = "-";
         if (planet.moon) {
           valueMooon =
-            planet.moon[id] == 0 ? "-" : this.formatToUnits(planet.moon[id], 2);
+            planet.moon[id] == 0
+              ? "-"
+              : toFormatedNumber(planet.moon[id], null, true);
         }
         let td = this.createDOM(
           "td",
-          { class: valuePLa == "-" ? "ogl-fleet-empty" : "" },
+          {
+            class: valuePLa == "-" ? "ogl-fleet-empty" : "tooltip",
+            "data-title": toFormatedNumber(planet[id], 0),
+          },
           valuePLa
         );
         if (moon) {
           td = this.createDOM(
             "td",
-            { class: valueMooon == "-" ? "ogl-fleet-empty" : "" },
+            {
+              class: valueMooon == "-" ? "ogl-fleet-empty" : "tooltip",
+              "data-title": toFormatedNumber(
+                planet.moon ? planet.moon[id] : 0,
+                0
+              ),
+            },
             valueMooon
           );
         }
@@ -6603,8 +10289,11 @@ class OGInfinity {
       row.appendChild(
         this.createDOM(
           "td",
-          { class: sum == "-" ? "ogl-fleet-empty" : "" },
-          sum == 0 ? "-" : this.formatToUnits(sum)
+          {
+            class: sum == "-" ? "ogl-fleet-empty" : "tooltip",
+            "data-title": toFormatedNumber(sum, 0),
+          },
+          sum == 0 ? "-" : toFormatedNumber(sum, null, true)
         )
       );
       table.appendChild(row);
@@ -7070,6 +10759,56 @@ class OGInfinity {
   betterFleetDispatcher() {
     if (
       this.page == "fleetdispatch" &&
+      fleetDispatcher.shipsOnPlanet.length == 0
+    ) {
+      let metal = Math.max(0, fleetDispatcher.metalOnPlanet);
+      let crystal = Math.max(0, fleetDispatcher.crystalOnPlanet);
+      let deut = Math.max(0, fleetDispatcher.deuteriumOnPlanet);
+      let sc = this.calcNeededShips({
+        fret: 202,
+        resources: metal + crystal + deut,
+      });
+      let lc = this.calcNeededShips({
+        fret: 203,
+        resources: metal + crystal + deut,
+      });
+      let pf = this.calcNeededShips({
+        fret: 219,
+        resources: metal + crystal + deut,
+      });
+      let rec = this.calcNeededShips({
+        fret: 209,
+        resources: metal + crystal + deut,
+      });
+      let warning = document.querySelector("#warning");
+      let neededShips = warning.appendChild(
+        this.createDOM("div", { class: "noShips" })
+      );
+      neededShips.appendChild(
+        this.createDOM(
+          "div",
+          { class: "ogl-res-transport" },
+          `<a tech-id="202" class="ogl-option noShips ogl-fleet-ship ogl-fleet-202"></a><span>${toFormatedNumber(
+            sc,
+            0
+          )}</span>
+          <a tech-id="203" class="ogl-option noShips ogl-fleet-ship ogl-fleet-203"></a><span>${toFormatedNumber(
+    lc,
+    0
+  )}</span>
+          <a tech-id="219" class="ogl-option noShips ogl-fleet-ship ogl-fleet-219"></a><span>${toFormatedNumber(
+    pf,
+    0
+  )}</span>
+          <a tech-id="209" class="ogl-option noShips ogl-fleet-ship ogl-fleet-209"></a><span>${toFormatedNumber(
+    rec,
+    0
+  )}</span>`
+        )
+      );
+    }
+    if (
+      this.page == "fleetdispatch" &&
       document.querySelector("#civilships") &&
       fleetDispatcher.shipsOnPlanet.length != 0
     ) {
@@ -7084,29 +10823,21 @@ class OGInfinity {
       ) {
         if (fleetDispatcher.mission) selectedMission = fleetDispatcher.mission;
       }
+      let lifeforms = document.querySelector(".lifeforms-enabled") != null;
+      let foodAvailable = Math.max(0, fleetDispatcher.foodOnPlanet);
 
       let needCargo = (fret) => {
-        let metal = Number(
-          metalFiller.value
-            .split(LocalizationStrings["thousandSeperator"])
-            .join("")
-        );
-        if (metal > metalAvailable) metalFiller.value = metalAvailable;
-        let crystal = Number(
-          crystalFiller.value
-            .split(LocalizationStrings["thousandSeperator"])
-            .join("")
-        );
-        if (crystal > crystalAvailable) crystalFiller.value = crystalAvailable;
-        let deut = Number(
-          deutFiller.value
-            .split(LocalizationStrings["thousandSeperator"])
-            .join("")
-        );
+        let metal = fromFormatedNumber(metalFiller.value, true);
+        if (metal > metalAvailable)
+          metalFiller.value = toFormatedNumber(metalAvailable, 0);
+        let crystal = fromFormatedNumber(crystalFiller.value, true);
+        if (crystal > crystalAvailable)
+          crystalFiller.value = toFormatedNumber(crystalAvailable, 0);
+        let deut = fromFormatedNumber(deutFiller.value, true);
         if (deut > deutAvailable)
-          deutFiller.value = Math.max(
-            0,
-            deutAvailable - fleetDispatcher.getConsumption()
+          deutFiller.value = toFormatedNumber(
+            Math.max(0, deutAvailable - fleetDispatcher.getConsumption()),
+            0
           );
         let amount = this.calcNeededShips({
           fret: fret,
@@ -7116,6 +10847,38 @@ class OGInfinity {
             Math.min(deut, deutAvailable),
         });
         return amount;
+      };
+      let highlightFleetTarget = () => {
+        this.planetList.forEach((planet) => {
+          let targetCoords = planet
+            .querySelector(".planet-koords")
+            .textContent.split(":");
+          planet.querySelector(".planetlink") &&
+            planet.querySelector(".planetlink").classList.remove("ogl-target");
+          planet.querySelector(".moonlink") &&
+            planet.querySelector(".moonlink").classList.remove("ogl-target");
+          planet.querySelector(".planetlink") &&
+            planet.querySelector(".planetlink").classList.remove("mission-3");
+          planet.querySelector(".moonlink") &&
+            planet.querySelector(".moonlink").classList.remove("mission-4");
+          if (
+            fleetDispatcher.targetPlanet.galaxy == targetCoords[0] &&
+            fleetDispatcher.targetPlanet.system == targetCoords[1] &&
+            fleetDispatcher.targetPlanet.position == targetCoords[2]
+          ) {
+            if (fleetDispatcher.targetPlanet.type == 1) {
+              planet.querySelector(".planetlink").classList.add("ogl-target");
+              planet
+                .querySelector(".planetlink")
+                .classList.add(`mission-${fleetDispatcher.mission}`);
+            } else if (planet.querySelector(".moonlink")) {
+              planet.querySelector(".moonlink").classList.add("ogl-target");
+              planet
+                .querySelector(".moonlink")
+                .classList.add(`mission-${fleetDispatcher.mission}`);
+            }
+          }
+        });
       };
       let dispatch = document
         .querySelector("#shipsChosen")
@@ -7133,6 +10896,42 @@ class OGInfinity {
       let coords = destination.appendChild(
         this.createDOM("div", { class: "ogl-coords" })
       );
+      document
+        .querySelectorAll("#buttonz .header")
+        .forEach((elem) => (elem.style.display = "none"));
+      document
+        .querySelectorAll("#buttonz .missionHeader")
+        .forEach((elem) => (elem.style.display = "none"));
+      document
+        .querySelectorAll("#buttonz .move-box-wrapper")
+        .forEach((elem) => (elem.style.display = "none"));
+      document
+        .querySelectorAll("#buttonz .footer")
+        .forEach((elem) => (elem.style.display = "none"));
+      document.querySelector("#target .coords").innerHTML = document
+        .querySelector("#target .coords")
+        .innerHTML.split("<br>\n")[1];
+      document.querySelector("#mission tr").style.display = "none";
+      document.querySelector("#start .coords").innerText =
+        "[" + document.querySelector("#start .coords span").innerText + "]";
+      document
+        .querySelector("#fleetboxdestination")
+        .parentNode.insertBefore(
+          this.createDOM("div", { id: "ogi-fleet2-ships" }),
+          document.querySelector("#fleetboxdestination").nextSibling
+        );
+      document
+        .querySelector("#ogi-fleet2-ships")
+        .appendChild(this.createDOM("div", { class: "content" }));
+      document
+        .querySelector("#ogi-fleet2-ships")
+        .appendChild(
+          this.createDOM(
+            "div",
+            { class: "ajax_loading", style: "display: none;" },
+            '<div class="ajax_loading_overlay"></div>'
+          )
+        );
       let warning = coords.appendChild(
         this.createDOM("a", {
           class: "ogl-warning tooltipRight",
@@ -7239,6 +11038,7 @@ class OGInfinity {
       );
 
       this.overwriteFleetDispatcher("stopLoading", false, () => {
+        let that = this;
         let missions = fleetDispatcher.getAvailableMissions();
         let warning = document.getElementsByClassName(
           "ogl-warning tooltipRight"
@@ -7247,20 +11047,24 @@ class OGInfinity {
         let iconsDiv;
         if (auxAjaxFailed) {
           missionsDiv.html(
-            '<span style="color: #9099a3"> No missions... </span>'
+            `<span style="color: #9099a3"> ${that.getTranslatedText(
+              111
+            )} </span>`
           );
           warning.style.visibility = "visible";
-          warning.setAttribute("data-title", "Error : No missions available");
+          warning.setAttribute("data-title", that.getTranslatedText(116));
           auxAjaxFailed = false;
         } else if (
           missions.length == 0 ||
           !fleetDispatcher.hasShipsSelected()
         ) {
           missionsDiv.html(
-            '<span style="color: #9099a3"> No missions... </span>'
+            `<span style="color: #9099a3"> ${that.getTranslatedText(
+              111
+            )} </span>`
           );
           warning.style.visibility = "visible";
-          warning.setAttribute("data-title", "Error : No ships selected");
+          warning.setAttribute("data-title", that.getTranslatedText(115));
         } else {
           warning.style.visibility = "hidden";
           missionsDiv.html(
@@ -7291,27 +11095,20 @@ class OGInfinity {
             fleetDispatcher.currentPage == "fleet1" ||
             (fleetDispatcher.currentPage == "fleet2" && missions.length > 0)
           ) {
-            if (!missions.includes(selectedMission)) {
-              selectedMission = null;
-            }
-
             if (missions.length == 1) {
               defaultMission = missions[0];
-            } else if (selectedMission) {
-              defaultMission = selectedMission;
-            } else if (
-              fleetDispatcher.getOwnPlanetName(
-                fleetDispatcher.targetPlanet,
-                fleetDispatcher.targetPlanet.type
-              )
-            ) {
-              defaultMission = that.json.options.harvestMission;
-            } else if (fleetDispatcher.targetIsBuddyOrAllyMember === true) {
-              defaultMission = 3;
-            } else if (fleetDispatcher.targetPlanet.position === 16) {
-              defaultMission = that.json.options.expeditionMission;
             } else {
-              defaultMission = that.json.options.foreignMission;
+              if (fleetDispatcher.mission == 0 || !missions.includes(fleetDispatcher.mission)) {
+                if (fleetDispatcher.targetPlanet.position === 16) {
+                  defaultMission = that.json.options.expeditionMission == 15 ? 15 : 6;
+                } else if (fleetDispatcher.targetIsBuddyOrAllyMember) {
+                  defaultMission = that.json.options.harvestMission;
+                } else {
+                  defaultMission = that.json.options.foreignMission;
+                }
+              } else {
+                defaultMission = fleetDispatcher.mission;
+              }
             }
           }
           let icon = document.querySelectorAll(
@@ -7323,10 +11120,10 @@ class OGInfinity {
           fleetDispatcher.selectMission(Number(defaultMission));
           $(".ogl-mission-icon").on("click", (e) => {
             $(".ogl-mission-icon").removeClass("ogl-active");
-            let missionClick = Number(e.target.getAttribute("mission"));
-            fleetDispatcher.selectMission(missionClick);
+            fleetDispatcher.selectMission(
+              Number(e.target.getAttribute("mission"))
+            );
             e.target.classList.add("ogl-active");
-            selectedMission = missionClick;
             update(false);
           });
           update(false);
@@ -7400,7 +11197,10 @@ class OGInfinity {
           fleetDispatcher.updateTarget();
           fleetDispatcher.fetchTargetPlayerData();
           update(true);
-        });
+        },
+        fleetDispatcher.targetPlanet,
+        fleetDispatcher.mission
+        );
         this.popup(false, container);
       });
       let briefing = destination.appendChild(
@@ -7435,6 +11235,7 @@ class OGInfinity {
             : '<div class="ogl-fleetSpeed">\n        <div data-step="1">10</div>\n        <div data-step="2">20</div>\n        <div data-step="3">30</div>\n        <div data-step="4">40</div>\n        <div data-step="5">50</div>\n        <div data-step="6">60</div>\n        <div data-step="7">70</div>\n        <div data-step="8">80</div>\n        <div data-step="9">90</div>\n        <div class="ogl-active" data-step="10">100</div>\n        </div>'
         )
       );
+      let oldDeut = null;
       $(".ogl-fleetSpeed div").on("click", (event) => {
         $(".ogl-fleetSpeed div").removeClass("ogl-active");
         fleetDispatcher.speedPercent = event.target.getAttribute("data-step");
@@ -7442,29 +11243,42 @@ class OGInfinity {
           `.ogl-fleetSpeed div[data-step="${fleetDispatcher.speedPercent}"]`
         ).addClass("ogl-active");
         update(false);
+        deutLeft.classList.remove("middlemark");
       });
       $(".ogl-fleetSpeed div").on("mouseover", (event) => {
         fleetDispatcher.speedPercent = event.target.getAttribute("data-step");
-        let old = deutLeft.innerText;
+        if (!oldDeut) oldDeut = deutFiller.value;
+        let old = fromFormatedNumber(deutLeft.innerText, true);
         update(false);
-        if (deutLeft.innerText != old) {
+        document.querySelector("input#deuterium").value = deutFiller.value;
+        if (fromFormatedNumber(deutLeft.innerText, true) != old) {
           deutLeft.classList.add("middlemark");
+          document
+            .querySelector(".ogi-deuteriumLeft")
+            .classList.add("middlemark");
         }
       });
       $(".ogl-fleetSpeed div").on("mouseout", (event) => {
         fleetDispatcher.speedPercent = slider
           .querySelector(".ogl-active")
           .getAttribute("data-step");
-        let middle = deutLeft.classList.contains("middlemark");
-        update(false);
-        if (middle) {
-          deutLeft.classList.add("middlemark");
+        deutFiller.value = oldDeut;
+        document.querySelector("input#deuterium").value = oldDeut;
+        oldDeut = null;
+        if (deutLeft.classList.contains("middlemark")) {
+          deutLeft.classList.remove("middlemark");
+          document
+            .querySelector(".ogi-deuteriumLeft")
+            .classList.remove("middlemark");
         }
+        update(false);
       });
       let missionsDiv = destination.appendChild(
         this.createDOM("div", { class: "ogl-missions", id: "missionsDiv" })
       );
-      missionsDiv.html('<span style="color: #9099a3"> No missions... </span>');
+      missionsDiv.html(
+        `<span style="color: #9099a3">${that.getTranslatedText(111)}</span>`
+      );
       let switchToPage = fleetDispatcher.switchToPage.bind(fleetDispatcher);
       let refresh = fleetDispatcher.refresh.bind(fleetDispatcher);
       let resetShips = fleetDispatcher.resetShips.bind(fleetDispatcher);
@@ -7478,6 +11292,7 @@ class OGInfinity {
         onResChange(2);
         onResChange(1);
         onResChange(0);
+        onShipsChange();
       };
       fleetDispatcher.resetShips = () => {
         resetShips();
@@ -7485,6 +11300,7 @@ class OGInfinity {
         onResChange(2);
         onResChange(1);
         onResChange(0);
+        onShipsChange();
       };
       let isDefaultMission = (index) => {
         if (this.rawURL.searchParams.get("mission") == 1) {
@@ -7633,7 +11449,11 @@ class OGInfinity {
       fleetDispatcher.displayErrors = function (errors) {
         document
           .querySelector(".ogl-dispatch .ogl-missions")
-          .html('<span style="color: #9099a3"> No missions... </span>');
+          .html(
+            `<span style="color: #9099a3"> ${that.getTranslatedText(
+              111
+            )} </span>`
+          );
         warning.style.visibility = "visible";
         document.querySelector("#continueToFleet2").style.filter =
           "hue-rotate(-50deg)";
@@ -7690,6 +11510,7 @@ class OGInfinity {
             fleetDispatcher.shipsToSend.map((elem) => elem.id)
           );
           let newTargetPlanet = JSON.stringify(fleetDispatcher.targetPlanet);
+          highlightFleetTarget();
           if (
             newFleet != fleet ||
             targetPlanet != newTargetPlanet ||
@@ -7731,11 +11552,15 @@ class OGInfinity {
           returnDiv.innerText = "-";
           document
             .querySelector(".ogl-dispatch .ogl-missions")
-            .html('<span style="color: #9099a3"> No missions... </span>');
+            .html(
+              `<span style="color: #9099a3"> ${that.getTranslatedText(
+                111
+              )} </span>`
+            );
           warning.style.visibility = "visible";
-          warning.setAttribute("data-title", "Error : current planet/moon...");
+          warning.setAttribute("data-title", that.getTranslatedText(117));
           if (noShips) {
-            warning.setAttribute("data-title", "Error : No ships selected...");
+            warning.setAttribute("data-title", that.getTranslatedText(115));
           }
           document.querySelector("#continueToFleet2").style.filter =
             "hue-rotate(-50deg)";
@@ -7787,16 +11612,17 @@ class OGInfinity {
             ) +
             "</strong>"
         );
-        consDiv.innerText = fleetDispatcher
-          .getConsumption()
-          .toLocaleString(separatorLang);
+        consDiv.innerText = toFormatedNumber(
+          fleetDispatcher.getConsumption(),
+          0
+        );
         if (fleetDispatcher.getConsumption() > deutAvailable) {
           consDiv.classList.add("overmark");
           if (!error) {
             warning.style.visibility = "visible";
             warning.setAttribute(
               "data-title",
-              "Error : No enough deuterium..."
+              fleetDispatcher.errorCodeMap[613]
             );
             document.querySelector("#continueToFleet2").style.filter =
               "hue-rotate(-50deg)";
@@ -7813,7 +11639,7 @@ class OGInfinity {
             getFormatedDate(
               new Date(serverTime).getTime() +
                 fleetDispatcher.getDuration() * 1e3,
-              "<strong> [G]:[i]:[s] </strong> - [d].[m]"
+              "[d].[m].[y] <strong> [G]:[i]:[s] </strong>"
             )
           );
           returnDiv.html(
@@ -7821,7 +11647,7 @@ class OGInfinity {
               new Date(serverTime).getTime() +
                 2 * fleetDispatcher.getDuration() * 1e3 +
                 (fleetDispatcher.mission == 15 ? 3600 : 0) * 1e3,
-              "<strong> [G]:[i]:[s] </strong> - [d].[m]"
+              "[d].[m].[y] <strong> [G]:[i]:[s] </strong>"
             )
           );
         }, 100);
@@ -7937,6 +11763,57 @@ class OGInfinity {
           src: "https://gf3.geo.gfsrv.net/cdnea/fa0c8ee62604e3af52e6ef297faf3c.gif",
         })
       );
+      if (!this.isMobile) {
+        [
+          metalFiller,
+          document.querySelector("input#metal"),
+          crystalFiller,
+          document.querySelector("input#crystal"),
+          deutFiller,
+          document.querySelector("input#deuterium")
+        ].forEach(elem => {
+          elem.addEventListener("keyup", (event) => {
+            const CODE = event.code;
+            let value =
+                fromFormatedNumber(event.target.value.replace("k", "")) || 0;
+            if (CODE === "ArrowUp" || CODE === "ArrowDown" || CODE === "KeyK") {
+              let add = event.ctrlKey ? 100 : event.shiftKey ? 10 : 1;
+              switch (CODE) {
+                case "ArrowUp":
+                  value = value + add;
+                  break;
+                case "ArrowDown":
+                  value = Math.max(value - add, 0);
+                  break;
+                case "KeyK":
+                  let factor = (value > 0 && elem.classList.contains("checkThousandSeparator")) ? 1 : 1000;
+                  value = (value || 1) * factor;
+                  break;
+              }
+            }
+            event.target.value = toFormatedNumber(value);
+          });
+        });
+      } else {
+        [
+          metalFiller,
+          document.querySelector("input#metal"),
+          crystalFiller,
+          document.querySelector("input#crystal"),
+          deutFiller,
+          document.querySelector("input#deuterium")
+        ].forEach(elem => {
+          elem.addEventListener("input", (event) => {
+            if (event.data == "K" || event.data == "k" || event.data == "0k") {
+              event.target.value = toFormatedNumber(1000);
+            } else {
+              let value =
+                fromFormatedNumber(event.target.value.replace("k", "000")) || 0;
+              event.target.value = toFormatedNumber(value);
+            }
+          });
+        });
+      }
       $("#selectMinMetal").after(
         this.createDOM("a", { id: "selectMostMetal", class: "select-most-min" })
       );
@@ -7952,6 +11829,10 @@ class OGInfinity {
           class: "select-most-min",
         })
       );
+      if (lifeforms)
+        $("#selectMaxFood").after(
+          this.createDOM("span", { class: "ogi-foodLeft" }, "-")
+        );
       $("#selectMaxMetal").after(
         this.createDOM("span", { class: "ogi-metalLeft" }, "-")
       );
@@ -7975,45 +11856,45 @@ class OGInfinity {
       });
       $("#selectMinMetal").on("click", () => {
         setTimeout(function () {
-          metalFiller.value = fleetDispatcher.cargoMetal;
+          metalFiller.value = toFormatedNumber(fleetDispatcher.cargoMetal, 0);
           refreshRes();
         }, 100);
       });
       $("#selectMaxMetal").on("click", () => {
         setTimeout(function () {
-          metalFiller.value = fleetDispatcher.cargoMetal;
+          metalFiller.value = toFormatedNumber(fleetDispatcher.cargoMetal, 0);
           refreshRes();
         }, 100);
       });
       $("#selectMinCrystal").on("click", () => {
         setTimeout(function () {
-          crystalFiller.value = fleetDispatcher.cargoCrystal;
+          crystalFiller.value = toFormatedNumber(fleetDispatcher.cargoCrystal,0);
           refreshRes();
         }, 100);
       });
       $("#selectMaxCrystal").on("click", () => {
         setTimeout(function () {
-          crystalFiller.value = fleetDispatcher.cargoCrystal;
+          crystalFiller.value = toFormatedNumber(fleetDispatcher.cargoCrystal,0);
           refreshRes();
         }, 100);
       });
       $("#selectMinDeuterium").on("click", () => {
         setTimeout(function () {
-          deutFiller.value = fleetDispatcher.cargoDeuterium;
+          deutFiller.value = toFormatedNumber(fleetDispatcher.cargoDeuterium,0);
           refreshRes();
         }, 100);
       });
       $("#selectMaxDeuterium").on("click", () => {
         setTimeout(function () {
-          deutFiller.value = fleetDispatcher.cargoDeuterium;
+          deutFiller.value = toFormatedNumber(fleetDispatcher.cargoDeuterium,0);
           refreshRes();
         }, 100);
       });
       $("#allresources").on("click", () => {
         setTimeout(function () {
-          metalFiller.value = fleetDispatcher.cargoMetal;
-          crystalFiller.value = fleetDispatcher.cargoCrystal;
-          deutFiller.value = fleetDispatcher.cargoDeuterium;
+          metalFiller.value = toFormatedNumber(fleetDispatcher.cargoMetal, 0);
+          crystalFiller.value = toFormatedNumber(fleetDispatcher.cargoCrystal,0);
+          deutFiller.value = toFormatedNumber(fleetDispatcher.cargoDeuterium,0);
           refreshRes();
         }, 100);
       });
@@ -8029,50 +11910,56 @@ class OGInfinity {
       document
         .querySelector("input[id=metal]")
         .addEventListener("keyup", (e) => {
-          let val = that.removeNumSeparator(
-            document.querySelector("input#metal").value
+          let val = fromFormatedNumber(
+            document.querySelector("input#metal").value,
+            true
           );
           let capacity = fleetDispatcher.getFreeCargoSpace();
           fleetDispatcher.cargoMetal = Math.min(
             Math.min(val, capacity + fleetDispatcher.cargoMetal),
             Math.max(0, metalAvailable)
           );
-          metalFiller.value = fleetDispatcher.cargoMetal;
+          metalFiller.value = toFormatedNumber(fleetDispatcher.cargoMetal, 0);
           fleetDispatcher.refresh();
           refreshRes();
         });
       document
         .querySelector("input[id=crystal]")
         .addEventListener("keyup", (e) => {
-          let val = that.removeNumSeparator(
-            document.querySelector("input#crystal").value
+          let val = fromFormatedNumber(
+            document.querySelector("input#crystal").value,
+            true
           );
           let capacity = fleetDispatcher.getFreeCargoSpace();
           fleetDispatcher.cargoCrystal = Math.min(
             Math.min(val, capacity + fleetDispatcher.cargoCrystal),
             Math.max(0, crystalAvailable)
           );
-          crystalFiller.value = fleetDispatcher.cargoCrystal;
+          crystalFiller.value = toFormatedNumber(fleetDispatcher.cargoCrystal,0);
           fleetDispatcher.refresh();
           refreshRes();
         });
       document
         .querySelector("input[id=deuterium]")
         .addEventListener("keyup", (e) => {
-          let val = that.removeNumSeparator(
-            document.querySelector("input#deuterium").value
+          let val = fromFormatedNumber(
+            document.querySelector("input#deuterium").value,
+            true
           );
           let capacity = fleetDispatcher.getFreeCargoSpace();
           fleetDispatcher.cargoDeuterium = Math.min(
             Math.min(val, capacity + fleetDispatcher.cargoDeuterium),
             Math.max(0, deutAvailable)
           );
-          deutFiller.value = fleetDispatcher.cargoDeuterium;
+          deutFiller.value = toFormatedNumber(fleetDispatcher.cargoDeuterium,0);
           fleetDispatcher.refresh();
           refreshRes();
         });
       let firstResRefresh = true;
       let refreshRes = () => {
+        let fLeft;
+        if (lifeforms)
+          fLeft = document.querySelector(".res_wrap .ogi-foodLeft");
         let mLeft = document.querySelector(".res_wrap .ogi-metalLeft");
         let cLeft = document.querySelector(".res_wrap .ogi-crystalLeft");
         let dLeft = document.querySelector(".res_wrap .ogi-deuteriumLeft");
@@ -8097,30 +11984,45 @@ class OGInfinity {
           mLeft.classList.remove("overmark");
           dLeft.classList.remove("overmark");
           dLeft.classList.remove("middlemark");
-          let val = this.removeNumSeparator(
-            document.querySelector("input#metal").value
+          let val = fromFormatedNumber(
+            document.querySelector("input#metal").value,
+            true
           );
-          mLeft.innerText = Math.max(0, metalAvailable - val).toLocaleString(
-            separatorLang
+          mLeft.innerText = toFormatedNumber(
+            Math.max(0, metalAvailable - val),
+            0
           );
-          val = this.removeNumSeparator(
-            document.querySelector("input#crystal").value
+          val = fromFormatedNumber(
+            document.querySelector("input#crystal").value,
+            true
           );
-          cLeft.innerText = Math.max(0, crystalAvailable - val).toLocaleString(
-            separatorLang
+          cLeft.innerText = toFormatedNumber(
+            Math.max(0, crystalAvailable - val),
+            0
           );
-          val = this.removeNumSeparator(
-            document.querySelector("input#deuterium").value
+          val = fromFormatedNumber(
+            document.querySelector("input#deuterium").value,
+            true
           );
-          dLeft.innerText = Math.max(
-            0,
-            deutAvailable - fleetDispatcher.getConsumption() - val
-          ).toLocaleString(separatorLang);
+          dLeft.innerText = toFormatedNumber(
+            Math.max(0, deutAvailable - fleetDispatcher.getConsumption() - val),
+            0
+          );
+          if (lifeforms) {
+            val = fromFormatedNumber(
+              document.querySelector("input#food").value,
+              true
+            );
+            fLeft.innerText = toFormatedNumber(
+              Math.max(0, foodAvailable - val),
+              0
+            );
+          }
         }
       };
       let kept =
         this.json.options.kept[
-          this.current.coords + this.current.isMoon ? "M" : "P"
+          this.current.coords + (this.current.isMoon ? "M" : "P")
         ] || this.json.options.defaultKept;
       $("#selectMostMetal").on("click", () => {
         let capacity = fleetDispatcher.getFreeCargoSpace();
@@ -8129,7 +12031,7 @@ class OGInfinity {
           fleetDispatcher.cargoMetal + capacity,
           Math.max(0, metalAvailable - (kept[0] || 0))
         );
-        metalFiller.value = fleetDispatcher.cargoMetal;
+        metalFiller.value = toFormatedNumber(fleetDispatcher.cargoMetal,0);
         fleetDispatcher.refresh();
         refreshRes();
       });
@@ -8139,7 +12041,7 @@ class OGInfinity {
           fleetDispatcher.cargoCrystal + capacity,
           Math.max(0, crystalAvailable - (kept[1] || 0))
         );
-        crystalFiller.value = fleetDispatcher.cargoCrystal;
+        crystalFiller.value = toFormatedNumber(fleetDispatcher.cargoCrystal,0);
         fleetDispatcher.refresh();
         refreshRes();
       });
@@ -8152,7 +12054,7 @@ class OGInfinity {
             deutAvailable - fleetDispatcher.getConsumption() - (kept[2] || 0)
           )
         );
-        deutFiller.value = fleetDispatcher.cargoDeuterium;
+        deutFiller.value = toFormatedNumber(fleetDispatcher.cargoDeuterium,0);
         fleetDispatcher.refresh();
         refreshRes();
       });
@@ -8160,11 +12062,31 @@ class OGInfinity {
         firstResRefresh = true;
       });
       $("#backToFleet1").on("click", () => {
-        if (fleetDispatcher.mission != 0) {
-          selectedMission = fleetDispatcher.mission;
-        }
         update(true);
       });
+      document
+        .querySelectorAll("#shipsChosen .technology .icon")
+        .forEach((elem) => {
+          elem.addEventListener("click", (event) => {
+            if (event.ctrlKey || event.metaKey) {
+              let shipId = elem.parentElement.getAttribute("data-technology");
+              let onPlanet = elem.firstElementChild.getAttribute("data-value");
+              let toSend = Math.max(0, onPlanet - (kept[shipId] || 0));
+              event.preventDefault();
+              event.stopPropagation();
+              let selected = fleetDispatcher.shipsToSend;
+              selected.forEach((ship) => {
+                if (ship.id == shipId && ship.number == toSend) {
+                  toSend = 0;
+                  elem.nextElementSibling.value = " ";
+                }
+              });
+              fleetDispatcher.selectShip(Number(shipId), toSend);
+              updateMissions();
+              document.querySelector("#continueToFleet2").focus();
+            }
+          });
+        });
       let load = this.createDOM("div", { class: "ogl-cargo" });
       let selectMostRes = load.appendChild(
         this.createDOM("a", { class: "select-most" })
@@ -8211,22 +12133,16 @@ class OGInfinity {
       });
       let updateCargo = () => {
         let total =
-          Number(this.removeNumSeparator(metalFiller.value)) +
-          Number(this.removeNumSeparator(crystalFiller.value)) +
-          Number(this.removeNumSeparator(deutFiller.value));
+          fromFormatedNumber(metalFiller.value) +
+          fromFormatedNumber(crystalFiller.value) +
+          fromFormatedNumber(deutFiller.value);
         let freeSpace = fleetDispatcher.getCargoCapacity() - total;
         bar.html(
           `<div class="fleft bar_container" data-current-amount="0" data-capacity="0">\n        <div class="filllevel_bar"></div>\n        </div>\n        <div>\n        <span class="${
             freeSpace >= 0 ? "undermark" : "overmark"
-          }">${freeSpace.toLocaleString(
-            document.getElementById("cookiebanner").getAttribute("data-locale")
-          )} </span>\n        / <span> ${fleetDispatcher
-            .getCargoCapacity()
-            .toLocaleString(
-              document
-                .getElementById("cookiebanner")
-                .getAttribute("data-locale")
-            )}</span>\n        </div>`
+          }">${toFormatedNumber(freeSpace, 0)} </span>\n        / <span> ${toFormatedNumber(
+            fleetDispatcher.getCargoCapacity(), 0
+          )}</span>\n        </div>`
         );
         let filler = document.querySelector(".ogl-cargo .filllevel_bar");
         let percent =
@@ -8249,11 +12165,14 @@ class OGInfinity {
         onResChange(0);
       });
       selectMaxMetal.addEventListener("click", () => {
-        metalFiller.value = metalAvailable;
+        metalFiller.value = toFormatedNumber(metalAvailable, 0);
         onResChange(0);
       });
       selectMostMetal.addEventListener("click", () => {
-        metalFiller.value = Math.max(0, metalAvailable - (kept[0] || 0));
+        metalFiller.value = toFormatedNumber(
+          Math.max(0, metalAvailable - (kept[0] || 0)),
+          0
+        );
         onResChange(0);
       });
       selectMinCrystal.addEventListener("click", () => {
@@ -8261,11 +12180,14 @@ class OGInfinity {
         onResChange(1);
       });
       selectMaxCrystal.addEventListener("click", () => {
-        crystalFiller.value = crystalAvailable;
+        crystalFiller.value = toFormatedNumber(crystalAvailable, 0);
         onResChange(1);
       });
       selectMostCrystal.addEventListener("click", () => {
-        crystalFiller.value = Math.max(0, crystalAvailable - (kept[1] || 0));
+        crystalFiller.value = toFormatedNumber(
+          Math.max(0, crystalAvailable - (kept[1] || 0)),
+          0
+        );
         onResChange(1);
       });
       selectMinDeut.addEventListener("click", () => {
@@ -8273,16 +12195,19 @@ class OGInfinity {
         onResChange(2);
       });
       selectMaxDeut.addEventListener("click", () => {
-        deutFiller.value = Math.max(
-          0,
-          deutAvailable - fleetDispatcher.getConsumption()
+        deutFiller.value = toFormatedNumber(
+          Math.max(0, deutAvailable - fleetDispatcher.getConsumption()),
+          0
         );
         onResChange(2);
       });
       selectMostDeut.addEventListener("click", () => {
-        deutFiller.value = Math.max(
-          0,
-          deutAvailable - fleetDispatcher.getConsumption() - (kept[2] || 0)
+        deutFiller.value = toFormatedNumber(
+          Math.max(
+            0,
+            deutAvailable - fleetDispatcher.getConsumption() - (kept[2] || 0)
+          ),
+          0
         );
         onResChange(2);
       });
@@ -8295,38 +12220,46 @@ class OGInfinity {
           class: "ogl-option ogl-fleet-ship ogl-fleet-202",
         })
       );
-      let ptNum = transport.appendChild(this.createDOM("span", {}, "-"));
+      let ptNum = transport.appendChild(
+        this.createDOM("span", { class: "tooltip" }, "-")
+      );
       let gtBtn = transport.appendChild(
         this.createDOM("a", {
           "tech-id": 203,
           class: "ogl-option ogl-fleet-ship ogl-fleet-203",
         })
       );
-      let gtNum = transport.appendChild(this.createDOM("span", {}, "-"));
+      let gtNum = transport.appendChild(
+        this.createDOM("span", { class: "tooltip" }, "-")
+      );
       let pfBtn = transport.appendChild(
         this.createDOM("a", {
           "tech-id": 219,
           class: "ogl-option ogl-fleet-ship ogl-fleet-219",
         })
       );
-      let pfNum = transport.appendChild(this.createDOM("span", {}, "-"));
+      let pfNum = transport.appendChild(
+        this.createDOM("span", { class: "tooltip" }, "-")
+      );
       let cyBtn = transport.appendChild(
         this.createDOM("a", {
           "tech-id": 209,
           class: "ogl-option ogl-fleet-ship ogl-fleet-209",
         })
       );
-      let cyNum = transport.appendChild(this.createDOM("span", {}, "-"));
+      let cyNum = transport.appendChild(this.createDOM("span", { class: "tooltip" }, "-"));
       let pbBtn;
       let pbNum;
-      if (this.json.pbFret != 0) {
+      if (this.json.ships[210].cargoCapacity != 0) {
         pbBtn = transport.appendChild(
           this.createDOM("a", {
             "tech-id": 210,
             class: "ogl-option ogl-fleet-ship ogl-fleet-210",
           })
         );
-        pbNum = transport.appendChild(this.createDOM("span", {}, "-"));
+        pbNum = transport.appendChild(
+          this.createDOM("span", { class: "tooltip" }, "-")
+        );
       }
       let updateShips = (e) => {
         let amount = e.target.nextElementSibling.getAttribute("amount");
@@ -8340,15 +12273,22 @@ class OGInfinity {
       gtBtn.addEventListener("click", updateShips);
       pfBtn.addEventListener("click", updateShips);
       cyBtn.addEventListener("click", updateShips);
-      if (pbBtn) pbBtn.addEventListener("click", updateShips);
+      if (pbBtn) {
+        pbBtn.addEventListener("click", updateShips);
+        ptBtn.classList.add("scale")
+        gtBtn.classList.add("scale")
+        pfBtn.classList.add("scale")
+        cyBtn.classList.add("scale")
+        pbBtn.classList.add("scale")
+      }
       let onResChange = (index) => {
         let capacity = fleetDispatcher.getCargoCapacity();
         if (capacity == 0) {
           fleetDispatcher.resetCargo();
         }
-        let filled = this.removeNumSeparator(deutFiller.value);
+        let filled = fromFormatedNumber(deutFiller.value);
         let deut = Math.min(
-          this.removeNumSeparator(deutFiller.value),
+          fromFormatedNumber(deutFiller.value),
           capacity,
           deutAvailable - fleetDispatcher.getConsumption()
         );
@@ -8358,40 +12298,42 @@ class OGInfinity {
             fleetDispatcher.cargoDeuterium + fleetDispatcher.getFreeCargoSpace()
           );
           let old = deutLeft.innerText;
-          deutLeft.innerText = (
+          deutLeft.innerText = toFormatedNumber(
             deutAvailable -
-            fleetDispatcher.getConsumption() -
-            fleetDispatcher.cargoDeuterium
-          ).toLocaleString(separatorLang);
+              fleetDispatcher.getConsumption() -
+              fleetDispatcher.cargoDeuterium,
+            0
+          );
           if (old != deutLeft.innerText || deutLeft.innerText == "0") {
             deutLeft.classList.remove("middlemark");
           }
           if (
             fleetDispatcher.getFreeCargoSpace() == 0 &&
-            deutLeft.innerText != "0"
+            deutLeft.innerText != "0" &&
+            deutLeft.innerText != toFormatedNumber(kept[2])
           ) {
             deutLeft.classList.add("overmark");
-            deutReal.innerText = Math.max(
-              0,
-              fleetDispatcher.cargoDeuterium
-            ).toLocaleString(separatorLang);
+            deutReal.innerText = toFormatedNumber(
+              Math.max(0, fleetDispatcher.cargoDeuterium),
+              0
+            );
           } else {
             deutLeft.classList.remove("overmark");
-            let currentDeut = deutAvailable - fleetDispatcher.getConsumption();
-            deutReal.innerText = currentDeut.toLocaleString(separatorLang);
+            deutReal.innerText = "-";
           }
           if (
             filled >
             Math.max(0, deutAvailable - fleetDispatcher.getConsumption())
           ) {
-            deutFiller.value = (
-              deutAvailable - fleetDispatcher.getConsumption()
-            ).toLocaleString(separatorLang);
+            deutFiller.value = toFormatedNumber(
+              deutAvailable - fleetDispatcher.getConsumption(),
+              0
+            );
           }
         } else if (index == 1) {
-          filled = this.removeNumSeparator(crystalFiller.value);
+          filled = fromFormatedNumber(crystalFiller.value);
           let crystal = Math.min(
-            this.removeNumSeparator(crystalFiller.value),
+            fromFormatedNumber(crystalFiller.value),
             capacity,
             crystalAvailable
           );
@@ -8399,27 +12341,28 @@ class OGInfinity {
             crystal,
             fleetDispatcher.cargoCrystal + fleetDispatcher.getFreeCargoSpace()
           );
-          crystalLeft.innerText = (
-            crystalAvailable - fleetDispatcher.cargoCrystal
-          ).toLocaleString(separatorLang);
+          crystalLeft.innerText = toFormatedNumber(
+            crystalAvailable - fleetDispatcher.cargoCrystal,
+            0
+          );
           if (
             fleetDispatcher.getFreeCargoSpace() == 0 &&
-            crystalLeft.innerText != "0"
+            crystalLeft.innerText != "0" &&
+            crystalLeft.innerText != toFormatedNumber(kept[1])
           ) {
             crystalLeft.classList.add("overmark");
-            crystalReal.innerText = Math.max(
-              0,
-              fleetDispatcher.cargoCrystal
-            ).toLocaleString(separatorLang);
+            crystalReal.innerText = toFormatedNumber(
+              Math.max(0, fleetDispatcher.cargoCrystal),
+              0
+            );
           } else {
             crystalLeft.classList.remove("overmark");
-            crystalReal.innerText =
-              crystalAvailable.toLocaleString(separatorLang);
+            crystalReal.innerText = "-";
           }
         } else if (index == 0) {
-          filled = this.removeNumSeparator(metalFiller.value);
+          filled = fromFormatedNumber(metalFiller.value);
           let metal = Math.min(
-            this.removeNumSeparator(metalFiller.value),
+            fromFormatedNumber(metalFiller.value),
             capacity,
             metalAvailable
           );
@@ -8427,21 +12370,23 @@ class OGInfinity {
             metal,
             fleetDispatcher.cargoMetal + fleetDispatcher.getFreeCargoSpace()
           );
-          metalLeft.innerText = (
-            metalAvailable - fleetDispatcher.cargoMetal
-          ).toLocaleString(separatorLang);
+          metalLeft.innerText = toFormatedNumber(
+            metalAvailable - fleetDispatcher.cargoMetal,
+            0
+          );
           if (
             fleetDispatcher.getFreeCargoSpace() == 0 &&
-            metalLeft.innerText != "0"
+            metalLeft.innerText != "0" &&
+            metalLeft.innerText != toFormatedNumber(kept[0])
           ) {
             metalLeft.classList.add("overmark");
-            metalReal.innerText = Math.max(
-              0,
-              fleetDispatcher.cargoMetal
-            ).toLocaleString(separatorLang);
+            metalReal.innerText = toFormatedNumber(
+              Math.max(0, fleetDispatcher.cargoMetal),
+              0
+            );
           } else {
             metalLeft.classList.remove("overmark");
-            metalReal.innerText = metalAvailable.toLocaleString(separatorLang);
+            metalReal.innerText = "-";
           }
         }
         let ships = {};
@@ -8454,28 +12399,52 @@ class OGInfinity {
         cyNum.classList.remove("overmark");
         if (pbNum) pbNum.classList.remove("overmark");
         let amount = needCargo(202);
-        ptNum.innerText = amount.toLocaleString(separatorLang);
+        ptNum.innerText = toFormatedNumber(amount, null, amount > 999999);
+        ptNum.setAttribute("data-title", toFormatedNumber(amount));
         ptNum.setAttribute("amount", amount);
         if (amount > (ships[202] || 0)) ptNum.classList.add("overmark");
         amount = needCargo(203);
-        gtNum.innerText = amount.toLocaleString(separatorLang);
+        gtNum.innerText = toFormatedNumber(amount, null, amount > 999999);
+        gtNum.setAttribute("data-title", toFormatedNumber(amount));
         gtNum.setAttribute("amount", amount);
         if (amount > (ships[203] || 0)) gtNum.classList.add("overmark");
         amount = needCargo(219);
-        pfNum.innerText = amount.toLocaleString(separatorLang);
+        pfNum.innerText = toFormatedNumber(amount, null, amount > 999999);
+        pfNum.setAttribute("data-title", toFormatedNumber(amount));
         pfNum.setAttribute("amount", amount);
         if (amount > (ships[219] || 0)) pfNum.classList.add("overmark");
         amount = needCargo(209);
-        cyNum.innerText = amount.toLocaleString(separatorLang);
+        cyNum.innerText = toFormatedNumber(amount, null, amount > 999999);
+        cyNum.setAttribute("data-title", toFormatedNumber(amount));
         cyNum.setAttribute("amount", amount);
         if (amount > (ships[209] || 0)) cyNum.classList.add("overmark");
         if (pbBtn) {
           amount = needCargo(210);
-          pbNum.innerText = amount.toLocaleString(separatorLang);
+          pbNum.innerText = toFormatedNumber(amount, null, amount > 999999);
+          pbNum.setAttribute("data-title", toFormatedNumber(amount));
           pbNum.setAttribute("amount", amount);
           if (amount > (ships[210] || 0)) pbNum.classList.add("overmark");
         }
         updateCargo();
+      };
+      let onShipsChange = () => {
+        let fleetSelected = "";
+        fleetDispatcher.shipsToSend.forEach((ship) => {
+          fleetSelected += `<div tech-id="${
+            ship.id
+          }" class="ogl-option ogl-fleet-ship ogl-fleet-${
+            ship.id
+          }"></div><span class="tooltip" data-title="${this.getTranslatedText(
+            ship.id,
+            'tech'
+          )}: ${toFormatedNumber(ship.number, 0)}">${toFormatedNumber(
+            ship.number,
+            null,
+            ship.number > 999999
+          )}</span>`;
+        });
+        document.querySelector("#ogi-fleet2-ships .content").innerHTML =
+          fleetSelected;
       };
       metalFiller.addEventListener("keyup", (e) => {
         onResChange(0);
@@ -8491,9 +12460,9 @@ class OGInfinity {
       });
       if (this.mode == 2 || this.mode == 1) {
         if (this.mode == 1) {
-          metalFiller.value = metalAvailable;
-          crystalFiller.value = crystalAvailable;
-          deutFiller.value = deutAvailable;
+          metalFiller.value = toFormatedNumber(metalAvailable, 0);
+          crystalFiller.value = toFormatedNumber(crystalAvailable, 0);
+          deutFiller.value = toFormatedNumber(deutAvailable, 0);
         } else if (this.mode == 2) {
           let coords =
             fleetDispatcher.targetPlanet.galaxy +
@@ -8508,23 +12477,24 @@ class OGInfinity {
               : "P";
           let missing = this.json.missing[coords];
           if (missing) {
-            metalFiller.value = Math.min(
-              missing[0],
-              fleetDispatcher.metalOnPlanet
+            metalFiller.value = toFormatedNumber(
+              Math.min(missing[0], fleetDispatcher.metalOnPlanet),
+              0
             );
-            crystalFiller.value = Math.min(
-              missing[1],
-              fleetDispatcher.crystalOnPlanet
+            crystalFiller.value = toFormatedNumber(
+              Math.min(missing[1], fleetDispatcher.crystalOnPlanet),
+              0
             );
-            deutFiller.value = Math.min(
-              missing[2],
-              fleetDispatcher.deuteriumOnPlanet
+            deutFiller.value = toFormatedNumber(
+              Math.min(missing[2], fleetDispatcher.deuteriumOnPlanet),
+              0
             );
           }
         }
         onResChange(2);
         onResChange(1);
         onResChange(0);
+        this.selectBestCargoShip();
       }
       update(false);
     }
@@ -8533,7 +12503,7 @@ class OGInfinity {
   neededCargo() {
     let kept =
       this.json.options.kept[
-        this.current.coords + this.current.isMoon ? "M" : "P"
+        this.current.coords + (this.current.isMoon ? "M" : "P")
       ] || this.json.options.defaultKept;
     if (this.page == "fleetdispatch" && document.querySelector("#shipChosen")) {
       shipsOnPlanet.forEach((ship) => {
@@ -8551,11 +12521,7 @@ class OGInfinity {
           let span = this.createDOM(
             "span",
             { class: "ogl-needed" },
-            amount.toLocaleString(
-              document
-                .getElementById("cookiebanner")
-                .getAttribute("data-locale")
-            )
+            toFormatedNumber(amount, 0)
           );
           document
             .querySelector(`.technology[data-technology="${ship.id}"]`)
@@ -8599,7 +12565,11 @@ class OGInfinity {
     });
   }
 
-  openPlanetList(callcback) {
+  openPlanetList(
+    callcback,
+    target = fleetDispatcher.targetPlanet,
+    mission = fleetDispatcher.mission
+  ) {
     let container = this.createDOM("div", {
       class: "ogl-dialogContainer ogl-quickLinks",
     });
@@ -8620,6 +12590,17 @@ class OGInfinity {
         (planet == this.current.planet && this.current.isMoon && type == 3)
       ) {
         div.classList.add("ogl-current");
+        div.classList.add(`mission-${mission}`);
+      }
+      if (
+        target &&
+        galaxy == target.galaxy &&
+        system == target.system &&
+        position == target.position &&
+        type == target.type
+      ) {
+        div.classList.add("ogl-target");
+        div.classList.add(`mission-${mission}`);
       }
       return div;
     };
@@ -8822,74 +12803,109 @@ class OGInfinity {
           this.calcNeededShips({ fret: 203, resources: maxTotal })
         );
         if (!document.querySelector("#allornone .allornonewrap")) return;
-        let ptExpe = document
+        let expCargoChoice = this.createDOM("div", {
+          class: "ogk-expedition-cargo",
+        });
+        let expType = this.json.options.expFret || 203;
+        let expCount = expType == 202 ? maxPT : maxGT;
+        let btnExpe = document
           .querySelector("#allornone .secondcol")
           .appendChild(
-            this.createDOM("button", { class: "ogl-prefab ogl-ptexpe" })
+            this.createDOM("button", {
+              class: `ogl-expedition ${
+                expType == 203 ? "largeCargo" : "smallCargo"
+              } `,
+            })
           );
-        let gtExpe = document
-          .querySelector("#allornone .secondcol")
-          .appendChild(
-            this.createDOM("button", { class: "ogl-prefab ogl-gtexpe" })
-          );
+        let sc = expCargoChoice.appendChild(
+          this.createDOM("div", {
+            class: "ogl-option ogl-fleet-ship choice ogl-fleet-202",
+          })
+        );
+        let lc = expCargoChoice.appendChild(
+          this.createDOM("div", {
+            class: "ogl-option ogl-fleet-ship choice ogl-fleet-203",
+          })
+        );
+        let updateDefaultExpoShip = (id) => {
+          this.json.options.expFret = id;
+          this.saveData();
+          location.reload();
+        };
+        sc.addEventListener("click", () => updateDefaultExpoShip(202));
+        lc.addEventListener("click", () => updateDefaultExpoShip(203));
+        btnExpe.addEventListener("mouseover", () =>
+          this.tooltip(btnExpe, expCargoChoice, false, false, 750)
+        );
         let coords = this.current.coords.split(":");
-        [ptExpe, gtExpe].forEach((btn) => {
-          btn.addEventListener("click", () => {
-            this.expedition = true;
-            document.querySelector("#resetall").click();
-            let type;
-            let count;
-            switch (btn) {
-              case ptExpe:
-                type = 202;
-                count = maxPT;
-                break;
-              case gtExpe:
-                type = 203;
-                count = maxGT;
-                break;
-              default:
+        btnExpe.addEventListener("click", () => {
+          document.querySelector("#resetall").click();
+          this.expedition = true;
+          this.collect = false;
+          this.json.href = undefined;
+          this.saveData();
+          let prio = [218, 213, 211, 215, 207];
+          let bigship = 0;
+          prio.forEach((shipID) => {
+            if (
+              bigship == 0 &&
+              document
+                .querySelector(
+                  `.technology[data-technology="${shipID}"] .amount`
+                )
+                .getAttribute("data-value") > 0
+            ) {
+              bigship = shipID;
             }
-            let prio = [218, 213, 211, 215, 207];
-            let bigship = 0;
-            prio.forEach((shipID) => {
-              if (
-                bigship == 0 &&
-                document
-                  .querySelector(
-                    `.technology[data-technology="${shipID}"] .amount`
-                  )
-                  .getAttribute("data-value") > 0
-              ) {
-                bigship = shipID;
-              }
-            });
-            let inputs = document.querySelectorAll(".ogl-coords input");
-            inputs[0].value = coords[0];
-            inputs[1].value = coords[1];
-            inputs[2].value = 16;
-            shipsOnPlanet.forEach((ship) => {
-              if (ship.id == type) this.selectShips(ship.id, count);
-              else if (ship.id == bigship) this.selectShips(ship.id, 1);
-              else if (ship.id == 210) this.selectShips(ship.id, 1);
-              else if (ship.id == 219) this.selectShips(ship.id, 1);
-            });
-            fleetDispatcher.targetPlanet.type = 1;
-            fleetDispatcher.targetPlanet.position = 16;
-            fleetDispatcher.refreshTarget();
-            fleetDispatcher.updateTarget();
-            fleetDispatcher.fetchTargetPlayerData();
-            fleetDispatcher.refresh();
-            document.querySelector("#expeditiontime").value =
-              this.json.options.expeditionDefaultTime || 1;
-            document
-              .querySelector(".ogl-moon-icon")
-              .classList.remove("ogl-active");
-            document
-              .querySelector(".ogl-planet-icon")
-              .classList.add("ogl-active");
-            this.expedition = false;
           });
+          let inputs = document.querySelectorAll(".ogl-coords input");
+          inputs[0].value = coords[0];
+          inputs[1].value = coords[1];
+          inputs[2].value = 16;
+          let expShips = [0, 0, 0, 0];
+          shipsOnPlanet.forEach((ship) => {
+            if (ship.id == expType)
+              expShips[0] = this.selectShips(ship.id, expCount);
+            else if (ship.id == bigship)
+              expShips[1] = this.selectShips(ship.id, 1);
+            else if (ship.id == 210) expShips[2] = this.selectShips(ship.id, 1);
+            else if (ship.id == 219) expShips[3] = this.selectShips(ship.id, 1);
+          });
+          let fadeText = "";
+          let noFade = true;
+          if (expShips[0] != expCount) {
+            fadeText += this.getTranslatedText(107) + "<br>";
+            noFade = false;
+          }
+          if (expShips[1] != 1) {
+            fadeText += this.getTranslatedText(108) + "<br>";
+            noFade = false;
+          }
+          if (expShips[2] != 1) {
+            fadeText += this.getTranslatedText(109) + "<br>";
+            noFade = false;
+          }
+          if (expShips[3] != 1) {
+            fadeText += this.getTranslatedText(110) + "<br>";
+            noFade = false;
+          }
+          if (!noFade) fadeBox(fadeText, true);
+          document.querySelector(".send_none").click();
+          fleetDispatcher.targetPlanet.type = 1;
+          fleetDispatcher.targetPlanet.position = 16;
+          fleetDispatcher.refreshTarget();
+          fleetDispatcher.updateTarget();
+          fleetDispatcher.fetchTargetPlayerData();
+          fleetDispatcher.refresh();
+          document.querySelector("#expeditiontime").value =
+            this.json.options.expeditionDefaultTime || 1;
+          document
+            .querySelector(".ogl-moon-icon")
+            .classList.remove("ogl-active");
+          document
+            .querySelector(".ogl-planet-icon")
+            .classList.add("ogl-active");
+          this.expedition = false;
         });
       });
     }
@@ -9022,6 +13038,7 @@ class OGInfinity {
           if (planet.moonID) {
             hasMoon = true;
           }
+          planet.invalidate = false;
         });
         if (hasMoon) {
           return fetch(
@@ -9045,6 +13062,7 @@ class OGInfinity {
                       }
                     }
                     planet.moon = moon;
+                    planet.moon.invalidate = false;
                   }
                 });
               });
@@ -9061,74 +13079,113 @@ class OGInfinity {
       deut = 0;
     let fleetCount = {};
     let uniques = {};
+    let transports = {};
     let ids = [];
     let planets = {};
     document.querySelectorAll(".eventFleet").forEach((line) => {
-      let tooltip = line.querySelector(".tooltip.tooltipClose");
+      let tooltip = line.querySelector(".tooltip");
       let id = Number(line.getAttribute("id").split("-")[1]);
       let back =
         line.getAttribute("data-return-flight") == "false" ? false : true;
       let type = line.getAttribute("data-mission-type");
-      let time = line.getAttribute("data-arrival-time");
-      let coords = line
+      let arrival = new Date(
+        parseInt(line.getAttribute("data-arrival-time")) * 1e3
+      );
+      let originCoords = line
         .querySelector(".coordsOrigin > a")
         .innerText.trim()
         .slice(1, -1);
+      let originName = line.querySelector(".originFleet").innerText.trim();
       let destCoords = line
         .querySelector(".destCoords > a")
         .innerText.trim()
         .slice(1, -1);
-      let destIsMoon = document.querySelector(".destFleet .moon");
-      let originIsMoon = document.querySelector(".originFleet .moon");
-      let origin = coords + (originIsMoon ? "M" : "P");
+      let destName = line.querySelector(".destFleet").innerText.trim();
+      let destIsMoon = line.querySelector(".destFleet .moon");
+      let originIsMoon = line.querySelector(".originFleet .moon");
+      let origin = originCoords + (originIsMoon ? "M" : "P");
       let dest = destCoords + (destIsMoon ? "M" : "P");
+      let own = false;
+      this.json.empire.forEach((planet) => {
+        if (planet.coordinates == line.children[4].innerText.trim()) own = true;
+      });
       let movement = {
         id: id,
-        origin: back ? dest : origin,
-        dest: back ? origin : dest,
         type: type,
+        own: own,
+        origin: origin,
+        originName: originName,
+        dest: dest,
+        destName: destName,
+        back: back,
+        arrival: arrival,
+        resDest: false,
+        metal: undefined,
+        crystal: undefined,
+        deuterium: undefined,
+        fleet: {},
       };
-      if (type == 16) return;
+      if (type == 16 || type == 18) return;
       let expe = {};
-      if (type == 4 || (back && !(id - 1 in uniques) && !(id - 2 in uniques))) {
+      let div = document.createElement("div");
+      div.html(
+        tooltip.getAttribute("title") || tooltip.getAttribute("data-title")
+      );
+      let addToTotal = false;
+      if (
+        type == 4 ||
+        (type != 3 && back && !(id - 1 in uniques) && !(id - 2 in uniques))
+      ) {
         uniques[id] = true;
-        let div = document.createElement("div");
-        div.html(
-          tooltip.getAttribute("title") || tooltip.getAttribute("data-title")
+        addToTotal = true;
+        movement.resDest = true;
+      }
+      let noRes = false;
+      if (type == 3 && !back) {
+        transports[id] = true;
+        addToTotal = true;
+        movement.resDest = true;
+      }
+      if (type == 3 && back && id - 1 in transports) {
+        noRes = true;
+      } else {
+        addToTotal = true;
+        movement.resDest = true;
+      }
+      div.querySelectorAll('td[colspan="2"]').forEach((tooltip) => {
+        let count = Number(
+          tooltip.nextElementSibling.innerHTML.trim().split(".").join("")
         );
-        div.querySelectorAll('td[colspan="2"]').forEach((tooltip) => {
-          let count = Number(
-            this.removeNumSeparator(tooltip.nextElementSibling.innerHTML.trim())
-          );
-          let name = tooltip.innerText.trim().slice(0, -1);
-          let id = this.json.shipNames[name];
-          if (id) {
-            expe[id] ? (expe[id] += count) : (expe[id] = count);
+        let name = tooltip.innerText.trim().slice(0, -1);
+        let id = this.json.shipNames[name];
+        if (id) {
+          expe[id] ? (expe[id] += count) : (expe[id] = count);
+          movement.fleet[id] = count;
+          if (addToTotal)
             fleetCount[id]
               ? (fleetCount[id] += count)
               : (fleetCount[id] = count);
-          } else {
-            if (!planets[coords]) {
-              planets[coords] = { metal: 0, crystal: 0, deuterium: 0 };
+        } else {
+          if (!planets[originCoords]) {
+              planets[originCoords] = { metal: 0, crystal: 0, deuterium: 0 };
             }
-            if (name == this.json.resNames[0]) {
-              movement.metal = count;
-              met += count;
-              planets[coords].metal += count;
-            }
-            if (name == this.json.resNames[1]) {
-              movement.crystal = count;
-              cri += count;
-              planets[coords].crystal += count;
-            }
-            if (name == this.json.resNames[2]) {
-              movement.deuterium = count;
-              deut += count;
-              planets[coords].deuterium += count;
-            }
+          if (name == this.json.resNames[0]) {
+            movement.metal = noRes ? 0 : count;
+            if (addToTotal) met += count;
+            planets[originCoords].metal += count;
           }
-        });
-      }
+          if (name == this.json.resNames[1]) {
+            movement.crystal = noRes ? 0 : count;
+            if (addToTotal) cri += count;
+            planets[originCoords].crystal += count;
+          }
+          if (name == this.json.resNames[2]) {
+            movement.deuterium = noRes ? 0 : count;
+            if (addToTotal) deut += count;
+            planets[originCoords].deuterium += count;
+          }
+        }
+      });
       ids.push(movement);
     });
     let t = {
@@ -9188,18 +13245,14 @@ class OGInfinity {
   updateresourceDetail() {
     if (!this.json.options.empire) return;
     if (!document.querySelector(".ogl-metal")) return;
+    this.getFlyingRes();
     let mSumP = 0,
       cSumP = 0,
       dSumP = 0;
     let mSumM = 0,
       cSumM = 0,
       dSumM = 0;
-    let emulatedEmpire = [];
-    let empire = this.json.empire;
-    if (emulatedEmpire.length != 0) {
-      empire = emulatedEmpire;
-    }
-    empire.forEach((planet) => {
+    this.json.empire.forEach((planet) => {
       let planetNode = document.querySelector(`div[id=planet-${planet.id}]`);
       let isFullM = planet.metalStorage - planet.metal > 0 ? "" : " ogl-full";
       let isFullC =
@@ -9219,64 +13272,314 @@ class OGInfinity {
         planet.production.hourly[2] * 2
           ? ""
           : " ogl-afull";
+      let [resPlanet, resMoon] = planetNode.querySelectorAll(".ogl-res");
+      resPlanet.classList.remove("ogi-invalidate");
+      if (planet.invalidate) {
+        resPlanet.classList.add("ogi-invalidate");
+      }
       let metalRess = planetNode.querySelectorAll(".ogl-metal");
       let crystalRess = planetNode.querySelectorAll(".ogl-crystal");
       let deutRess = planetNode.querySelectorAll(".ogl-deut");
+      if (metalRess.length > 0) {
+        metalRess[0].innerText = toFormatedNumber(
+          Math.floor(planet.metal),
+          null,
+          true
+        );
+        metalRess[0].setAttribute(
+          "data-title",
+          toFormatedNumber(Math.floor(planet.metal))
+        );
+      }
+      if (crystalRess.length > 0) {
+        crystalRess[0].innerText = toFormatedNumber(
+          Math.floor(planet.crystal),
+          null,
+          true
+        );
+        crystalRess[0].setAttribute(
+          "data-title",
+          toFormatedNumber(Math.floor(planet.crystal))
+        );
+      }
+      if (deutRess.length > 0) {
+        deutRess[0].innerText = toFormatedNumber(
+          Math.floor(planet.deuterium),
+          null,
+          true
+        );
+        deutRess[0].setAttribute(
+          "data-title",
+          toFormatedNumber(Math.floor(planet.deuterium))
+        );
+      }
       if (metalRess.length > 0)
-        metalRess[0].innerText = this.formatToUnits(planet.metal);
+        metalRess[0].classList = "ogl-metal tooltip " + isFullM + isaFullM;
       if (crystalRess.length > 0)
-        crystalRess[0].innerText = this.formatToUnits(planet.crystal);
+        crystalRess[0].classList = "ogl-crystal tooltip " + isFullC + isaFullC;
       if (deutRess.length > 0)
-        deutRess[0].innerText = this.formatToUnits(planet.deuterium);
-      if (metalRess.length > 0)
-        metalRess[0].classList = "ogl-metal " + isFullM + isaFullM;
-      if (crystalRess.length > 0)
-        crystalRess[0].classList = "ogl-crystal " + isFullC + isaFullC;
-      if (deutRess.length > 0)
-        deutRess[0].classList = "ogl-deut " + isFullD + isaFullD;
+        deutRess[0].classList = "ogl-deut tooltip " + isFullD + isaFullD;
       mSumP += planet.metal;
       cSumP += planet.crystal;
       dSumP += planet.deuterium;
       if (planet.moon != undefined && metalRess.length > 0 && metalRess[1]) {
-        metalRess[1].innerText = this.formatToUnits(planet.moon.metal);
-        crystalRess[1].innerText = this.formatToUnits(planet.moon.crystal);
-        deutRess[1].innerText = this.formatToUnits(planet.moon.deuterium);
+        resMoon.classList.remove("ogi-invalidate");
+        if (planet.moon.invalidate) {
+          resMoon.classList.add("ogi-invalidate");
+        }
+        metalRess[1].innerText = toFormatedNumber(
+          Math.floor(planet.moon.metal),
+          null,
+          true
+        );
+        metalRess[1].setAttribute(
+          "data-title",
+          toFormatedNumber(Math.floor(planet.moon.metal))
+        );
+        crystalRess[1].innerText = toFormatedNumber(
+          Math.floor(planet.moon.crystal),
+          null,
+          true
+        );
+        crystalRess[1].setAttribute(
+          "data-title",
+          toFormatedNumber(Math.floor(planet.moon.crystal))
+        );
+        deutRess[1].innerText = toFormatedNumber(
+          Math.floor(planet.moon.deuterium),
+          null,
+          true
+        );
+        deutRess[1].setAttribute(
+          "data-title",
+          toFormatedNumber(Math.floor(planet.moon.deuterium))
+        );
         mSumM += planet.moon.metal;
         cSumM += planet.moon.crystal;
         dSumM += planet.moon.deuterium;
       }
       let sumNodes = document.querySelectorAll(".ogl-summary");
       sumNodes[0].querySelectorAll(".ogl-metal")[0].innerText =
-        this.formatToUnits(mSumP);
+        toFormatedNumber(Math.floor(mSumP), null, true);
+      sumNodes[0]
+        .querySelectorAll(".ogl-metal")[0]
+        .setAttribute("data-title", toFormatedNumber(Math.floor(mSumP)));
+      sumNodes[0]
+        .querySelectorAll(".ogl-metal")[0]
+        .setAttribute("class", "ogl-metal tooltip");
       sumNodes[0].querySelectorAll(".ogl-crystal")[0].innerText =
-        this.formatToUnits(cSumP);
-      sumNodes[0].querySelectorAll(".ogl-deut")[0].innerText =
-        this.formatToUnits(dSumP);
+        toFormatedNumber(Math.floor(cSumP), null, true);
+      sumNodes[0]
+        .querySelectorAll(".ogl-crystal")[0]
+        .setAttribute("data-title", toFormatedNumber(Math.floor(cSumP)));
+      sumNodes[0]
+        .querySelectorAll(".ogl-crystal")[0]
+        .setAttribute("class", "ogl-crystal tooltip");
+      sumNodes[0].querySelectorAll(".ogl-deut")[0].innerText = toFormatedNumber(
+        Math.floor(dSumP),
+        null,
+        true
+      );
+      sumNodes[0]
+        .querySelectorAll(".ogl-deut")[0]
+        .setAttribute("data-title", toFormatedNumber(Math.floor(dSumP)));
+      sumNodes[0]
+        .querySelectorAll(".ogl-deut")[0]
+        .setAttribute("class", "ogl-deut tooltip");
+
       sumNodes[0].querySelectorAll(".ogl-metal")[1].innerText =
-        this.formatToUnits(mSumM);
+        toFormatedNumber(Math.floor(mSumM), null, true);
+      sumNodes[0]
+        .querySelectorAll(".ogl-metal")[1]
+        .setAttribute("data-title", toFormatedNumber(Math.floor(mSumM)));
+      sumNodes[0]
+        .querySelectorAll(".ogl-metal")[1]
+        .setAttribute("class", "ogl-metal tooltip");
       sumNodes[0].querySelectorAll(".ogl-crystal")[1].innerText =
-        this.formatToUnits(cSumM);
-      sumNodes[0].querySelectorAll(".ogl-deut")[1].innerText =
-        this.formatToUnits(dSumM);
-      sumNodes[1].querySelector(".ogl-metal").innerText = this.formatToUnits(
-        this.json.flying.metal
+        toFormatedNumber(Math.floor(cSumM), null, true);
+      sumNodes[0]
+        .querySelectorAll(".ogl-crystal")[1]
+        .setAttribute("data-title", toFormatedNumber(Math.floor(cSumM)));
+      sumNodes[0]
+        .querySelectorAll(".ogl-crystal")[1]
+        .setAttribute("class", "ogl-crystal tooltip");
+      sumNodes[0].querySelectorAll(".ogl-deut")[1].innerText = toFormatedNumber(
+        Math.floor(dSumM),
+        null,
+        true
       );
-      sumNodes[1].querySelector(".ogl-crystal").innerText = this.formatToUnits(
-        this.json.flying.crystal
+      sumNodes[0]
+        .querySelectorAll(".ogl-deut")[1]
+        .setAttribute("data-title", toFormatedNumber(Math.floor(dSumM)));
+      sumNodes[0]
+        .querySelectorAll(".ogl-deut")[1]
+        .setAttribute("class", "ogl-deut tooltip");
+
+      sumNodes[1].querySelector(".ogl-metal").innerText = toFormatedNumber(
+        Math.floor(this.json.flying.metal),
+        null,
+        true
       );
-      sumNodes[1].querySelector(".ogl-deut").innerText = this.formatToUnits(
-        this.json.flying.deuterium
+      sumNodes[1]
+        .querySelector(".ogl-metal")
+        .setAttribute(
+          "data-title",
+          toFormatedNumber(Math.floor(this.json.flying.metal))
+        );
+      sumNodes[1]
+        .querySelector(".ogl-metal")
+        .setAttribute("class", "ogl-metal tooltip");
+
+      sumNodes[1].querySelector(".ogl-crystal").innerText = toFormatedNumber(
+        Math.floor(this.json.flying.crystal),
+        null,
+        true
       );
-      sumNodes[2].querySelector(".ogl-metal").innerText = this.formatToUnits(
-        mSumP + mSumM + this.json.flying.metal
+      sumNodes[1]
+        .querySelector(".ogl-crystal")
+        .setAttribute(
+          "data-title",
+          toFormatedNumber(Math.floor(this.json.flying.crystal))
+        );
+      sumNodes[1]
+        .querySelector(".ogl-crystal")
+        .setAttribute("class", "ogl-crystal tooltip");
+
+      sumNodes[1].querySelector(".ogl-deut").innerText = toFormatedNumber(
+        Math.floor(this.json.flying.deuterium),
+        null,
+        true
       );
-      sumNodes[2].querySelector(".ogl-crystal").innerText = this.formatToUnits(
-        cSumP + cSumM + this.json.flying.crystal
+      sumNodes[1]
+        .querySelector(".ogl-deut")
+        .setAttribute(
+          "data-title",
+          toFormatedNumber(Math.floor(this.json.flying.deuterium))
+        );
+      sumNodes[1]
+        .querySelector(".ogl-deut")
+        .setAttribute("class", "ogl-deut tooltip");
+
+      sumNodes[2].querySelector(".ogl-metal").innerText = toFormatedNumber(
+        Math.floor(mSumP + mSumM + this.json.flying.metal),
+        null,
+        true
       );
-      sumNodes[2].querySelector(".ogl-deut").innerText = this.formatToUnits(
-        dSumP + dSumM + this.json.flying.deuterium
+      sumNodes[2]
+        .querySelector(".ogl-metal")
+        .setAttribute(
+          "data-title",
+          toFormatedNumber(Math.floor(mSumP + mSumM + this.json.flying.metal))
+        );
+      sumNodes[2]
+        .querySelector(".ogl-metal")
+        .setAttribute("class", "ogl-metal tooltip");
+      sumNodes[2].querySelector(".ogl-crystal").innerText = toFormatedNumber(
+        Math.floor(cSumP + cSumM + this.json.flying.crystal),
+        null,
+        true
       );
+      sumNodes[2]
+        .querySelector(".ogl-crystal")
+        .setAttribute(
+          "data-title",
+          toFormatedNumber(Math.floor(cSumP + cSumM + this.json.flying.crystal))
+        );
+      sumNodes[2]
+        .querySelector(".ogl-crystal")
+        .setAttribute("class", "ogl-crystal tooltip");
+      sumNodes[2].querySelector(".ogl-deut").innerText = toFormatedNumber(
+        Math.floor(dSumP + dSumM + this.json.flying.deuterium),
+        null,
+        true
+      );
+      sumNodes[2]
+        .querySelector(".ogl-deut")
+        .setAttribute(
+          "data-title",
+          toFormatedNumber(
+            Math.floor(dSumP + dSumM + this.json.flying.deuterium)
+          )
+        );
+      sumNodes[2]
+        .querySelector(".ogl-deut")
+        .setAttribute("class", "ogl-deut tooltip");
     });
+    let flyingDetails = {};
+    this.json.flying.ids.forEach((mov) => {
+      if (
+        mov.resDest &&
+        (mov.type == "4" || mov.type == "3" || mov.type == "15")
+      ) {
+        let coords = mov.back ? mov.origin : mov.dest;
+        flyingDetails[coords] = flyingDetails[coords] || {
+          metal: 0,
+          crystal: 0,
+          deuterium: 0,
+        };
+        flyingDetails[coords].metal += mov.metal || 0;
+        flyingDetails[coords].crystal += mov.crystal || 0;
+        flyingDetails[coords].deuterium += mov.deuterium || 0;
+        flyingDetails[coords].name = mov.back ? mov.originName : mov.destName;
+        flyingDetails[coords].own = false;
+      }
+    });
+    this.json.empire.forEach((planet) => {
+      let indexPlanet = planet.coordinates.slice(1, -1) + "P";
+      if (flyingDetails[indexPlanet]) {
+        flyingDetails[indexPlanet].own = true;
+      }
+      if (planet.moon) {
+        let indexMoon = planet.coordinates.slice(1, -1) + "M";
+        if (flyingDetails[indexMoon]) {
+          flyingDetails[indexMoon].own = true;
+        }
+      }
+    });
+    let flyingRows = "";
+    for (const [coords, details] of Object.entries(flyingDetails)) {
+      let res = details.metal + details.crystal + details.deuterium;
+      if (res > 0) {
+        let href = `https://s${this.universe}-${
+          this.gameLang
+        }.ogame.gameforge.com/game/index.php?page=ingame&amp;component=galaxy&galaxy=${
+          coords.split(":")[0]
+        }&system=${coords.split(":")[1]}&position=${coords
+          .split(":")[2]
+          .slice(0, -1)}`;
+        flyingRows += `<tr>
+      <td>${details.name}</td>
+      <td class=${
+  details.own ? "own" : "friendly"
+}><a href=${href}>[${coords.slice(0, -1)}]</a></td>
+      <td><figure class="${
+  coords.slice(-1) == "M" ? "planetIcon moon" : "planetIcon planet"
+}"></figure></td>
+      <td class="value ogl-metal">${toFormatedNumber(details.metal)}</td>
+      <td class="value ogl-crystal">${toFormatedNumber(details.crystal)}</td>
+      <td class="value ogl-deut">${toFormatedNumber(details.deuterium)}</td>
+      </tr>`;
+      }
+    }
+    document.querySelector(".ogl-sum-symbol .icon_movement").setAttribute(
+      "data-title",
+      `<div class="htmlTooltip">
+        <h1>${this.getTranslatedText(128)}</h1>
+        <div class="splitLine"></div>
+        <tbody>
+          <table class="flyingFleet">
+            <tr>
+                <th colspan="3">${this.getTranslatedText(127)}</th>
+                <th class="ogl-metal">${this.getTranslatedText(0, "res")}</th>
+                <th class="ogl-crystal">${this.getTranslatedText(1, "res")}</th>
+                <th class="ogl-deut">${this.getTranslatedText(2, "res")}</th>
+            </tr>
+            ${flyingRows}
+          </table>
+        </tbody>
+      </div>
+  `
+    );
   }
 
   resourceDetail() {
@@ -9308,24 +13611,89 @@ class OGInfinity {
     flying.appendChild(
       this.createDOM(
         "span",
-        { class: "ogl-metal" },
-        this.formatToUnits(this.json.flying.metal)
+        {
+          class: "tooltip ogl-metal",
+          "data-title": toFormatedNumber(this.json.flying.metal, 0),
+        },
+        toFormatedNumber(this.json.flying.metal, null, true)
       )
     );
     flying.appendChild(
       this.createDOM(
         "span",
-        { class: "ogl-crystal" },
-        this.formatToUnits(this.json.flying.crystal)
+        {
+          class: "tooltip ogl-crystal",
+          "data-title": toFormatedNumber(this.json.flying.crystal, 0),
+        },
+        toFormatedNumber(this.json.flying.crystal, null, true)
       )
     );
     flying.appendChild(
       this.createDOM(
         "span",
-        { class: "ogl-deut" },
-        this.formatToUnits(this.json.flying.deuterium)
+        {
+          class: "tooltip ogl-deut",
+          "data-title": toFormatedNumber(this.json.flying.deuterium, 0),
+        },
+        toFormatedNumber(this.json.flying.deuterium, null, true)
       )
     );
+    let flyingDetails = {};
+    this.json.flying.ids.forEach((mov) => {
+      if (
+        mov.resDest &&
+        (mov.type == "4" || mov.type == "3" || mov.type == "15")
+      ) {
+        let coords = mov.back ? mov.origin : mov.dest;
+        flyingDetails[coords] = flyingDetails[coords] || {
+          metal: 0,
+          crystal: 0,
+          deuterium: 0,
+        };
+        flyingDetails[coords].metal += mov.metal || 0;
+        flyingDetails[coords].crystal += mov.crystal || 0;
+        flyingDetails[coords].deuterium += mov.deuterium || 0;
+        flyingDetails[coords].name = mov.back ? mov.originName : mov.destName;
+        flyingDetails[coords].own = false;
+      }
+    });
+    this.json.empire.forEach((planet) => {
+      let indexPlanet = planet.coordinates.slice(1, -1) + "P";
+      if (flyingDetails[indexPlanet]) {
+        flyingDetails[indexPlanet].own = true;
+      }
+      if (planet.moon) {
+        let indexMoon = planet.coordinates.slice(1, -1) + "M";
+        if (flyingDetails[indexMoon]) {
+          flyingDetails[indexMoon].own = true;
+        }
+      }
+    });
+    let flyingRows = "";
+    for (const [coords, details] of Object.entries(flyingDetails)) {
+      let res = details.metal + details.crystal + details.deuterium;
+      if (res > 0) {
+        let href = `https://s${this.universe}-${
+          this.gameLang
+        }.ogame.gameforge.com/game/index.php?page=ingame&amp;component=galaxy&galaxy=${
+          coords.split(":")[0]
+        }&system=${coords.split(":")[1]}&position=${coords
+          .split(":")[2]
+          .slice(0, -1)}`;
+        flyingRows += `<tr>
+      <td>${details.name}</td>
+      <td class=${
+  details.own ? "own" : "friendly"
+}><a href=${href}>[${coords.slice(0, -1)}]</a></td>
+      <td><figure class="${
+  coords.slice(-1) == "M" ? "planetIcon moon" : "planetIcon planet"
+}"></figure></td>
+      <td class="value ogl-metal">${toFormatedNumber(details.metal, 0)}</td>
+      <td class="value ogl-crystal">${toFormatedNumber(details.crystal, 0)}</td>
+      <td class="value ogl-deut">${toFormatedNumber(details.deuterium, 0)}</td>
+      </tr>`;
+      }
+    }
     let flyingSum = this.createDOM("div", {
       class: "smallplanet smaller ogl-summary",
     });
@@ -9336,6 +13704,28 @@ class OGInfinity {
         '<span class="icon_movement"></span>'
       )
     );
+    flyingSum
+      .querySelector(".icon_movement")
+      .classList.add("tooltip", "tooltipLeft", "tooltipClose");
+    flyingSum.querySelector(".icon_movement").setAttribute(
+      "data-title",
+      `<div class="htmlTooltip">
+        <h1>${this.getTranslatedText(128)}</h1>
+        <div class="splitLine"></div>
+        <tbody>
+          <table class="flyingFleet">
+            <tr>
+                <th colspan="3">${this.getTranslatedText(127)}</th>
+                <th class="ogl-metal">${this.getTranslatedText(0, "res")}</th>
+                <th class="ogl-crystal">${this.getTranslatedText(1, "res")}</th>
+                <th class="ogl-deut">${this.getTranslatedText(2, "res")}</th>
+            </tr>
+            ${flyingRows}
+          </table>
+        </tbody>
+      </div>
+  `
+    );
     flyingSum.appendChild(flying);
     let mSumP = 0,
       cSumP = 0,
@@ -9343,8 +13733,7 @@ class OGInfinity {
     let mSumM = 0,
       cSumM = 0,
       dSumM = 0;
-    let empire = this.json.empire;
-    empire.forEach((elem) => {
+    this.json.empire.forEach((elem) => {
       let planet = list.querySelector(`div[id=planet-${elem.id}]`);
       if (!planet) return;
       let isFullM = elem.metalStorage - elem.metal > 0 ? "" : " ogl-full";
@@ -9368,22 +13757,31 @@ class OGInfinity {
       divPla.appendChild(
         this.createDOM(
           "span",
-          { class: "ogl-metal" + isFullM + isaFullM },
-          this.formatToUnits(elem.metal)
+          {
+            class: "tooltip ogl-metal" + isFullM + isaFullM,
+            "data-title": toFormatedNumber(Math.floor(elem.metal)),
+          },
+          toFormatedNumber(Math.floor(elem.metal), null, true)
         )
       );
       divPla.appendChild(
         this.createDOM(
           "span",
-          { class: "ogl-crystal" + isFullC + isaFullC },
-          this.formatToUnits(elem.crystal)
+          {
+            class: "tooltip ogl-crystal" + isFullC + isaFullC,
+            "data-title": toFormatedNumber(Math.floor(elem.crystal)),
+          },
+          toFormatedNumber(Math.floor(elem.crystal), null, true)
         )
       );
       divPla.appendChild(
         this.createDOM(
           "span",
-          { class: "ogl-deut" + isFullD + isaFullD },
-          this.formatToUnits(elem.deuterium)
+          {
+            class: "tooltip ogl-deut" + isFullD + isaFullD,
+            "data-title": toFormatedNumber(Math.floor(elem.deuterium)),
+          },
+          toFormatedNumber(Math.floor(elem.deuterium), null, true)
         )
       );
       mSumP += elem.metal;
@@ -9403,22 +13801,31 @@ class OGInfinity {
         divMoon.appendChild(
           this.createDOM(
             "span",
-            { class: "ogl-metal" },
-            this.formatToUnits(elem.moon.metal)
+            {
+              class: "tooltip ogl-metal",
+              "data-title": toFormatedNumber(Math.floor(elem.moon.metal)),
+            },
+            toFormatedNumber(Math.floor(elem.moon.metal), null, true)
           )
         );
         divMoon.appendChild(
           this.createDOM(
             "span",
-            { class: "ogl-crystal" },
-            this.formatToUnits(elem.moon.crystal)
+            {
+              class: "tooltip ogl-crystal",
+              "data-title": toFormatedNumber(Math.floor(elem.moon.crystal)),
+            },
+            toFormatedNumber(Math.floor(elem.moon.crystal), null, true)
           )
         );
         divMoon.appendChild(
           this.createDOM(
             "span",
-            { class: "ogl-deut" },
-            this.formatToUnits(elem.moon.deuterium)
+            {
+              class: "tooltip ogl-deut",
+              "data-title": toFormatedNumber(Math.floor(elem.moon.deuterium)),
+            },
+            toFormatedNumber(Math.floor(elem.moon.deuterium), null, true)
           )
         );
         mSumM += elem.moon.metal;
@@ -9429,31 +13836,62 @@ class OGInfinity {
     });
     let divPlaSum = this.createDOM("div", { class: "ogl-res" });
     divPlaSum.appendChild(
-      this.createDOM("span", { class: "ogl-metal" }, this.formatToUnits(mSumP))
+      this.createDOM(
+        "span",
+        {
+          class: "tooltip ogl-metal",
+          "data-title": toFormatedNumber(Math.floor(mSumP)),
+        },
+        toFormatedNumber(Math.floor(mSumP), null, true)
+      )
     );
     divPlaSum.appendChild(
       this.createDOM(
         "span",
-        { class: "ogl-crystal" },
-        this.formatToUnits(cSumP)
+        { class: "tooltip ogl-crystal", "data-title": toFormatedNumber(cSumP) },
+        toFormatedNumber(Math.floor(cSumP), null, true)
       )
     );
     divPlaSum.appendChild(
-      this.createDOM("span", { class: "ogl-deut" }, this.formatToUnits(dSumP))
+      this.createDOM(
+        "span",
+        {
+          class: "tooltip ogl-deut",
+          "data-title": toFormatedNumber(Math.floor(dSumP)),
+        },
+        toFormatedNumber(Math.floor(dSumP), null, true)
+      )
     );
     let divMoonSum = this.createDOM("div", { class: "ogl-res" });
     divMoonSum.appendChild(
-      this.createDOM("span", { class: "ogl-metal" }, this.formatToUnits(mSumM))
+      this.createDOM(
+        "span",
+        {
+          class: "tooltip ogl-metal",
+          "data-title": toFormatedNumber(Math.floor(mSumM)),
+        },
+        toFormatedNumber(Math.floor(mSumM), null, true)
+      )
     );
     divMoonSum.appendChild(
       this.createDOM(
         "span",
-        { class: "ogl-crystal" },
-        this.formatToUnits(cSumM)
+        {
+          class: "tooltip ogl-crystal",
+          "data-title": toFormatedNumber(Math.floor(cSumM)),
+        },
+        toFormatedNumber(Math.floor(cSumM), null, true)
       )
     );
     divMoonSum.appendChild(
-      this.createDOM("span", { class: "ogl-deut" }, this.formatToUnits(dSumM))
+      this.createDOM(
+        "span",
+        {
+          class: "tooltip ogl-deut",
+          "data-title": toFormatedNumber(Math.floor(dSumM)),
+        },
+        toFormatedNumber(Math.floor(dSumM), null, true)
+      )
     );
     let sumPlanet = this.createDOM("div", {
       class: "smallplanet smaller ogl-summary",
@@ -9475,22 +13913,49 @@ class OGInfinity {
     sumres.appendChild(
       this.createDOM(
         "span",
-        { class: "ogl-metal" },
-        this.formatToUnits(mSumP + mSumM + this.json.flying.metal)
+        {
+          class: "tooltip ogl-metal",
+          "data-title": toFormatedNumber(
+            Math.floor(mSumP + mSumM + this.json.flying.metal)
+          ),
+        },
+        toFormatedNumber(
+          Math.floor(mSumP + mSumM + this.json.flying.metal),
+          null,
+          true
+        )
       )
     );
     sumres.appendChild(
       this.createDOM(
         "span",
-        { class: "ogl-crystal" },
-        this.formatToUnits(cSumP + cSumM + this.json.flying.crystal)
+        {
+          class: "tooltip ogl-crystal",
+          "data-title": toFormatedNumber(
+            Math.floor(cSumP + cSumM + this.json.flying.crystal)
+          ),
+        },
+        toFormatedNumber(
+          Math.floor(cSumP + cSumM + this.json.flying.crystal),
+          null,
+          true
+        )
       )
     );
     sumres.appendChild(
       this.createDOM(
         "span",
-        { class: "ogl-deut" },
-        this.formatToUnits(dSumP + dSumM + this.json.flying.deuterium)
+        {
+          class: "tooltip ogl-deut",
+          "data-title": toFormatedNumber(
+            Math.floor(dSumP + dSumM + this.json.flying.deuterium)
+          ),
+        },
+        toFormatedNumber(
+          Math.floor(dSumP + dSumM + this.json.flying.deuterium),
+          null,
+          true
+        )
       )
     );
     sum.appendChild(this.createDOM("div", { class: "ogl-sum-symbol" }, "ΣΣ"));
@@ -9514,10 +13979,17 @@ class OGInfinity {
     return this.getEmpireInfo().then((json) => {
       this.json.empire = json;
       this.json.lastEmpireUpdate = new Date();
+      this.json.empire.forEach((planet) => {
+        planet.invalidate = false;
+        if (planet.moon) planet.moon.invalidate = false;
+      });
       this.updateresourceDetail();
       this.flyingFleet();
       this.isLoading = false;
       this.json.needsUpdate = false;
+      for (let techId in this.json.technology) {
+        this.json.technology[techId] = this.json.empire[0][techId];
+      }
       this.saveData();
       document.querySelector(".spinner").remove();
     });
@@ -9544,7 +14016,7 @@ class OGInfinity {
       ].forEach((color) => {
         let toggle = this.createDOM("div", {
           class: "tooltip ogl-toggle",
-          title: this.getTranslatedText(5),
+          title: this.getTranslatedText(40),
         });
         toggle.setAttribute("data-toggle", color);
         markers.appendChild(toggle);
@@ -10025,20 +14497,20 @@ class OGInfinity {
       planets.forEach((e) => list.appendChild(e));
       this.highlightTarget();
       date.html(this.timeSince(new Date(player.lastUpdate)));
-      count.html(player.planets.length + " planet(s)");
+      count.html(player.planets.length + " " + this.getTranslatedText(42));
       detailRank.html(
-        `\n      <div><div class="ogl-totalIcon"></div> ${this.formatToUnits(
-          player.points.score
-        )} <small>pts</small></div>\n      <div><div class="ogl-ecoIcon"></div> ${this.formatToUnits(
-          player.economy.score
-        )} <small>pts</small></div>\n      <div><div class="ogl-techIcon"></div> ${this.formatToUnits(
-          player.research.score
-        )} <small>pts</small></div>\n      <div><div class="ogl-fleetIcon"></div> ${this.formatToUnits(
-          player.military.score
-        )} <small>pts</small></div>\n      <div><div class="ogl-fleetIcon grey"></div> ${this.formatToUnits(
-          player.def
-        )} <small>pts</small></div>\n      <div><div class="ogl-fleetIcon orange"></div> ${this.formatToUnits(
-          player.military.ships
+        `\n      <div><div class="ogl-totalIcon"></div> ${toFormatedNumber(
+          player.points.score, null, true
+        )} <small>pts</small></div>\n      <div><div class="ogl-ecoIcon"></div> ${toFormatedNumber(
+          player.economy.score, null, true
+        )} <small>pts</small></div>\n      <div><div class="ogl-techIcon"></div> ${toFormatedNumber(
+          player.research.score, null, true
+        )} <small>pts</small></div>\n      <div><div class="ogl-fleetIcon"></div> ${toFormatedNumber(
+          player.military.score, null, true
+        )} <small>pts</small></div>\n      <div><div class="ogl-fleetIcon grey"></div> ${toFormatedNumber(
+          player.def, null, true
+        )} <small>pts</small></div>\n      <div><div class="ogl-fleetIcon orange"></div> ${toFormatedNumber(
+          player.military.ships, null, true
         )} <small>ships</small></div>`
       );
     };
@@ -10467,11 +14939,13 @@ class OGInfinity {
           let total = 0;
           const frag = document.createDocumentFragment();
           debris.querySelectorAll(".debris-content").forEach((resources) => {
-            let value = this.removeNumSeparator(
+            let value = fromFormatedNumber(
               resources.innerText.replace(/(\D*)/, "")
             );
             total += parseInt(value);
-            frag.appendChild(document.createTextNode(this.formatToUnits(value)));
+            frag.appendChild(
+              document.createTextNode(toFormatedNumber(value, null, true))
+            );
             frag.appendChild(document.createElement("br"));
           });
           element.querySelector(".microdebris").appendChild(frag);
@@ -10493,8 +14967,12 @@ class OGInfinity {
         expeBox.html(
           `\n<img src="https://gf1.geo.gfsrv.net/cdnc5/fa3e396b8af2ae31e28ef3b44eca91.gif">\n<div>\n<div class="ogl-metal">${res[0]}</div>\n<div class="ogl-crystal">${res[1]}</div>\n</div>\n<div>\n<div>${scouts.textContent}</div>\n<div>${action.outerHTML}</div>\n</div>\n`
         );
-        expeBox.querySelector("a").setAttribute(
-        "onclick", action.outerHTML.match(/(?<=k=")(.*?)(?=">)/)[0]);
+        expeBox
+          .querySelector("a")
+          .setAttribute(
+            "onclick",
+            action.outerHTML.match(/(?<=k=")(.*?)(?=">)/)[0]
+          );
       }
     }
   }
@@ -10793,7 +15271,7 @@ class OGInfinity {
     let enableTable = tableOptions.appendChild(
       this.createDOM("button", {
         class: "icon icon_eye tooltip",
-        title: this.getTranslatedText(8),
+        title: this.getTranslatedText(106),
       })
     );
     if (this.json.options.spyTableEnable)
@@ -10808,7 +15286,7 @@ class OGInfinity {
     let appendOption = tableOptions.appendChild(
       this.createDOM("button", {
         class: "icon icon_plus tooltip",
-        title: "Append reports",
+        title: this.getTranslatedText(105),
       })
     );
     if (this.json.options.spyTableAppend)
@@ -10823,7 +15301,7 @@ class OGInfinity {
     let autoDelete = tableOptions.appendChild(
       this.createDOM("button", {
         class: "icon icon_trash tooltip",
-        title: this.getTranslatedText(7),
+        title: this.getTranslatedText(104),
       })
     );
     if (this.json.options.autoDeleteEnable)
@@ -10845,31 +15323,56 @@ class OGInfinity {
     table.appendChild(header);
     header.appendChild(this.createDOM("th", {}, "#"));
     header.appendChild(
-      this.createDOM("th", { "data-filter": "DATE" }, "Date (*)")
+      this.createDOM(
+        "th",
+        { "data-filter": "DATE" },
+        `${this.getTranslatedText(97)} (*)`
+      )
     );
     header.appendChild(
-      this.createDOM("th", { "data-filter": "COORDS" }, "Coords")
+      this.createDOM(
+        "th",
+        { "data-filter": "COORDS" },
+        this.getTranslatedText(98)
+      )
     );
-    header.appendChild(this.createDOM("th", {}, "Name (+)"));
-    header.appendChild(this.createDOM("th", { "data-filter": "$" }, "Renta"));
     header.appendChild(
-      this.createDOM("th", { "data-filter": "FLEET" }, "Fleet")
+      this.createDOM("th", {}, `${this.getTranslatedText(73)} (+)`)
     );
-    header.appendChild(this.createDOM("th", { "data-filter": "DEF" }, "Def"));
-    let cargoChoice = this.createDOM("div", { class: "ogk-cargo" });
+    header.appendChild(
+      this.createDOM("th", { "data-filter": "$" }, this.getTranslatedText(99))
+    );
+    header.appendChild(
+      this.createDOM(
+        "th",
+        { "data-filter": "FLEET" },
+        this.getTranslatedText(100)
+      )
+    );
+    header.appendChild(
+      this.createDOM(
+        "th",
+        { "data-filter": "DEF" },
+        this.getTranslatedText(101)
+      )
+    );
+
+    let cargoChoice = this.createDOM("div", {
+      class: `ogk-cargo${this.json.ships[210].cargoCapacity ? " spio" : ""}`,
+    });
     let sc = cargoChoice.appendChild(
       this.createDOM("div", {
-        class: "ogl-option ogl-fleet-ship ogl-fleet-202",
+        class: "ogl-option ogl-fleet-ship choice ogl-fleet-202",
       })
     );
     let lc = cargoChoice.appendChild(
       this.createDOM("div", {
-        class: "ogl-option ogl-fleet-ship ogl-fleet-203",
+        class: "ogl-option ogl-fleet-ship choice ogl-fleet-203",
       })
     );
     let pf = cargoChoice.appendChild(
       this.createDOM("div", {
-        class: "ogl-option ogl-fleet-ship ogl-fleet-219",
+        class: "ogl-option ogl-fleet-ship choice ogl-fleet-219",
       })
     );
     let updateDefaultShip = (id) => {
@@ -10880,10 +15383,10 @@ class OGInfinity {
     sc.addEventListener("click", () => updateDefaultShip(202));
     lc.addEventListener("click", () => updateDefaultShip(203));
     pf.addEventListener("click", () => updateDefaultShip(219));
-    if (this.json.pbFret != 0) {
+    if (this.json.ships[210].cargoCapacity != 0) {
       let pb = cargoChoice.appendChild(
         this.createDOM("div", {
-          class: "ogl-option ogl-fleet-ship ogl-fleet-210",
+          class: "ogl-option ogl-fleet-ship choice ogl-fleet-210",
         })
       );
       pb.addEventListener("click", () => updateDefaultShip(210));
@@ -10892,7 +15395,7 @@ class OGInfinity {
       this.createDOM(
         "th",
         {},
-        `<span style="display: flex;" class="ogl-option ogl-fleet-ship ogl-fleet-${this.json.options.spyFret}"></span>`
+        `<span style="display: flex;" class="ogl-option ogl-fleet-ship choice ogl-fleet-${this.json.options.spyFret}"></span>`
       )
     );
     cargo.addEventListener("mouseover", () =>
@@ -10901,7 +15404,7 @@ class OGInfinity {
     header.appendChild(
       this.createDOM("th", { class: "ogl-headerColors" }, "-")
     );
-    header.appendChild(this.createDOM("th", {}, "Actions"));
+    header.appendChild(this.createDOM("th", {}, this.getTranslatedText(102)));
     document.querySelectorAll(".ogl-spyTable th").forEach((th) => {
       let filter = th.getAttribute("data-filter");
       if (this.json.options.spyFilter == filter) th.classList.add("ogl-active");
@@ -10921,8 +15424,7 @@ class OGInfinity {
       if (report.new) {
         indexDiv.classList.add("ogi-new");
       }
-      let dateDetail = `\n${report.cleanDate.toLocaleDateString()}<br>\n${report.cleanDate.toLocaleTimeString()}<br>\nActivity : ${
-        report.activity
+      let dateDetail = `\n${report.cleanDate.toLocaleDateString()}<br>\n${report.cleanDate.toLocaleTimeString()}<br>\n${this.getTranslatedText(107)} : ${report.activity
       }\n`;
       let dateText = `${this.timeSince(report.cleanDate)}<br>`;
       let date = line.appendChild(
@@ -10961,20 +15463,20 @@ class OGInfinity {
           report.name + " " + report.status
         )
       );
-      let totalDetail = `\n<div class="ogl-metal">M: ${this.formatToUnits(
-        report.metal
-      )}</div>\n<div class="ogl-crystal">C: ${this.formatToUnits(
-        report.crystal
-      )}</div>\n<div class="ogl-deut">D: ${this.formatToUnits(
-        report.deut
-      )}</div>\n<div class="splitLine"></div>\nTOTAL: ${this.formatToUnits(
-        report.total
+      let totalDetail = `\n<div class="ogl-metal">${this.getTranslatedText(0, "res")}: ${toFormatedNumber(
+        report.metal, null, true
+      )}</div>\n<div class="ogl-crystal">${this.getTranslatedText(1, "res")}: ${toFormatedNumber(
+        report.crystal, null, true
+      )}</div>\n<div class="ogl-deut">${this.getTranslatedText(2, "res")}: ${toFormatedNumber(
+        report.deut, null, true
+      )}</div>\n<div class="splitLine"></div>\n${this.getTranslatedText(40)}: ${toFormatedNumber(
+        report.total, null, true
       )}\n`;
       let total = line.appendChild(
         this.createDOM(
           "td",
           { class: "tooltipLeft ogl-lootable", title: totalDetail },
-          this.formatToUnits(report.renta)
+          toFormatedNumber(report.renta, null, true)
         )
       );
       if (
@@ -10991,12 +15493,12 @@ class OGInfinity {
         report.resRatio[0] + report.resRatio[1]
       }%, rgb(166, 224, 176) ${report.resRatio[2]}%)`;
       let fleet = line.appendChild(
-        this.createDOM("td", {}, this.formatToUnits(report.fleet))
+        this.createDOM("td", {}, toFormatedNumber(report.fleet, null, true))
       );
       if (report.fleet > 0 || report.fleet == "No Data")
         fleet.classList.add("ogl-care");
       let defense = line.appendChild(
-        this.createDOM("td", {}, this.formatToUnits(report.defense))
+        this.createDOM("td", {}, toFormatedNumber(report.defense, null, true))
       );
       if (report.defense > 0 || report.defense == "No Data")
         defense.classList.add("ogl-danger");
@@ -11027,9 +15529,7 @@ class OGInfinity {
               window.location.pathname +
               fleetLink,
           },
-          shipCount.toLocaleString(
-            document.getElementById("cookiebanner").getAttribute("data-locale")
-          )
+          toFormatedNumber(shipCount)
         )
       );
       let colorsContainer = line.appendChild(this.createDOM("td"));
@@ -11088,10 +15588,15 @@ class OGInfinity {
         location.href = fleetLink;
       });
       simulateBtn.addEventListener("click", () => {
-        let apiTechData = {};
-        for (let id in this.json.apiTechData) {
-          apiTechData[id] = { level: this.json.apiTechData[id] };
-        }
+        let apiTechData = {
+          109: { level: this.json.technology[109] },
+          110: { level: this.json.technology[110] },
+          111: { level: this.json.technology[111] },
+          115: { level: this.json.technology[115] },
+          117: { level: this.json.technology[117] },
+          118: { level: this.json.technology[118] },
+          114: { level: this.json.technology[114] },
+        };
         let coords = this.current.coords.split(":");
         let json = {
           0: [
@@ -11193,12 +15698,12 @@ class OGInfinity {
         }
         let div = this.createDOM("div");
         div.html(
-          `\n          <div style="width: 75px">Missing </div>\n          <hr>\n          <div class="ogl-metal">M: ${this.formatToUnits(
-            Math.max(0, missing[0])
-          )}</div>\n          <div class="ogl-crystal">C: ${this.formatToUnits(
-            Math.max(0, missing[1])
-          )}</div>\n          <div class="ogl-deut">D: ${this.formatToUnits(
-            Math.max(0, missing[2])
+          `\n          <div style="width: 75px">Missing </div>\n          <hr>\n          <div class="ogl-metal">M: ${toFormatedNumber(
+            Math.max(0, missing[0]), null, true
+          )}</div>\n          <div class="ogl-crystal">C: ${toFormatedNumber(
+            Math.max(0, missing[1]), null, true
+          )}</div>\n          <div class="ogl-deut">D: ${toFormatedNumber(
+            Math.max(0, missing[2]), null, true
           )}</div>\n          <hr>\n          `
         );
         let deleteBtn = div.appendChild(
@@ -11212,6 +15717,7 @@ class OGInfinity {
         }
         deleteBtn.addEventListener("click", () => {
           delete this.json.missing[coords];
+          this.json.needSync = true;
           this.saveData();
           this.sideLock();
           document.querySelector(".ogl-tooltip .close-tooltip").click();
@@ -11285,23 +15791,6 @@ class OGInfinity {
     });
   }
 
-  checkInputs() {
-    this.FPSLoop("checkInputs");
-    if (this.page == "fleetdispatch") {
-      document
-        .querySelectorAll('form[name="shipsChosen"] input')
-        .forEach((i) => i.classList.add("ogl-formatInput"));
-    }
-    document.querySelectorAll("input.ogl-formatInput").forEach((input) => {
-      if (input.value == "-") return;
-      if (input.value == "NaN") input.value = "";
-      if (input.value)
-        input.value = parseInt(
-          this.removeNumSeparator(input.value, true)
-        ).toLocaleString(separatorLang);
-    });
-  }
-
   selectShips(shipID, amount) {
     if (this.page == "fleetdispatch") {
       fleetDispatcher.shipsOnPlanet.forEach((ship) => {
@@ -11345,32 +15834,21 @@ class OGInfinity {
   calcNeededShips(options) {
     options = options || {};
     let resources = [
-      this.removeNumSeparator(
-        document.querySelector("#resources_metal").getAttribute("data-raw")
+      fromFormatedNumber(
+        document.querySelector("#resources_metal").textContent
       ),
-      this.removeNumSeparator(
-        document.querySelector("#resources_crystal").getAttribute("data-raw")
+      fromFormatedNumber(
+        document.querySelector("#resources_crystal").textContent
       ),
-      this.removeNumSeparator(
-        document.querySelector("#resources_deuterium").getAttribute("data-raw")
+      fromFormatedNumber(
+        document.querySelector("#resources_deuterium").textContent
       ),
     ];
     resources = resources.reduce((a, b) => parseInt(a) + parseInt(b));
     if (options.resources || options.resources == 0)
       resources = options.resources;
     let type = options.fret || this.json.options.fret;
-    let fret;
-    if (type == 202) {
-      fret = this.json.ptFret;
-    } else if (type == 203) {
-      fret = this.json.gtFret;
-    } else if (type == 219) {
-      fret = this.json.pfFret;
-    } else if (type == 210) {
-      fret = this.json.pbFret;
-    } else if (type == 209) {
-      fret = this.json.cyFret;
-    }
+    let fret = this.json.ships[type].cargoCapacity;
     let total = resources / fret;
     if (options.moreFret) total *= 107 / 100;
     return Math.ceil(total);
@@ -11378,7 +15856,9 @@ class OGInfinity {
 
   calcAvailableFret(shipAmount) {
     let fret =
-      this.json.options.fret == 203 ? this.json.gtFret : this.json.ptFret;
+      this.json.options.fret == 203
+        ? this.json.ships[203].cargoCapacity
+        : this.json.ships[202].cargoCapacity;
     return shipAmount * fret;
   }
 
@@ -11404,7 +15884,11 @@ class OGInfinity {
     let lastPantrySync = null;
     let lastLocalSync = this.json.pantrySync;
     let pantrySyncObj = null;
-    if (!pantryKey || (lastLocalSync && Date.now() - lastLocalSync < 180000)) {
+    if (
+      !pantryKey ||
+      !this.json.needSync ||
+      (lastLocalSync && Date.now() - lastLocalSync < 180000)
+    ) {
       return;
     }
     let syncRequest = await fetch(
@@ -11495,6 +15979,9 @@ class OGInfinity {
       mainSyncJsonObj.markers = this?.json?.markers;
       mainSyncJsonObj.sideStargetTabstalk = this?.json?.targetTabs;
       mainSyncJsonObj.missing = this?.json?.missing;
+      mainSyncJsonObj.flying = this?.json?.flying;
+      mainSyncJsonObj.buildingProgress = this?.json?.productionProgress;
+      mainSyncJsonObj.researchProgress = this?.json?.researchProgress;
       mainSyncJsonObj.pantrySync = mainSyncObj?.pantrySync;
 
       const mainSyncRequest = fetch(
@@ -11666,6 +16153,12 @@ class OGInfinity {
           this.json.options = cloudConsolidated?.options || this.json.options;
           this.json.searchHistory =
             cloudConsolidated?.searchHistory || this.json.searchHistory;
+          this.json.flying = cloudConsolidated?.flying || this.json.flying;
+          this.json.missing = cloudConsolidated?.missing || this.json.missing;
+          this.json.productionProgress =
+            cloudConsolidated?.buildingProgress || this.json.productionProgress;
+          this.json.researchProgress =
+            cloudConsolidated?.researchProgress || this.json.researchProgress;
           this.json.pantrySync = Date.now();
           this.saveData();
           console.info("[OGInfinity] - Pantry synchronisation complete");
@@ -11803,19 +16296,17 @@ class OGInfinity {
   }
 
   consumption(id, lvl) {
-    let baseCons = { 1: 10, 2: 10, 3: 20, 12: 10 };
-    let cons = baseCons[id] * lvl * Math.pow(1.1, lvl);
-    return Math.floor(cons);
+    if (!BUIDLING_INFO[id].baseCons || !BUIDLING_INFO[id].factorCons) return 0;
+    return Math.floor(
+      BUIDLING_INFO[id].baseCons *
+        lvl *
+        Math.pow(BUIDLING_INFO[id].factorCons, id >= 11101 && lvl == 1 ? 0 : lvl)
+    );
   }
 
   minesProduction(id, lvl, position, temp) {
-    let baseProd = { 1: 30, 2: 20, 3: 10, 4: 20 };
-    let initProd = 0;
-    if (id == 1) {
-      initProd += 30;
-    } else if (id == 2) {
-      initProd += 15;
-    }
+    let baseProd = {1: 30,2: 20,3: 10,4: 20 };
+
     let positionBonus = 1;
     if (id == 1) {
       if (position == 6 || position == 10) {
@@ -11840,190 +16331,155 @@ class OGInfinity {
       prod *= 1.44 - 0.004 * temp;
     }
     if (id == 12) {
-      prod = 30 * lvl * Math.pow(1.05 + tech113 * 0.01, lvl);
+      prod = 30 * lvl * Math.pow(1.05 + this.json.technology[113] * 0.01, lvl);
     }
     prod = prod * positionBonus;
     if (id == 1 || id == 2 || id == 3) {
       prod = prod * this.json.speed;
     }
-    return Math.round(prod);
+    return Math.floor(prod);
   }
 
-  production(id, lvl, total, coords) {
-    coords = coords || this.current.coords;
-    let position = coords.split(":")[2];
-    let prodFactor = 1;
-    let tech113, tech122, temp;
-    let mines = this.json.myMines[coords];
-    tech113 = this.json.empire[0][113];
-    tech122 = this.json.empire[0][122];
-    this.json.empire.forEach((planet) => {
-      if (planet.coordinates.slice(1, -1) == this.current.coords) {
-        let splits = planet.temperature.split(" ");
-        temp = splits[splits.length - 1];
-        temp = temp.replace("°C", "");
-      }
-    });
-    let percentBonus = 0;
-    let maxCrawlerCount =
-      (Number(mines.metal) + Number(mines.crystal) + Number(mines.deuterium)) *
-      8;
-    if (this.geologist) {
-      maxCrawlerCount = maxCrawlerCount * 1.1;
-    }
-    let crawlerBonus =
-      Math.min(mines.crawlers, maxCrawlerCount) *
-      (this.playerClass == PLAYER_CLASS_MINER ? 0.003 : 0.002);
-    let geologistFactor = this.geologist ? 0.1 : 0;
-    if (this.allOfficers) {
-      geologistFactor = 0.12;
-    }
-    let baseProd = { 1: 30, 2: 20, 3: 10, 4: 20 };
-    let plasmaFactor = { 1: 0.01, 2: 0.0066, 3: 0.0033 };
-    let initProd = 0;
-    if (id == 1) {
-      initProd += 30;
-    } else if (id == 2) {
-      initProd += 15;
-    }
-    let positionBonus = 1;
-    if (id == 1) {
-      if (position == 6 || position == 10) {
-        positionBonus = 1.17;
-      } else if (position == 7 || position == 9) {
-        positionBonus = 1.23;
-      } else if (position == 8) {
-        positionBonus = 1.35;
-      }
-    }
-    if (id == 2) {
-      if (position == 1) {
-        positionBonus = 1.4;
-      } else if (position == 2) {
-        positionBonus = 1.3;
-      } else if (position == 3) {
-        positionBonus = 1.2;
-      }
-    }
-    let prod = baseProd[id] * lvl * Math.pow(1.1, lvl);
-    if (id == 3) {
-      prod *= 1.44 - 0.004 * temp;
-    }
-    if (id == 12) {
-      prod = 30 * lvl * Math.pow(1.05 + tech113 * 0.01, lvl);
-    }
-    if (total) prod = prod * prodFactor;
-    prod = prod * positionBonus;
-    tech122 = 12;
-    let plasma = prod * plasmaFactor[id] * tech122;
-    let crawlers = prod * crawlerBonus;
-    let geologist = prod * geologistFactor;
-    let bonus = prod * percentBonus;
-    let miner = (this.playerClass == PLAYER_CLASS_MINER ? 1 : 0) * 0.25 * prod;
-    let totalProd =
-      initProd + prod + geologist + plasma + crawlers + miner + bonus;
-    if (id == 1 || id == 2 || id == 3) {
-      prod = prod * this.json.speed;
-      totalProd = totalProd * this.json.speed;
-      return total ? Math.round(totalProd) : Math.round(prod);
-    }
-    return Math.round(prod);
-  }
-
-  research(id, lvl, labs, technocrat, explorer, bonus) {
+  research(id, lvl, labs, technocrat, explorer, acceleration) {
     if (labs == 0) {
       labs = 1;
     }
-    let baseCost = {
-      106: [200, 1e3, 200],
-      108: [0, 400, 600],
-      109: [800, 200, 0],
-      110: [200, 600, 0],
-      111: [1e3, 0, 0],
-      113: [0, 800, 400],
-      114: [0, 4e3, 2e3],
-      115: [400, 0, 600],
-      117: [2e3, 4e3, 600],
-      118: [1e4, 2e4, 6e3],
-      120: [200, 100, 0],
-      121: [1e3, 300, 100],
-      122: [2e3, 4e3, 1e3],
-      123: [24e4, 4e5, 16e4],
-      124: [4e3, 8e3, 4e3],
-      199: [0, 0, 0, 3e5],
-    };
-    let cost = baseCost[id];
-    cost[0] *= Math.pow(2, lvl - 1);
-    cost[1] *= Math.pow(2, lvl - 1);
-    cost[2] *= Math.pow(2, lvl - 1);
-    if (id == 199) {
-      cost[3] *= Math.pow(3, lvl - 1);
-    } else if (id == 124) {
-      cost[0] = Math.ceil((4e3 * Math.pow(1.75, lvl - 1)) / 100) * 100;
-      cost[1] = Math.ceil((8e3 * Math.pow(1.75, lvl - 1)) / 100) * 100;
-      cost[2] = Math.ceil((4e3 * Math.pow(1.75, lvl - 1)) / 100) * 100;
-      cost[0] = 4e3 * Math.pow(1.75, lvl - 1);
-      cost[1] = 8e3 * Math.pow(1.75, lvl - 1);
-      cost[2] = 4e3 * Math.pow(1.75, lvl - 1);
-    }
+    let researchTimeFactor = 1;
+    this.json.empire &&
+      this.json.empire.forEach(
+        (planet) => (researchTimeFactor -= (planet[14207] || 0) * 0.001)
+      );
+    let cost = [
+      Math.floor(
+        Math.floor(
+          RESEARCH_INFO[id].baseCost[0] *
+            Math.pow(RESEARCH_INFO[id].factorCost, lvl - 1) *
+            (id >= 11101 ? lvl : 1)
+        ) * (id >= 11101 && labs > 1 ? 1.0 - 0.005 * labs : 1)
+      ),
+      Math.floor(
+        Math.floor(
+          RESEARCH_INFO[id].baseCost[1] *
+            Math.pow(RESEARCH_INFO[id].factorCost, lvl - 1) *
+            (id >= 11101 ? lvl : 1)
+        ) * (id >= 11101 && labs > 1 ? 1.0 - 0.005 * labs : 1)
+      ),
+      Math.floor(
+        Math.floor(
+          RESEARCH_INFO[id].baseCost[2] *
+            Math.pow(RESEARCH_INFO[id].factorCost, lvl - 1) *
+            (id >= 11101 ? lvl : 1)
+        ) * (id >= 11101 && labs > 1 ? 1.0 - 0.005 * labs : 1)
+      ),
+    ];
+    if (RESEARCH_INFO[id].baseCost[3])
+      cost.push(
+        Math.floor(
+          RESEARCH_INFO[id].baseCost[3] *
+            Math.pow(RESEARCH_INFO[id].factorEnergy, lvl - 1)
+        )
+      );
     let time =
-      (cost[0] + cost[1]) /
-      (1e3 * labs) /
-      this.json.speed /
-      this.json.researchDivisor;
+      ((cost[0] + cost[1]) /
+        (this.json.speed * 1000 * (1 + labs)) /
+        this.json.researchDivisor) *
+      3600;
     if (technocrat) time -= time * 0.25;
     if (explorer) time -= time * 0.25;
-    if (bonus) time -= time * bonus;
-    return { time: time ? time : 1 / 3600, cost: cost };
+    if (acceleration) time -= time * 0.25;
+    if (id == 124) {
+      time = Math.round(time / 100) * 100;
+    }
+    if (RESEARCH_INFO[id].factorTime) {
+      time = Math.floor(
+        Math.floor(
+          (RESEARCH_INFO[id].baseTime *
+            Math.pow(RESEARCH_INFO[id].factorTime, lvl) *
+            lvl) /
+            this.json.speed
+        ) * (labs > 1 ? 1.0 - 0.02 * labs : 1)
+      );
+    }
+
+    time *= researchTimeFactor;
+    return {
+      time: Math.max(Math.floor(time), 1),
+      cost: cost,
+    };
   }
 
-  getRobotsNanites(id, lvl, time) {
-    for (let i = 0; i < 15; i++) {
-      for (let j = 0; j < 25; j++) {
-        let newTime = this.building(id, lvl, j, i).time;
-        if (
-          time ==
-            formatTimeWrapper(newTime * 60 * 60, 2, true, " ", false, "") ||
-          time ==
-            formatTimeWrapper(newTime * 60 * 60 - 1, 2, true, " ", false, "") ||
-          time ==
-            formatTimeWrapper(newTime * 60 * 60 + 1, 2, true, " ", false, "")
-        ) {
-          return { robotics: j, nanites: i };
-        }
+  getRobotsNanites(id, lvl, time, object = null) {
+    let r = object[14] || 0;
+    let n = object[15] || 0;
+    let newTime = this.building(id, lvl, r, n).time;
+    if (time == newTime) return { robotics: r, nanites: n };
+    for (let j = 0; j < 25; j++) {
+      for (let i = 0; i < 15; i++) {
+        newTime = this.building(id, lvl, j, i).time;
+        if (time == newTime) return { robotics: j, nanites: i };
       }
     }
   }
 
-  getLabs(id, lvl, time, technocrat, explorer, bonus) {
+  getLabs(id, lvl, time, technocrat, explorer, acceleration) {
+    if (this.json.empire) {
+      if (id > 11001) {
+        let lab = 1;
+        if (this.json.empire[this.current.index][11103])
+          lab = this.json.empire[this.current.index][11103];
+        if (this.json.empire[this.current.index][12103])
+          lab = this.json.empire[this.current.index][12103];
+        if (this.json.empire[this.current.index][13103])
+          lab = this.json.empire[this.current.index][13103];
+        if (this.json.empire[this.current.index][14103])
+          lab = this.json.empire[this.current.index][14103];
+        let newTime = this.research(
+          id,
+          lvl,
+          lab,
+          technocrat,
+          explorer,
+          acceleration
+        ).time;
+        if (time == newTime) return lab;
+      } else {
+        let labs = [];
+        let igfn = this.json.technology[123];
+        this.json.empire.forEach((planet) => labs.push(planet[31]));
+        let totalLvl = this.current.isMoon
+          ? 0
+          : this.json.empire[this.current.index][31];
+        if (!this.current.isMoon) labs.splice(this.current.index, 1);
+        labs
+          .sort((a, b) => b - a)
+          .slice(0, igfn)
+          .map((x) => (totalLvl += x));
+        let newTime = this.research(
+          id,
+          lvl,
+          totalLvl,
+          technocrat,
+          explorer,
+          acceleration
+        ).time;
+        console.log(`newTime = ${newTime}`);
+        if (time == newTime) return totalLvl;
+      }
+    }
     for (let i = 0; i < 300; i++) {
-      let newTime = this.research(id, lvl, i, technocrat, explorer, bonus).time;
-      if (
-        time == formatTimeWrapper(newTime * 60 * 60, 2, true, " ", false, "") ||
-        time ==
-          formatTimeWrapper(newTime * 60 * 60 - 1, 2, true, " ", false, "") ||
-        time ==
-          formatTimeWrapper(newTime * 60 * 60 + 1, 2, true, " ", false, "")
-      ) {
+      let newTime = this.research(
+        id,
+        lvl,
+        i,
+        technocrat,
+        explorer,
+        acceleration
+      ).time;
+      console.log(`i = ${i}: time = ${newTime}`);
+      if (time == newTime) {
         return i;
       }
     }
-  }
-
-  getTimeFromString(str) {
-    var regexStr = str.match(/[a-z]+|[^a-z]+/gi);
-    let time = 0;
-    for (let i = 0; i < regexStr.length; i++) {
-      let num = Number(regexStr[i]);
-      if (!isNaN(num)) {
-        if (regexStr[i + 1] == "M") num *= 60;
-        if (regexStr[i + 1] == "H") num *= 60 * 60;
-        if (regexStr[i + 1] == "DT") num *= 60 * 60 * 24;
-        time += num;
-        i++;
-      }
-    }
-    return time;
   }
 
   convertDuration(t) {
@@ -12095,382 +16551,86 @@ class OGInfinity {
   }
 
   building(id, lvl, robotic, nanite) {
-    let currentMRC = 0;
-    let currentMegalith = 0;
-    this.json.empire.forEach((planet) => {
-      if (planet.coordinates.slice(1, -1) == this.current.coords) {
-        currentMRC = planet["12111"] ? planet["12111"] : 0;
-        currentMegalith = planet["12108"] ? planet["12108"] : 0;
-      }
-    });
-
-    let prodBuildings = [
-      1, 2, 3, 11101, 11102, 12101, 12102, 13101, 13102, 14101, 14102,
+    let specialFactor = 1;
+    if (id >= 11101) lvl = Math.max(lvl, 1); // needed for demolish to lvl 0
+    if (Math.floor(id / 1000) == 12) {
+      specialFactor -= this.json.empire[this.current.index][12108] / 100;
+    }
+    let cost = [
+      Math.floor(
+        Math.floor(
+          BUIDLING_INFO[id].baseCost[0] *
+            Math.pow(BUIDLING_INFO[id].factorCost, lvl - 1) *
+            (id >= 11101 ? lvl : 1)
+        ) * specialFactor
+      ),
+      Math.floor(
+        Math.floor(
+          BUIDLING_INFO[id].baseCost[1] *
+            Math.pow(BUIDLING_INFO[id].factorCost, lvl - 1) *
+            (id >= 11101 ? lvl : 1)
+        ) * specialFactor
+      ),
+      Math.floor(
+        Math.floor(
+          BUIDLING_INFO[id].baseCost[2] *
+            Math.pow(BUIDLING_INFO[id].factorCost, lvl - 1) *
+            (id >= 11101 ? lvl : 1)
+        ) * specialFactor
+      ),
     ];
-
-    let baseCost = {
-      1: [60, 15, 0],
-      2: [48, 24, 0],
-      3: [225, 75, 0],
-      4: [75, 30, 0],
-      12: [900, 360, 180],
-      22: [1e3, 0, 0],
-      23: [1e3, 500, 0],
-      24: [1e3, 1e3, 0],
-      14: [400, 120, 200],
-      15: [1e6, 5e5, 1e5],
-      21: [400, 200, 100],
-      31: [200, 400, 200],
-      33: [0, 5e4, 1e5, 1e3],
-      34: [2e4, 4e4, 0],
-      36: [200, 0, 50, 50],
-      44: [2e4, 2e4, 1e3],
-      41: [2e4, 4e4, 2e4],
-      42: [2e4, 4e4, 2e4],
-      43: [2e6, 4e6, 2e6],
+    if (BUIDLING_INFO[id].baseCost[3])
+      cost.push(
+        Math.floor(
+          Math.floor(
+            BUIDLING_INFO[id].baseCost[3] *
+              Math.pow(
+                BUIDLING_INFO[id].factorEnergy,
+                lvl - (id >= 11101 ? (lvl == 1 ? 1 : 0) : 1)
+              ) *
+              (id >= 11101 ? lvl : 1)
+          ) * specialFactor
+        )
+      );
+    let time = Math.max(
+      Math.floor(
+        ((cost[0] + cost[1]) /
+          (2500 *
+            (1 + robotic) *
+            Math.pow(2, nanite) *
+            (![15, 41, 42, 43].includes(id) ? Math.max(4 - lvl / 2, 1) : 1) *
+            this.json.speed)) *
+          3600
+      ),
+      1
+    );
+    if (BUIDLING_INFO[id].factorTime) {
+      time = Math.max(
+        Math.round(
+          Math.floor(
+            (BUIDLING_INFO[id].baseTime *
+              Math.pow(BUIDLING_INFO[id].factorTime, lvl) *
+              lvl) /
+              ((1 + robotic) * Math.pow(2, nanite) * this.json.speed)
+          ) * specialFactor
+        ),
+        lvl
+      );
+    }
+    let returnValue = {
+      time: time,
+      cost: cost,
     };
-    let time;
-    let cost;
-    if (id <= 14218 && id >= 11101) {
-      let lfValCSV = `7,2,0,1.2,1.2,0
-      5,2,0,1.23,1.23,0
-      20000,25000,10000,1.3,1.3,1.3
-      5000,3200,1500,1.7,1.7,1.7
-      50000,40000,50000,1.7,1.7,1.7
-      9000,6000,3000,1.5,1.5,1.5
-      25000,13000,7000,1.09,1.09,1.09
-      50000,25000,15000,1.5,1.5,1.5
-      75000,20000,25000,1.09,1.09,1.09
-      150000,30000,15000,1.12,1.12,1.12
-      80000,35000,60000,1.5,1.5,1.5
-      250000,125000,125000,1.2,1.2,1.2
-      5000,2500,500,1.3,1.3,1.3
-      7000,10000,5000,1.5,1.5,1.5
-      15000,10000,5000,1.3,1.3,1.3
-      20000,15000,7500,1.3,1.3,1.3
-      25000,20000,10000,1.2,1.2,1.2
-      35000,25000,15000,1.5,1.5,1.5
-      70000,40000,20000,1.3,1.3,1.3
-      80000,50000,20000,1.5,1.5,1.5
-      320000,240000,100000,1.5,1.5,1.5
-      320000,240000,100000,1.5,1.5,1.5
-      120000,30000,25000,1.5,1.5,1.5
-      100000,40000,30000,1.3,1.3,1.3
-      200000,100000,100000,1.3,1.3,1.3
-      160000,120000,50000,1.5,1.5,1.5
-      160000,120000,50000,1.5,1.5,1.5
-      320000,240000,100000,1.5,1.5,1.5
-      300000,180000,120000,1.5,1.5,1.5
-      500000,300000,200000,1.3,1.3,1.3
-      9,3,0,1.2,1.2,0
-      7,2,0,1.2,1.2,0
-      40000,10000,15000,1.3,1.3,1.3
-      5000,3800,1000,1.7,1.7,1.7
-      50000,40000,50000,1.65,1.65,1.65
-      10000,8000,1000,1.4,1.4,1.4
-      20000,15000,10000,1.2,1.2,1.2
-      50000,35000,15000,1.5,1.5,1.5
-      85000,44000,25000,1.4,1.4,1.4
-      120000,50000,20000,1.4,1.4,1.4
-      250000,150000,100000,1.8,1.8,1.8
-      250000,125000,125000,1.5,1.5,1.5
-      10000,6000,1000,1.5,1.5,1.5
-      7500,12500,5000,1.5,1.5,1.5
-      15000,10000,5000,1.5,1.5,1.5
-      20000,15000,7500,1.3,1.3,1.3
-      25000,20000,10000,1.5,1.5,1.5
-      50000,50000,20000,1.5,1.5,1.5
-      70000,40000,20000,1.5,1.5,1.5
-      160000,120000,50000,1.5,1.5,1.5
-      75000,55000,25000,1.5,1.5,1.5
-      85000,40000,35000,1.5,1.5,1.5
-      120000,30000,25000,1.5,1.5,1.5
-      100000,40000,30000,1.5,1.5,1.5
-      200000,100000,100000,1.2,1.2,1.2
-      220000,110000,110000,1.3,1.3,1.3
-      240000,120000,120000,1.3,1.3,1.3
-      250000,250000,250000,1.4,1.4,1.4
-      500000,300000,200000,1.5,1.5,1.5
-      300000,180000,120000,1.7,1.7,1.7
-      6,2,0,1.21,1.21,0
-      5,2,0,1.18,1.18,0
-      30000,20000,10000,1.3,1.3,1.3
-      5000,3800,1000,1.8,1.8,1.8
-      50000,40000,50000,1.8,1.8,1.8
-      7500,7000,1000,1.3,1.3,1.3
-      35000,15000,10000,1.5,1.5,1.5
-      50000,20000,30000,1.07,1.07,1.07
-      100000,10000,3000,1.14,1.14,1.14
-      100000,40000,20000,1.5,1.5,1.5
-      55000,50000,30000,1.5,1.5,1.5
-      250000,125000,125000,1.4,1.4,1.4
-      10000,6000,1000,1.5,1.5,1.5
-      7500,12500,5000,1.3,1.3,1.3
-      15000,10000,5000,1.5,1.5,1.5
-      20000,15000,7500,1.3,1.3,1.3
-      160000,120000,50000,1.5,1.5,1.5
-      50000,50000,20000,1.5,1.5,1.5
-      70000,40000,20000,1.3,1.3,1.3
-      160000,120000,50000,1.5,1.5,1.5
-      160000,120000,50000,1.5,1.5,1.5
-      85000,40000,35000,1.2,1.2,1.2
-      120000,30000,25000,1.3,1.3,1.3
-      160000,120000,50000,1.5,1.5,1.5
-      200000,100000,100000,1.5,1.5,1.5
-      160000,120000,50000,1.5,1.5,1.5
-      320000,240000,100000,1.5,1.5,1.5
-      320000,240000,100000,1.5,1.5,1.5
-      500000,300000,200000,1.5,1.5,1.5
-      300000,180000,120000,1.7,1.7,1.7
-      4,3,0,1.21,1.21,0
-      6,3,0,1.21,1.21,0
-      20000,20000,30000,1.3,1.3,1.3
-      7500,5000,800,1.8,1.8,1.8
-      60000,30000,50000,1.8,1.8,1.8
-      8500,5000,3000,1.25,1.25,1.25
-      15000,15000,20000,1.2,1.2,1.2
-      75000,25000,30000,1.05,1.05,1.05
-      87500,25000,30000,1.2,1.2,1.2
-      150000,30000,30000,1.5,1.5,1.5
-      75000,50000,55000,1.2,1.2,1.2
-      500000,250000,250000,1.4,1.4,1.4
-      10000,6000,1000,1.5,1.5,1.5
-      7500,12500,5000,1.5,1.5,1.5
-      15000,10000,5000,1.5,1.5,1.5
-      20000,15000,7500,1.5,1.5,1.5
-      25000,20000,10000,1.5,1.5,1.5
-      50000,50000,20000,1.3,1.3,1.3
-      70000,40000,20000,1.5,1.5,1.5
-      80000,50000,20000,1.2,1.2,1.2
-      320000,240000,100000,1.5,1.5,1.5
-      85000,40000,35000,1.2,1.2,1.2
-      120000,30000,25000,1.5,1.5,1.5
-      100000,40000,30000,1.5,1.5,1.5
-      200000,100000,100000,1.5,1.5,1.5
-      160000,120000,50000,1.5,1.5,1.5
-      240000,120000,120000,1.5,1.5,1.5
-      320000,240000,100000,1.5,1.5,1.5
-      500000,300000,200000,1.5,1.5,1.5
-      300000,180000,120000,1.7,1.7,1.7
-`;
 
-      let lfIDCSV = `11101
-11102
-11103
-11104
-11105
-11106
-11107
-11108
-11109
-11110
-11111
-11112
-11201
-11202
-11203
-11204
-11205
-11206
-11207
-11208
-11209
-11210
-11211
-11212
-11213
-11214
-11215
-11216
-11217
-11218
-12101
-12102
-12103
-12104
-12105
-12106
-12107
-12108
-12109
-12110
-12111
-12112
-12201
-12202
-12203
-12204
-12205
-12206
-12207
-12208
-12209
-12210
-12211
-12212
-12213
-12214
-12215
-12216
-12217
-12218
-13101
-13102
-13103
-13104
-13105
-13106
-13107
-13108
-13109
-13110
-13111
-13112
-13201
-13202
-13203
-13204
-13205
-13206
-13207
-13208
-13209
-13210
-13211
-13212
-13213
-13214
-13215
-13216
-13217
-13218
-14101
-14102
-14103
-14104
-14105
-14106
-14107
-14108
-14109
-14110
-14111
-14112
-14201
-14202
-14203
-14204
-14205
-14206
-14207
-14208
-14209
-14210
-14211
-14212
-14213
-14214
-14215
-14216
-14217
-14218`;
-
-      let LFIDArray = lfIDCSV.split("\n");
-
-      let csvData = lfValCSV.split("\n");
-      let LFDict = {};
-      for (let i = 0; i < LFIDArray.length; i++) {
-        LFDict[LFIDArray[i]] = csvData[i].split(",");
-      }
-      var metalTotalCost = 0;
-      var crystalTotalCost = 0;
-      var deutTotalCost = 0;
-
-      var metalBaseCost = parseInt(LFDict[id][0]);
-      var crystalBaseCost = parseInt(LFDict[id][1]);
-      var deutBaseCost = parseInt(LFDict[id][2]);
-      var metalInc = parseFloat(LFDict[id][3]);
-      var crystalInc = parseFloat(LFDict[id][4]);
-      var deutInc = parseFloat(LFDict[id][5]);
-      var metalCost = parseInt(
-        Math.floor(metalBaseCost * lvl * metalInc ** (lvl - 1))
+    if (BUIDLING_INFO[id].basePop)
+      returnValue.pop = Math.floor(
+        Math.floor(
+          BUIDLING_INFO[id].basePop *
+            Math.pow(BUIDLING_INFO[id].factorPop, lvl - 1)
+        ) * specialFactor
       );
-      var crystalCost = parseInt(
-        Math.floor(crystalBaseCost * lvl * crystalInc ** (lvl - 1))
-      );
-      var deutCost = parseInt(
-        Math.floor(deutBaseCost * lvl * deutInc ** (lvl - 1))
-      );
-      // let metalCost = document.querySelector(".costs").childNodes[3].querySelector('.metal').getAttribute('data-value');
-      // let crystalCost = document.querySelector(".costs").childNodes[3].querySelector('.crystal').getAttribute('data-value');
-      // let deutCost = document.querySelector(".costs").childNodes[3].querySelector('.deuterium') ? document.querySelector(".costs").childNodes[3].querySelector('.deuterium').getAttribute('data-value') : 0;
-      cost = [metalCost, crystalCost, deutCost];
-      let reduction = [0, 0, 0];
-      //#lnx MRC REDUCTION FOR ROCKTAL
-      if (prodBuildings.includes(id)) {
-        reduction[0] = (0.5 / 100) * currentMRC * cost[0];
-        reduction[1] = (0.5 / 100) * currentMRC * cost[1];
-        reduction[2] = (0.5 / 100) * currentMRC * cost[2];
-      }
-      //#lnx MEGALITH REDUCTION FOR ROCKTAL
-      if (id <= 12112 && id >= 12101) {
-        reduction[0] += (currentMegalith / 100) * cost[0];
-        reduction[1] += (currentMegalith / 100) * cost[1];
-        reduction[2] += (currentMegalith / 100) * cost[2];
-      }
-      cost[0] -= reduction[0];
-      cost[1] -= reduction[1];
-      cost[2] -= reduction[2];
 
-      let dur = document
-        .querySelector(".build_duration")
-        .childNodes[3].getAttribute("datetime");
-      time = this.getTimeFromString(dur) / 60 / 60;
-      return { time: time, cost: cost };
-    } else {
-      cost = baseCost[id];
-      if (id == 1 || id == 3 || id == 4) {
-        cost[0] *= Math.pow(1.5, lvl - 1);
-        cost[1] *= Math.pow(1.5, lvl - 1);
-      } else if (id == 2) {
-        cost[0] *= Math.pow(1.6, lvl - 1);
-        cost[1] *= Math.pow(1.6, lvl - 1);
-      } else if (id == 12) {
-        cost[0] *= Math.pow(1.8, lvl - 1);
-        cost[1] *= Math.pow(1.8, lvl - 1);
-        cost[2] *= Math.pow(1.8, lvl - 1);
-      } else if (id == 36) {
-        cost[0] *= Math.pow(5, lvl - 1);
-        cost[2] *= Math.pow(5, lvl - 1);
-        cost[3] *= Math.ceil(Math.pow(2.5, lvl - 1));
-      } else if (id == 33) {
-        cost[1] *= Math.pow(2, lvl - 1);
-        cost[2] *= Math.pow(2, lvl - 1);
-        cost[3] *= Math.pow(2, lvl - 1);
-      } else {
-        cost[0] *= Math.pow(2, lvl - 1);
-        cost[1] *= Math.pow(2, lvl - 1);
-        cost[2] *= Math.pow(2, lvl - 1);
-      }
-      time =
-        (cost[0] + cost[1]) /
-        (2500 * Math.max(4 - lvl / 2, 1) * (1 + robotic) * Math.pow(2, nanite));
-      if (id == 15 || id == 36 || id == 43 || id == 42 || id == 41) {
-        time =
-          ((cost[0] + cost[1]) / 2500) *
-          (1 / (1 + robotic)) *
-          Math.pow(0.5, nanite);
-      }
-    }
-    //#lnx MRC REDUCTION FOR ROCKTAL
-    if (prodBuildings.includes(id)) {
-      cost[0] = cost[0] - (0.5 / 100) * currentMRC * cost[0];
-      cost[1] = cost[1] - (0.5 / 100) * currentMRC * cost[1];
-      cost[2] = cost[2] - (0.5 / 100) * currentMRC * cost[2];
-    }
-
-    time /= this.json.speed;
-    return { time: time, cost: cost };
+    return returnValue;
   }
 
   keyboardActions() {
@@ -12487,7 +16647,7 @@ class OGInfinity {
       return false;
     };
     document.addEventListener("keydown", (event) => {
-      if (event.keyCode == 13 || event.keyCode == 32 || event.keyCode == 27) {
+      if (event.key == "Escape") {
         if (this.json.welcome) return;
         closeDialog();
       }
@@ -12495,7 +16655,7 @@ class OGInfinity {
         if (document.activeElement.getAttribute("type") == "search") {
           return;
         }
-        if (event.keyCode == 13 || event.keyCode == 32) {
+        if (event.code == "Space" || event.key == "Enter") {
           if (document.querySelector(".refreshPhalanxLink")) {
             document.querySelector(".refreshPhalanxLink").click();
           } else {
@@ -12503,24 +16663,140 @@ class OGInfinity {
           }
         }
       }
-      if ((event.ctrlKey || event.metaKey) && event.keyCode == 70) {
-        if (this.page != "highscore") {
-          document.querySelector(".ogl-search-icon").click();
-          event.preventDefault();
-          event.stopPropagation();
+      if ( !$(document.activeElement).is('input') && (event.ctrlKey || event.metaKey) && event.code == "ArrowDown") {
+        let planetList = document.querySelectorAll('[id^="planet-"]');
+        let active = 0;
+        let isMoon = 0;
+        let idList = [];
+        planetList.forEach((planet, index) => {
+          idList.push([
+            planet.id.split("-")[1],
+            planet.querySelector(".moonlink")
+              ? planet.querySelector(".moonlink").href.split("cp=")[1]
+              : null,
+          ]);
+          if (planet.classList.contains("hightlightMoon")) {
+            isMoon = 1;
+            active = index;
+          }
+          if (planet.classList.contains("hightlightPlanet")) {
+            active = index;
+          }
+        });
+
+        let nextIndex = active + 1 < idList.length ? active + 1 : 0;
+        let nextId = idList[nextIndex][isMoon];
+        if (isMoon) {
+          if (document.querySelectorAll(".moonlink").length == 1) return;
+          while (!idList[nextIndex][isMoon]) {
+            nextIndex = nextIndex + 1 < idList.length ? nextIndex + 1 : 0;
+          }
         }
-      } else if ((event.ctrlKey || event.metaKey) && event.keyCode == 69) {
-        document.querySelector(".ogl-empire-icon").click();
+        let url = new URL(window.location.href);
+        url.searchParams.delete("cp");
+        url.searchParams.append("cp", nextId);
+
         event.preventDefault();
         event.stopPropagation();
-      } else if ((event.ctrlKey || event.metaKey) && event.keyCode == 83) {
-        document.querySelector(".ogl-statistics-icon").click();
+        window.location.href = url;
+      }
+      if ( !$(event.target).is('input') && (event.ctrlKey || event.metaKey) && event.code == "ArrowUp") {
+        let planetList = document.querySelectorAll('[id^="planet-"]');
+        let active = 0;
+        let isMoon = 0;
+        let idList = [];
+        planetList.forEach((planet, index) => {
+          idList.push([
+            planet.id.split("-")[1],
+            planet.querySelector(".moonlink")
+              ? planet.querySelector(".moonlink").href.split("cp=")[1]
+              : null,
+          ]);
+          if (planet.classList.contains("hightlightMoon")) {
+            isMoon = 1;
+            active = index;
+          }
+          if (planet.classList.contains("hightlightPlanet")) {
+            active = index;
+          }
+        });
+
+        let nextIndex = active > 0 ? active - 1 : idList.length - 1;
+        let nextId = idList[nextIndex][isMoon];
+        if (isMoon) {
+          if (document.querySelectorAll(".moonlink").length == 1) return;
+          while (!idList[nextIndex][isMoon]) {
+            nextIndex = nextIndex > 0 ? nextIndex - 1 : idList.length - 1;
+          }
+        }
+        let url = new URL(window.location.href);
+        url.searchParams.delete("cp");
+        url.searchParams.append("cp", nextId);
         event.preventDefault();
         event.stopPropagation();
-      } else if ((event.ctrlKey || event.metaKey) && event.keyCode == 68) {
-        document.querySelector(".ogl-targetIcon").click();
+        window.location.href = url;
+      }
+      if ((event.ctrlKey || event.metaKey) && event.code == "ArrowRight") {
+        let planetList = document.querySelectorAll('[id^="planet-"]');
+        let active = 0;
+        let isMoon = 0;
+        let idList = [];
+        planetList.forEach((planet, index) => {
+          idList.push([
+            planet.id.split("-")[1],
+            planet.querySelector(".moonlink")
+              ? planet.querySelector(".moonlink").href.split("cp=")[1]
+              : null,
+          ]);
+          if (planet.classList.contains("hightlightMoon")) {
+            isMoon = 1;
+            active = index;
+          }
+          if (planet.classList.contains("hightlightPlanet")) {
+            active = index;
+          }
+        });
+        if (isMoon || !idList[active][1]) return;
+        let nextId = idList[active][1];
+
+        let url = new URL(window.location.href);
+        url.searchParams.delete("cp");
+        url.searchParams.append("cp", nextId);
+
         event.preventDefault();
         event.stopPropagation();
+        window.location.href = url;
+      }
+      if ((event.ctrlKey || event.metaKey) && event.code == "ArrowLeft") {
+        let planetList = document.querySelectorAll('[id^="planet-"]');
+        let active = 0;
+        let isMoon = 0;
+        let idList = [];
+        planetList.forEach((planet, index) => {
+          idList.push([
+            planet.id.split("-")[1],
+            planet.querySelector(".moonlink")
+              ? planet.querySelector(".moonlink").href.split("cp=")[1]
+              : null,
+          ]);
+          if (planet.classList.contains("hightlightMoon")) {
+            isMoon = 1;
+            active = index;
+          }
+          if (planet.classList.contains("hightlightPlanet")) {
+            active = index;
+          }
+        });
+        if (!isMoon) return;
+        let nextId = idList[active][0];
+
+        let url = new URL(window.location.href);
+        url.searchParams.delete("cp");
+        url.searchParams.append("cp", nextId);
+
+        event.preventDefault();
+        event.stopPropagation();
+        window.location.href = url;
       }
     });
     let actionSkip = () => {
@@ -12555,11 +16831,72 @@ class OGInfinity {
     };
     if (this.page == "fleetdispatch") {
       document.addEventListener("keydown", (event) => {
-        if (event.keyCode == 78) {
+        if (
+          fleetDispatcher.currentPage == "fleet1" &&
+          document.activeElement.tagName != "INPUT"
+        ) {
+          if (event.code == "KeyE") {
+            document.querySelector(".ogl-expedition").click();
+            document.querySelector("#continueToFleet2").click();
+          }
+          if (
+            event.code == "KeyC" &&
+            document.activeElement.tagName != "INPUT"
+          ) {
+            document.querySelector(".ogl-collect").click();
+            document.querySelector("#continueToFleet2").click();
+          }
+          if (event.code == "KeyN" && document.activeElement.tagName != "INPUT")
+            document.querySelector("#resetall").click();
+          if (event.code == "KeyA" && document.activeElement.tagName != "INPUT")
+            document.querySelector("#sendall").click();
+          if (event.code == "KeyM" && document.activeElement.tagName != "INPUT")
+            document.querySelector("span.select-most").click();
+        } else if (fleetDispatcher.currentPage == "fleet2") {
+          if (event.code == "KeyA")
+            document.querySelector("#loadAllResources img").click();
+          if (event.code == "KeyM" && !event.shiftKey)
+            document.querySelector("#loadAllResources .select-most").click();
+          if (event.code == "KeyN")
+            document.querySelector("#loadAllResources .send_none").click();
+          if (event.code == "KeyP" && event.shiftKey)
+            document.querySelector("#pbutton").click();
+          if (event.code == "KeyM" && event.shiftKey)
+            document.querySelector("#mbutton").click();
+          if (event.code == "KeyD" && event.shiftKey)
+            document.querySelector("#dbutton").click();
+          if (event.code == "KeyX" && document.querySelector("#button1.on"))
+            document.querySelector("#missionButton1").click(); // attack
+          if (
+            event.code == "KeyX" &&
+            event.altKey &&
+            document.querySelector("#button2.on")
+          )
+            document.querySelector("#missionButton2").click(); // ACS attack
+          if (event.code == "KeyT" && document.querySelector("#button3.on"))
+            document.querySelector("#missionButton3").click(); // transport
+          if (event.code == "KeyD" && document.querySelector("#button4.on"))
+            document.querySelector("#missionButton4").click(); // deployment
+          if (event.code == "KeyH" && document.querySelector("#button5.on"))
+            document.querySelector("#missionButton5").click(); // hold (ACS defend)
+          if (event.code == "KeyS" && document.querySelector("#button6.on"))
+            document.querySelector("#missionButton6").click(); // espionage
+          if (event.code == "KeyC" && document.querySelector("#button7.on"))
+            document.querySelector("#missionButton7").click(); // colonisation
+          if (event.code == "KeyR" && document.querySelector("#button8.on"))
+            document.querySelector("#missionButton8").click(); // recycle debris field
+          if (
+            event.code == "KeyX" &&
+            event.ctrlKey &&
+            document.querySelector("#button9.on")
+          )
+            document.querySelector("#missionButton9").click(); // moon destruction
+          if (event.code == "KeyE" && document.querySelector("#button15.on"))
+            document.querySelector("#missionButton15").click(); // expedition
         }
       });
       document.addEventListener("keydown", (event) => {
-        if (event.keyCode == 13) {
+        if (event.key == "Enter") {
           if (fleetDispatcher.currentPage == "fleet1") {
             document.querySelector("#continueToFleet2").click();
           } else if (fleetDispatcher.currentPage == "fleet2") {
@@ -12693,7 +17030,7 @@ class OGInfinity {
         if (this.json.welcome) {
           this.json.welcome = false;
           this.saveData();
-          if (this.playerClass == 0) {
+          if (this.playerClass == PLAYER_CLASS_NONE) {
             window.location.href = `https://s${this.universe}-${this.gameLang}.ogame.gameforge.com/game/index.php?page=ingame&component=characterclassselection`;
           } else {
             window.location.href = `https://s${this.universe}-${this.gameLang}.ogame.gameforge.com/game/index.php?page=ingame&component=overview`;
@@ -12739,10 +17076,15 @@ class OGInfinity {
         }
       }
     });
-    let apiTechData = {};
-    for (let id in this.json.apiTechData) {
-      apiTechData[id] = { level: this.json.apiTechData[id] };
-    }
+    let apiTechData = {
+      109: { level: this.json.technology[109] },
+      110: { level: this.json.technology[110] },
+      111: { level: this.json.technology[111] },
+      115: { level: this.json.technology[115] },
+      117: { level: this.json.technology[117] },
+      118: { level: this.json.technology[118] },
+      114: { level: this.json.technology[114] },
+    };
     btn.addEventListener("click", () => {
       let coords = this.current.coords.split(":");
       let json = {
@@ -12879,7 +17221,7 @@ class OGInfinity {
       let first = data.indexOf("'");
       let second = data.indexOf("'", first + 1);
       sender.addEventListener("click", () => {
-        fadeBox("<br/>API Key copied in clipboard");
+        fadeBox(`<br/>${this.getTranslatedText(58)}`);
         navigator.clipboard.writeText(
           data.substr(first + 1, second - first - 1)
         );
@@ -12893,7 +17235,7 @@ class OGInfinity {
         let first = data.indexOf('value="');
         let second = data.indexOf('"', first + 7);
         sender.addEventListener("click", () => {
-          fadeBox("<br/>API Key copied in clipboard");
+          fadeBox(`<br/>${this.getTranslatedText(58)}`);
           navigator.clipboard.writeText(
             data.substr(first + 7, second - first - 7)
           );
@@ -13027,21 +17369,23 @@ class OGInfinity {
       });
       let data = fleetDispatcher.fleetHelper.shipsData;
       for (let id in data) {
-        let infos = `\n            <div class="ogl-fleetInfo">\n                ${
-          data[id].name
-        }\n                <hr>\n                <div><span>Fret</span>${data[
-          id
-        ].cargoCapacity.toLocaleString(
-          document.getElementById("cookiebanner").getAttribute("data-locale")
-        )}</div>\n                <div><span>${this.getTranslatedText(
-          19
-        )}</span>${data[id].speed.toLocaleString(
-          document.getElementById("cookiebanner").getAttribute("data-locale")
-        )}</div>\n                <div><span>Conso</span>${data[
-          id
-        ].fuelConsumption.toLocaleString(
-          document.getElementById("cookiebanner").getAttribute("data-locale")
-        )}</div>\n            </div>`;
+        let infos = `
+        <div class="ogl-fleetInfo">
+        ${data[id].name}
+        <hr>
+        <div><span>${this.getTranslatedText(47)} </span>${toFormatedNumber(
+  data[id].cargoCapacity,
+  0
+)}</div>
+        <div><span>${this.getTranslatedText(48)} </span>${toFormatedNumber(
+  data[id].speed,
+  0
+)}</div>
+        <div><span>${this.getTranslatedText(49)} </span>${toFormatedNumber(
+  data[id].fuelConsumption,
+  0
+)}</div>
+        </div>`;
         let ship = document.querySelector(
           `.technology[data-technology="${id}"]`
         );
@@ -13062,12 +17406,9 @@ class OGInfinity {
           lastFleetBtn = fleet.querySelector(".reversal a");
         }
         let type = fleet.getAttribute("data-mission-type");
-        let originCoords = fleet
-          .querySelector(".originCoords")
-          .innerText.slice(1, -1);
-        this.planetList.forEach((planet) => {
-          let coords = planet.querySelector(".planet-koords").textContent;
-          if (coords == originCoords) {
+        let originCoords = fleet.querySelector(".originCoords").innerText;
+        this.json.empire.forEach((planet) => {
+          if (planet.coordinates == originCoords) {
             fleet.querySelector(".timer").classList.add("friendly");
             fleet.querySelector(".nextTimer") &&
               fleet.querySelector(".nextTimer").classList.add("friendly");
@@ -13082,41 +17423,24 @@ class OGInfinity {
         let backed = [0, 0, 0];
         values.forEach((value, index) => {
           if (index == values.length - 1) {
-            backed[2] = Number(
-              value.innerText
-                .split(LocalizationStrings["thousandSeperator"])
-                .join("")
-            );
+            backed[2] = fromFormatedNumber(value.innerText);
             return;
           }
           if (index == values.length - 2) {
-            backed[1] = Number(
-              value.innerText
-                .split(LocalizationStrings["thousandSeperator"])
-                .join("")
-            );
+            backed[1] = fromFormatedNumber(value.innerText);
             return;
           }
           if (index == values.length - 3) {
-            backed[0] = Number(
-              value.innerText
-                .split(LocalizationStrings["thousandSeperator"])
-                .join("")
-            );
+            backed[0] = fromFormatedNumber(value.innerText);
             return;
           }
-          fleetCount += Number(
-            value.innerText
-              .split(LocalizationStrings["thousandSeperator"])
-              .join("")
-          );
+          fleetCount += fromFormatedNumber(value.innerText);
         });
-        let destination = fleet
-          .querySelector(".destinationCoords a")
-          .innerText.slice(1, -1);
-        let coords =
-          destination +
-          (fleet.querySelector(".destinationData moon") ? "M" : "P");
+        let destCoords = fleet.querySelector(".destinationCoords a").innerText;
+        let destMoon = fleet.querySelector(".destinationData moon")
+          ? true
+          : false;
+        let coords = destCoords.slice(1, -1) + (destMoon ? "M" : "P");
         let revesal = fleet.querySelector(".reversal a");
         if (revesal) {
           revesal.addEventListener("click", () => {
@@ -13140,7 +17464,7 @@ class OGInfinity {
           this.createDOM(
             "div",
             { class: "ogk-ships-count" },
-            this.formatToUnits(fleetCount) + " ships"
+            toFormatedNumber(fleetCount, null, true) + " " + this.getTranslatedText(64)
           )
         );
         if (!fleet.querySelector(".reversal")) return;
@@ -13178,7 +17502,7 @@ class OGInfinity {
           content.html(
             getFormatedDate(
               date.getTime(),
-              "<strong> [G]:[i]:[s] </strong> - [d].[m]"
+              "[d].[m].[y] <strong> [G]:[i]:[s] </strong>"
             )
           );
         };
@@ -13215,59 +17539,439 @@ class OGInfinity {
     window.onbeforeunload = () => cancelController.abort();
   }
 
-  getTranslatedText(id) {
-    let text = {
-      0: ["Gestion des données", "Manage data"],
-      1: ["Ouvrir la liste de cibles", "Open targets list"],
-      2: [
-        "Alterne entre PT et GT comme type de vaisseaux à utilser pour les envois de ressources",
-        "Switch between SC and LC as default ship to use for transporting resources",
+  getTranslatedText(id, type = "text") {
+    let language = ["de", "en"].includes(this.gameLang) ? this.gameLang : "en";
+    // language = "en"
+    let translation = {
+      tech: {
+        1: { de: "Metallmine", en: "Metal Mine" },
+        2: { de: "Kristallmine", en: "Crystal Mine" },
+        3: { de: "Deuterium-Synthetisierer", en: "Deuterium Synthesizer" },
+        4: { de: "Solarkraftwerk", en: "Solar Plant" },
+        12: { de: "Fusionskraftwerk", en: "Fusion Reactor" },
+        14: { de: "Roboterfabrik", en: "Robotics Factory" },
+        15: { de: "Nanitenfabrik", en: "Nanite Factory" },
+        21: { de: "Raumschiffswerft", en: "Shipyard" },
+        22: { de: "Metallspeicher", en: "Metal Storage" },
+        23: { de: "Kristallspeicher", en: "Crystal Storage" },
+        24: { de: "Deuteriumtank", en: "Deuterium Tank" },
+        31: { de: "Forschungslabor", en: "Research Lab" },
+        33: { de: "Terraformer", en: "Terraformer" },
+        34: { de: "Allianzdepot", en: "Alliance Depot" },
+        36: { de: "Raumdock", en: "Space Dock" },
+        41: { de: "Mondbasis", en: "Lunar Base" },
+        42: { de: "Sensorphalanx", en: "Sensor Phalanx" },
+        43: { de: "Sprungtor", en: "Sprungtor" },
+        44: { de: "Raketensilo", en: "Missile Silo" },
+        106: { de: "Spionagetechnik", en: "Espionage Technology" },
+        108: { de: "Computertechnik", en: "Computer Technology" },
+        109: { de: "Waffentechnik", en: "Weapon Technology" },
+        110: { de: "Schildtechnik", en: "Shielding Technology" },
+        111: { de: "Raumschiffpanzerung", en: "Armour Technology" },
+        113: { de: "Energietechnik", en: "Energy Technology" },
+        114: { de: "Hyperraumtechnik", en: "Hyperspace Technology" },
+        115: { de: "Verbrennungstriebwerk", en: "Combustion Drive" },
+        117: { de: "Impulstriebwerk", en: "Impulse Drive" },
+        118: { de: "Hyperraumantrieb", en: "Hyperspace Drive" },
+        120: { de: "Lasertechnik", en: "Laser Technology" },
+        121: { de: "Ionentechnik", en: "Ion Technology" },
+        122: { de: "Plasmatechnik", en: "Plasma Technology" },
+        123: {
+          de: "Intergalaktisches Forschungsnetzwerk",
+          en: "Intergalactic Research Network",
+        },
+        124: { de: "Astrophysik", en: "Astrophysics" },
+        199: { de: "Gravitonforschung", en: "Graviton Technology" },
+        202: { de: "Kleiner Transporter", en: "Small Cargo Ship" },
+        203: { de: "Großer Transporter", en: "Large Cargo Ship" },
+        204: { de: "Leichter Jäger", en: "Light Fighter" },
+        205: { de: "Schwerer Jäger", en: "Heavy Fighter" },
+        206: { de: "Kreuzer", en: "Cruiser" },
+        207: { de: "Schlachtschiff", en: "Battleship" },
+        208: { de: "Kolonieschiff", en: "Colony Ship" },
+        209: { de: "Recycler", en: "Recycler" },
+        210: { de: "Spionagesonde", en: "Espionage Probe" },
+        211: { de: "Bomber", en: "Bomber" },
+        212: { de: "Solarsatellit", en: "Solar Satellite" },
+        213: { de: "Zerstörer", en: "Destroyer" },
+        214: { de: "Todesstern", en: "Death Star" },
+        215: { de: "Schlachtkreuzer", en: "Battlecruiser" },
+        217: { de: "Crawler", en: "Crawler" },
+        218: { de: "Reaper", en: "Reaper" },
+        219: { de: "Pathfinder", en: "Pathfinder" },
+        401: { de: "Raketenwerfer", en: "Rocket Launcher" },
+        402: { de: "Leichtes Lasergeschütz", en: "Light Laser" },
+        403: { de: "Schweres Lasergeschütz", en: "Heavy Laser" },
+        404: { de: "Gaußkanone", en: "Gauss Cannon" },
+        405: { de: "Ionengeschütz", en: "Ion Cannon" },
+        406: { de: "Plasmawerfer", en: "Plasma Turret" },
+        407: { de: "Kleine Schildkuppel", en: "Small Shield Dome" },
+        408: { de: "Große Schildkuppel", en: "Large Shield Dome" },
+        502: { de: "Abfangrakete", en: "Anti-ballistic Missile" },
+        503: { de: "Interplanetarrakete", en: "Interplanetary Missile" },
+        label: { de: "", en: "" },
+      },
+      res: [
+        { de: "Metall", en: "Metal", fr: "Métal" },
+        { de: "Kristall", en: "Crystal", fr: "Cristal" },
+        { de: "Deuterium", en: "Deuterium", fr: "Deutérium" },
+        { de: "Dunkle Materie", en: "Dark Matter", fr: "Matière noire" },
+        { de: "Energie", en: "Energy", fr: "Énergie" },
       ],
-      3: [
-        "Alterne entre transport et stationnement comme type de mission à utiliser pour les rapatriements",
-        "Switch between transport and deployment as default mission to use for transporting resources",
-      ],
-      4: [
-        "Rapatrie les ressources vers la planète/lune ciblée",
-        "Send resources to the target planet/moon",
-      ],
-      5: ["Afficher/masquer les cibles", "Show ignored targets"],
-      6: [
-        "Rentabilité minimale d'une cible pour être considéré comme intéressante",
-        "Minimal target rentability to be considered as interesting",
-      ],
-      7: [
-        "Active/désactive la suppression automatique des rapports inintéréssants",
-        "Toggle automatic removal of low rentability reports",
-      ],
-      8: ["Active/désactive le tableau d'espionnage", "Toggle spy table"],
-      9: ["Ignorer cette planète", "Skip this planet"],
-      10: ["Envoyer vers...", "Send to..."],
-      11: ["Active/désactive la vue compacte", "Toggle compact view"],
-      12: [
-        "Quantité de ressources à laisser ici",
-        "Amount of resources that stays here",
-      ],
-      13: ["Liste des cibles", "Targets list"],
-      14: ["Aucun résultat trouvé", "No data found"],
-      15: ["PT", "SC"],
-      16: ["GT", "LC"],
-      17: ["Epingler ces données", "Pin this data"],
-      18: ["Ressources en vol", "In flight resources"],
-      19: ["Vit.", "Speed"],
-      20: ["Espionner la planète", "Spy planet"],
-      21: ["Espionner la lune", "Spy moon"],
-      22: ["Attaquer la planète", "Attack planet"],
-      23: ["Technologie hyperespace", "Hyperspace technology"],
-      24: ["Seuil rentabilité", "Rentability threshold"],
-      25: ["Quantité de ressources à garder", "Resources amount to keep"],
-      26: [
-        "Nombre d'heures par défaut pour les expéditions (1-16)",
-        "Number of hours by default for the expéditions (1-16)",
+      text: [
+        /*0*/ { de: "Einstellungen", en: "Setting", fr: "Gestion des données" },
+        /*1*/ { de: "Zielliste", en: "Targets list", fr: "Liste des cibles" },
+        /*2*/ {
+          de: "Spielersuche",
+          en: "Player search",
+          fr: "Recherche de joueur",
+        },
+        /*3*/ { de: "Statistik", en: "Statistics", fr: "Statistiques" },
+        /*4*/ { de: "Übersicht", en: "Overview", fr: "Aperçu" },
+        /*5*/ {
+          de: "Planeten Übersicht",
+          en: "Planets overview",
+          fr: "Aperçu des planètes",
+        },
+        /*6*/ { de: "Hier", en: "Here", fr: "Ici" },
+        /*7*/ {
+          de: "Fehlerberichte",
+          en: "Bug reporting",
+          fr: "Rapport de bogue",
+        },
+        /*8*/ {
+          de: "Featureanfrage",
+          en: "Feature request",
+          fr: "Demande de fonctionnalité",
+        },
+        /*9*/ {
+          de: "Universumseigenschaften",
+          en: "Universe characteristics",
+          fr: "Caractéristiques de l'univers",
+        },
+        /*10*/ { de: "Punkte #1", en: "Points #1", fr: "Point #1" },
+        /*11*/ {
+          de: "Öko Geschwindigkeit",
+          en: "Eco Speed",
+          fr: "Vitesse éco",
+        },
+        /*12*/ {
+          de: "Flottengeschwindigkeit (feindlich)",
+          en: "Fleet speed (war)",
+          fr: "Vitesse de flotte (guerre)",
+        },
+        /*13*/ {
+          de: "Flottengeschwindigkeit (friedlich)",
+          en: "Fleet speed (peaceful)",
+          fr: "Vitesse de flotte (paisible)",
+        },
+        /*14*/ {
+          de: "Flottengeschwindigkeit (halten)",
+          en: "Fleet speed (hoding)",
+          fr: "Vitesse de la flotte (en attente)",
+        },
+        /*15*/ {
+          de: "Datenverwaltung",
+          en: "Data management",
+          fr: "Gestion de données",
+        },
+        /*16*/ {
+          de: "Expeditionsdaten",
+          en: "Expeditions data",
+          fr: "Données d'expéditions",
+        },
+        /*17*/ {
+          de: "Kampfdaten",
+          en: "Combats data",
+          fr: "Combat les données",
+        },
+        /*18*/ { de: "Zieldaten", en: "Targets data", fr: "Données cibles" },
+        /*19*/ {
+          de: "Gescannte Daten (Galaxie)",
+          en: "Scanned data (galaxy)",
+          fr: "Données numérisées (galaxie)",
+        },
+        /*20*/ {
+          de: "Optionsdaten",
+          en: "Options data",
+          fr: "Données d'options",
+        },
+        /*21*/ {
+          de: "Cache und Temporäre Daten",
+          en: "Cache and Temp data",
+          fr: "Données de cache et temporaires",
+        },
+        /*22*/ {
+          de: "Andere Add-On-Daten",
+          en: "Other add-on's data",
+          fr: "Données d'autres add-ons",
+        },
+        /*23*/ { de: "Aktualisieren", en: "Update", fr: "Mettre à jour" },
+        /*24*/ { de: "Exportieren", en: "Export", fr: "Exportation" },
+        /*25*/ { de: "Importieren", en: "Import", fr: "Importer" },
+        /*26*/ { de: "Zurücksetzen", en: "Reset", fr: "Réinitialiser" },
+        /*27*/ { de: "Speichern", en: "Save", fr: "Sauvegarder" },
+        /*28*/ {
+          de: "Am Planeten verbleibende Ressourcen",
+          en: "Resources to keep on planets",
+          fr: "Ressources restantes sur la planète",
+        },
+        /*29*/ {
+          de: "Am Planeten verbleibende Schiffe",
+          en: "Ships to keep on planets",
+          fr: "Navires restant sur la planète",
+        },
+        /*30*/ {
+          de: "Standardmission (eigene)",
+          en: "Default mission (own)",
+          fr: "Mission par défaut (propre)",
+        },
+        /*31*/ {
+          de: "Standardmission (andere)",
+          en: "Default mission (others)",
+          fr: "Mission par défaut (autres)",
+        },
+        /*32*/ {
+          de: "Standardmission (Expedition)",
+          en: "Default mission (expedition)",
+          fr: "Mission par défaut (expédition)",
+        },
+        /*33*/ {
+          de: "Aktivitätstimer anzeigen",
+          en: "Show activity timers",
+          fr: "Afficher les minuteurs d'activité",
+        },
+        /*34*/ {
+          de: "Automatisches Abrufen von Imperium deaktivieren",
+          en: "Disable auto fetch Empire",
+          fr: "Désactiver la récupération automatique de l'Empire",
+        },
+        /*35*/ {
+          de: "Rentabilitätswert",
+          en: "Rentability value",
+          fr: "Valeur de rentabilité",
+        },
+        /*36*/ {
+          de: "Uhren auf die lokale Zeitzone umstellen",
+          en: "Change clocks to local time zone",
+          fr: "Changer les horloges au fuseau horaire local",
+        },
+        /*37*/ {
+          de: "Prozentsatz der derzeit im Flug befindlichen Flotte",
+          en: "Percentage of fleet currently in flight",
+          fr: "Pourcentage de la flotte actuellement en vol",
+        },
+        /*38*/ { de: "Fliegend", en: "Flying", fr: "En volant" },
+        /*39*/ { de: "Fehlend", en: "Missing", fr: "Disparu" },
+        /*40*/ { de: "Gesamt", en: "Total", fr: "Total" },
+        /*41*/ { de: "Expeditionen", en: "Expeditions", fr: "Expéditions" },
+        /*42*/ { de: "Planet(en)", en: "planet(s)", fr: "planète(s)" },
+        /*43*/ { de: "Ankunft", en: "Arrival", fr: "Arrivées" },
+        /*44*/ { de: "Dauer", en: "Duration", fr: "Durée" },
+        /*45*/ { de: "Rückkehr", en: "Return", fr: "Retourner" },
+        /*46*/ {
+          de: "Keine Missionen...",
+          en: "No missions...",
+          fr: "Aucune mission...",
+        },
+        /*47*/ { de: "Ladekapazität", en: "Cargo Capacity", fr: "Fret" },
+        /*48*/ { de: "Geschwindigkeit", en: "Speed", fr: "Vitesse" },
+        /*49*/ {
+          de: "Treibstoffverbrauch",
+          en: "Fuel Consumption",
+          fr: "Consommation",
+        },
+        /*50*/ {
+          de: "Amortisationsdauer",
+          en: "Payback period",
+          fr: "Période de remboursement",
+        },
+        /*51*/ { de: "Ökonomie", en: "Economy", fr: "Économie" },
+        /*52*/ { de: "Forschung", en: "Research", fr: "Recherche" },
+        /*53*/ { de: "Militär", en: "Military", fr: "Militaire" },
+        /*54*/ { de: "Verteidigung", en: "Defense", fr: "La défense" },
+        /*55*/ { de: "Sieg", en: "Win", fr: "Gagner" },
+        /*56*/ { de: "Niederlage", en: "Lose", fr: "Perdre" },
+        /*57*/ { de: "Unentschieden", en: "Draw", fr: "Dessiner" },
+        /*58*/ {
+          de: "API in die Zwischenablage kopiert",
+          en: "API Key copied in clipboard",
+          fr: "Clé API copiée dans le presse-papiers",
+        },
+        /*59*/ { de: "Verhältnis", en: "Ratio", fr: "Rapport" },
+        /*60*/ { de: "Stunde", en: "Hour", fr: "Heure" },
+        /*61*/ { de: "Tag", en: "Day", fr: "Jour" },
+        /*62*/ { de: "Woche", en: "Week", fr: "Semaine" },
+        /*63*/ { de: "Flotte", en: "Fleet", fr: "Flotte" },
+        /*64*/ { de: "Schiffe", en: "ships", fr: "navires" },
+        /*65*/ { de: "Recycling", en: "Recycling", fr: "Recyclage" },
+        /*66*/ {
+          de: "Für diese Funktionen ist der Commander erforderlich ...",
+          en: "The commander officier is required for these features...",
+          fr: "L'officier de commandement est requis pour ces fonctions...",
+        },
+        /*67*/ { de: "Ressourcen", en: "Resources", fr: "Ressources" },
+        /*68*/ { de: "Verluste", en: "Losses", fr: "Pertes" },
+        /*69*/ { de: "Recycled", en: "Recycled", fr: "Recyclé" },
+        /*70*/ { de: "Treibstoff", en: "Fuel", fr: "Carburant" },
+        /*71*/ { de: "S. Loch", en: "B. Hole", fr: "Trou noir" },
+        /*72*/ {
+          de: "Beste Kämpfe",
+          en: "Best combats",
+          fr: "Meilleurs combats",
+        },
+        /*73*/ { de: "Name", en: "Name", fr: "Nom" },
+        /*74*/ { de: "Beute", en: "Loot", fr: "Proie" },
+        /*75*/ { de: "Schaden", en: "Damage", fr: "Dommage" },
+        /*76*/ { de: "Trümmerfeld", en: "Debris", fr: "Débris" },
+        /*77*/ { de: "Anpassen", en: "Adjust", fr: "Régler" },
+        /*78*/ { de: "Items", en: "Items", fr: "Items" },
+        /*79*/ { de: "Aliens", en: "Aleins", fr: "Extraterrestres" },
+        /*80*/ { de: "Piraten", en: "Pirates", fr: "Pirates" },
+        /*81*/ { de: "Spät", en: "Late", fr: "En retard" },
+        /*82*/ { de: "Frühzeitig", en: "Early", fr: "De bonne heure" },
+        /*83*/ { de: "Leer", en: "Empty", fr: "Vide" },
+        /*84*/ { de: "Händler", en: "Merchant", fr: "Marchande" },
+        /*85*/ { de: "Produktion", en: "Production", fr: "Production" },
+        /*86*/ { de: "Kampf", en: "Combat", fr: "Combat" },
+        /*87*/ { de: "Antrieb", en: "Drive", fr: "Conduire" },
+        /*88*/ {
+          de: "Empfohlene Weiterentwicklung",
+          en: "Recommended further development",
+          fr: "Développement ultérieur recommandé",
+        },
+        /*89*/ { de: "Verteidigung", en: "Defence", fr: "Défense" },
+        /*90*/ { de: "Minen", en: "Mines", fr: "Mines" },
+        /*91*/ { de: "Allgemein", en: "General", fr: "Général" },
+        /*92*/ { de: "Kämpfe", en: "Combats", fr: "Combat" },
+        /*93*/ { de: "Astro", en: "Astro", fr: "Astro" },
+        /*94*/ { de: "Computer", en: "Computer", fr: "L'ordinateur" },
+        /*95*/ { de: "Hyperraum", en: "Hyperspace", fr: "Hyperespace" },
+        /*96*/ { de: "Plasma", en: "Plasma", fr: "Plasma" },
+        /*97*/ { de: "Datum", en: "Date", fr: "" },
+        /*98*/ { de: "Koordinaten", en: "Coords", fr: "" },
+        /*99*/ { de: "Beute", en: "Loot", fr: "" },
+        /*100*/ { de: "Flotte", en: "Fleet", fr: "" },
+        /*101*/ { de: "Verteidigung", en: "Defense", fr: "" },
+        /*102*/ { de: "Aktionen", en: "Actions", fr: "" },
+        /*103*/ { de: "Optionen", en: "Options", fr: "" },
+        /*104*/ {
+          de: "Automatisches Löschen von wenig rentablen Berichten aktivieren/deaktivieren",
+          en: "Toggle automatic removal of low rentability reports",
+          fr: "Active/désactive la suppression automatique des rapports inintéréssants",
+        },
+        /*105*/ {
+          de: "Minimale Rentabilität um als interessant angesehen zu werden",
+          en: "Minimal target rentability to be considered as interesting",
+          fr: "Rentabilité minimale d'une cible pour être considéré comme intéressante",
+        },
+        /*106*/ {
+          de: "Spionagetabelle aktivieren/deaktivieren",
+          en: "oggle spy table",
+          fr: "Active/désactive le tableau d'espionnage",
+        },
+        /*107*/ {
+          de: "Nicht genügend Transportschiffe...",
+          en: "Not enough cargo ships...",
+          fr: "",
+        },
+        /*108*/ { de: "Kein Kampfschiff...", en: "No combat ship...", fr: "" },
+        /*109*/ {
+          de: "Keine Spionagesonde...",
+          en: "No Espionage Probe...",
+          fr: "",
+        },
+        /*110*/ { de: "Kein Pathfinder...", en: "No Pathfinder...", fr: "" },
+        /*111*/ { de: "Keine Mission...", en: "No mission...", fr: "" },
+        /*112*/ {
+          de: "Unbekannte Expeditionsnachricht...",
+          en: "Unknown expedition message...",
+          fr: "",
+        },
+        /*113*/ {
+          de: "Hilf mir alle zu finden",
+          en: "Help me find them all",
+          fr: "",
+        },
+        /*114*/ {
+          de: "Warnung: Expeditionsposition wird schwach...",
+          en: "Warning: expedition position is getting weak...",
+          fr: "",
+        },
+        /*115*/ {
+          de: "Fehler: Keine Schiffe ausgewählt",
+          en: "Error: No ships selected",
+          fr: "",
+        },
+        /*116*/ {
+          de: "Fehler: Keine Mission verfügbar",
+          en: "Error: No mission available",
+          fr: "",
+        },
+        /*117*/ {
+          de: "Fehler: Aktueller Planet/Mond",
+          en: "Errog: Current planet/moon",
+          fr: "",
+        },
+        /*118*/ {
+          de: "Keine neue Kolonie",
+          en: "No new colony",
+          fr: "Pas de nouvelle colonie",
+        },
+        /*119*/ { de: "Handelskurs", en: "Trade rate", fr: "" },
+        /*120*/ { de: "Rentabilität", en: "Profitability", fr: "Rentabilité" },
+        /*121*/ {
+          de: "Die Amortisationszeit errechnet sich aus der Differenz der Gesamtproduktion und den Kosten für die Zielstufe. Ausreichende Energieversorgung und unveränderte globale Produktionsbooster (Spieler- und Allianzklasse, Offiziere) werden vorausgesetzt. Zur Bewertung der Ressourcen wird der angegebene Handelskurs verwendet.<br>Bei Minen wird die Änderung der Gesamtproduktion durch erhöhtes Crawler-Limit berücksichtigt, dabei wird der Produktionsfaktor und eine eventuelle Begrenzung wie angegeben verwendet.<br>Für die Astrophysik werden die Forschungskosten und die Kosten für den Bau von Minen auf der neuen Kolonie bis zum Durchschnittslevel berücksichtigt. Die Produktionsänderung wird durch die durchschnittliche Planetenparameter angenähert, da die tatsächliche Produktion von der Temperatur und der Position der neuen Kolonie abhängt. Baukosten für die Energieversorgung oder andere Anlagen werden nicht berücksichtigt.",
+          en: "The payback period is calculated based on the differnece in total production and the cost for the target level. Sufficient energy supply and unchanged global production boosters (player and alliance class, officers) are assumed. The configured trade rate is used to value the resources.<br>For mines the change of total production dueto increased crawler limit is taken into account, using the settings from above.<br>For Astrophysics the research cost and the cost of building mines to the average level on the new colony are taken into account.The change in production ist approximated by the average planet parameters, because the actual production depends on the new colony's temperature and position. Building costs for energy supply or other facilities are not considered.",
+          fr: "La période de récupération est calculée en fonction de la différence entre la production totale et le coût pour le niveau cible. Un approvisionnement énergétique suffisant et des boosters de production mondiaux inchangés (classe de joueur et d'alliance, officiers) sont supposés. Le taux d'échange configuré est utilisé pour évaluer les ressources.<br>Pour les mines, le changement de production totale dû à l'augmentation de la limite de chenilles est pris en compte, en utilisant les paramètres ci-dessus.<br>Pour l'astrophysique, le coût de recherche et le coût de construction des mines au niveau moyen de la nouvelle colonie sont pris en compte. Le changement de production est approximé par les paramètres moyens de la planète, car la production réelle dépend de la température et de la position de la nouvelle colonie. Les coûts de construction pour l'approvisionnement en énergie ou d'autres installations ne sont pas pris en compte.",
+        },
+        /*122*/ {
+          de: "Nur Werte größer gleich 1 ...",
+          en: "Only values greater or equal to 1 allowed...",
+          fr: "Seules les valeurs supérieures ou égales à 1 sont autorisées...",
+        },
+        /*123*/ {
+          de: "Alle Nachrichten löschen",
+          en: "Delete all messages",
+          fr: "Supprimer tous les messages",
+        },
+        /*124*/ {
+          de: "Feindliche Spionageberichte löschen",
+          en: "Delete enemy spy reports",
+          fr: "Supprimer les rapports d'espionnage ennemis",
+        },
+        /*125*/ {
+          de: "Wenn aktiviert, wird die Anzahl der Crawler mit den derzeit gebauten Crawlern begrenzt.",
+          en: "If activated, the number of crawlers will be limited with the currently built crawlers.",
+          fr: "S'il est activé, le nombre de Crawler d'exploration sera limité aux Crawler d'exploration actuellement construits.",
+        },
+        /*126*/ {
+          de: "Crawler Produktionsfaktor",
+          en: "Crawler production factor",
+          fr: "Crawler facteur de production",
+        },
+        /*127*/ { de: "Ziel", en: "Destination", fr: "Destination" },
+        /*128*/ {
+          de: "Ressourcentransport",
+          en: "Resource transport",
+          fr: "Transport des ressources",
+        },
+        /*129*/ { de: "Abriss", en: "Demolition", fr: "Démolition" },
+        /*130*/ { de: "Filter", en: "Filter", fr: "Filtre" },
+        /*131*/ { de: "Kapazität", en: "Capacity", fr: "Capacité" },
+        /*132*/ {
+          de: "Füllzeit",
+          en: "Filling time",
+          fr: "Temps de remplissage",
+        },
+        /*133*/ {
+          de: "Beitragen oder Bugs melden",
+          en: "Contribute or bug report",
+          fr: "Contribuer ou signaler un bogue"
+        },
       ],
     };
-    let line = this.gameLang == "fr" ? 0 : 1;
-    return '<span class="ogl-translated">' + text[id][line] + "</span>";
+    return translation[type][id][language];
   }
 
   getLocalStorageSize() {
@@ -13318,7 +18022,7 @@ class OGInfinity {
       this.createDOM(
         "div",
         { class: "ogi-checkbox" },
-        '<strong class="undermark">Contribute or bug report</strong>\n        <a target="_blank" href="https://discord.gg/9aMdQgk"> Discord </span>'
+        `<strong class="undermark">${this.getTranslatedText(133)}</strong>\n        <a target="_blank" href="https://discord.gg/9aMdQgk"> Discord </span>`
       )
     );
     // dataDiv.appendChild(
@@ -13329,67 +18033,6 @@ class OGInfinity {
     //   )
     // );
     let optiondiv = dataDiv.appendChild(this.createDOM("hr"));
-    optiondiv = dataDiv.appendChild(
-      this.createDOM(
-        "span",
-        {
-          style:
-            "display: flex;justify-content: space-between; align-items: center;",
-        },
-        "Show activity timers"
-      )
-    );
-    let timerCheck = optiondiv.appendChild(
-      this.createDOM("input", { type: "checkbox" })
-    );
-    timerCheck.addEventListener("change", () => {
-      this.json.options.activitytimers = timerCheck.checked;
-      this.saveData();
-    });
-    if (this.json.options.activitytimers) {
-      timerCheck.checked = true;
-    }
-
-    dataDiv.appendChild(this.createDOM("hr"));
-    // optiondiv = dataDiv.appendChild(
-    //   this.createDOM(
-    //     "span",
-    //     { style: "display: flex;justify-content: space-between; align-items: center;" },
-    //     "Show planet icons"
-    //   )
-    // );
-    // let planetIconsCheck = optiondiv.appendChild(this.createDOM("input", { type: "checkbox" }));
-    // planetIconsCheck.addEventListener("change", () => {
-    //   this.json.options.planetIcons = planetIconsCheck.checked;
-    //   this.saveData();
-    // });
-    // if (this.json.options.planetIcons) {
-    //   planetIconsCheck.checked = true;
-    // }
-    // dataDiv.appendChild(this.createDOM("hr"));
-    optiondiv = dataDiv.appendChild(
-      this.createDOM(
-        'span',
-        {
-          style:
-            'display: flex;justify-content: space-between; align-items: center;',
-        },
-        'Disable auto fetch Empire'
-      )
-    );
-    let disableautofetchempirebox = optiondiv.appendChild(
-      this.createDOM('input', { type: 'checkbox' })
-    );
-    disableautofetchempirebox.addEventListener('change', () => {
-      this.json.options.disableautofetchempire =
-        disableautofetchempirebox.checked;
-      this.saveData();
-    });
-    if (this.json.options.disableautofetchempire) {
-      disableautofetchempirebox.checked = true;
-    }
-    dataDiv.appendChild(this.createDOM('hr'));
-
     optiondiv = dataDiv.appendChild(
       this.createDOM(
         "span",
@@ -13407,7 +18050,7 @@ class OGInfinity {
     );
 
     dataDiv.appendChild(this.createDOM("hr"));
-    dataDiv.appendChild(this.createDOM("h1", {}, "Server settings"));
+    dataDiv.appendChild(this.createDOM("h1", {}, this.getTranslatedText(9)));
     let srvDatas = dataDiv.appendChild(
       this.createDOM(
         "span",
@@ -13415,19 +18058,23 @@ class OGInfinity {
           style:
             "display: flex;justify-content: space-between; align-items: center;",
         },
-        "Server Settings : <br/>Top Score : " +
-          this.formatToUnits(this.json.topScore) +
-          "<br/>Eco Speed : " +
-          this.json.speed +
-          "<br/>Fleet Speed War: " +
-          this.json.speedFleetWar +
-          "<br/>Fleet Speed Peaceful: " +
-          this.json.speedFleetPeaceful +
-          "<br/>Fleet Speed Holding: " +
-          this.json.speedFleetHolding
+        `<br/>${this.getTranslatedText(10)}: ` +
+        toFormatedNumber(this.json.topScore, null, true) +
+        `<br/>${this.getTranslatedText(11)}: ` +
+        toFormatedNumber(this.json.speed) +
+        `<br/>${this.getTranslatedText(12)}: ` +
+        toFormatedNumber(this.json.speedFleetWar) +
+        `<br/>${this.getTranslatedText(13)}: ` +
+        toFormatedNumber(this.json.speedFleetPeaceful) +
+        `<br/>${this.getTranslatedText(14)}: ` +
+        toFormatedNumber(this.json.speedFleetHolding)
       )
     );
-    let srvDatasBtn = this.createDOM("button", { class: "btn_blue" }, "Update");
+    let srvDatasBtn = this.createDOM(
+      "button",
+      { class: "btn_blue update" },
+      this.getTranslatedText(23)
+    );
     srvDatas.appendChild(srvDatasBtn);
     srvDatasBtn.addEventListener("click", () => {
       this.json.updateSettings = true;
@@ -13443,7 +18090,7 @@ class OGInfinity {
             style:
               "display: flex;justify-content: space-between; align-items: center;margin-bottom: 10px",
           },
-          "Change clocks to local time zone"
+          this.getTranslatedText(36)
         )
       );
       let timeZoneCheck = spanZone.appendChild(
@@ -13462,7 +18109,9 @@ class OGInfinity {
       this.createDOM(
         "h1",
         {},
-        `Data management <span style="font-weight: 100;color: white; float:right"> <strong class="${
+        `${this.getTranslatedText(
+          15
+        )}<span style="font-weight: 100;color: white; float:right"> <strong class="${
           size.total > 4 ? "overmark" : "undermark"
         }"> ${size.total}</strong>  / 5 Mb`
       )
@@ -13472,56 +18121,58 @@ class OGInfinity {
       this.createDOM(
         "div",
         { class: "ogi-checkbox" },
-        '<label for="expeditions">Expeditions data</label>\n        <input type="checkbox" id="expeditions" name="expeditions">'
+        `<label for="expeditions">${this.getTranslatedText(16)}</label>
+        <input type="checkbox" id="expeditions" name="expeditions">`
       )
     );
     let combatsBox = dataDiv.appendChild(
       this.createDOM(
         "div",
         { class: "ogi-checkbox" },
-        '<label for="combats">Combats data</label>\n        <input type="checkbox" id="combats" name="combats">'
+        `<label for="combats">${this.getTranslatedText(17)}</label>
+        <input type="checkbox" id="combats" name="combats">`
       )
     );
     let targetsBox = dataDiv.appendChild(
       this.createDOM(
         "div",
         { class: "ogi-checkbox" },
-        '<label for="targets">Targets data</label>\n        <input type="checkbox" id="targets" name="targets">'
+        `<label for="targets">${this.getTranslatedText(18)}</label>
+        <input type="checkbox" id="targets" name="targets">`
       )
     );
     let scanBox = dataDiv.appendChild(
       this.createDOM(
         "div",
         { class: "ogi-checkbox" },
-        '<label for="scan">Scanned data (galaxy)</label>\n        <input type="checkbox" id="scan" name="scan">'
+        `<label for="scan">${this.getTranslatedText(19)}</label>
+        <input type="checkbox" id="scan" name="scan">`
       )
     );
     let OptionsBox = dataDiv.appendChild(
       this.createDOM(
         "div",
         { class: "ogi-checkbox" },
-        '<label for="combats">Options data</label>\n        <input type="checkbox" id="combats" name="combats">'
+        `<label for="combats">${this.getTranslatedText(20)}</label>
+        <input type="checkbox" id="combats" name="combats">`
       )
     );
     let cacheBox = dataDiv.appendChild(
       this.createDOM(
         "div",
         { class: "ogi-checkbox" },
-        '<label for="temp">Cache and Temp data</label>\n        <input type="checkbox" id="temp" name="temp" checked>'
+        `<label for="temp">${this.getTranslatedText(21)}</label>
+        <input type="checkbox" id="temp" name="temp" checked>`
       )
     );
     let purgeBox = dataDiv.appendChild(
       this.createDOM(
         "div",
-        {
-          class: "ogi-checkbox",
-          style: "margin-top: 10px",
-        },
-        `<label for="purge">Other add-on's data <span class="${
+        { class: "ogi-checkbox", style: "margin-top: 10px" },
+        `<label for="purge">${this.getTranslatedText(22)}<span class="${
           size.other > 3 ? "undermark" : "overmark"
-        }">(${
-          size.other
-        }Mb)</span></label>\n        <input type="checkbox" id="purge" name="purge">`
+        }"> (${size.other}Mb)</span></label>
+        <input type="checkbox" id="purge" name="purge">`
       )
     );
     dataDiv.appendChild(this.createDOM("hr"));
@@ -13546,7 +18197,11 @@ class OGInfinity {
       this.createDOM("div", { style: "display: flex;align-items: flex-end;" })
     );
     let exportBtn = dataBtns.appendChild(
-      this.createDOM("button", { class: "btn_blue" }, "Export")
+      this.createDOM(
+        "button",
+        { class: "btn_blue" },
+        this.getTranslatedText(24)
+      )
     );
     let fileHandler = dataBtns.appendChild(
       this.createDOM("input", {
@@ -13561,7 +18216,7 @@ class OGInfinity {
       this.createDOM(
         "label",
         { for: "file", class: "btn_blue", style: "margin: 0px 10px" },
-        "Import"
+        this.getTranslatedText(25)
       )
     );
     fileHandler.addEventListener("change", () => {
@@ -13582,7 +18237,11 @@ class OGInfinity {
       download(data, `oginfinity-${this.gameLang}-${this.universe}.data`);
     });
     let resetBtn = dataBtns.appendChild(
-      this.createDOM("button", { class: "btn_blue ogl-btn_red" }, "Reset")
+      this.createDOM(
+        "button",
+        { class: "btn_blue ogl-btn_red" },
+        this.getTranslatedText(26)
+      )
     );
     container.appendChild(
       this.createDOM("div", { style: "width: 1px; background: #10171d;" })
@@ -13590,7 +18249,11 @@ class OGInfinity {
     let settingDiv = container.appendChild(
       this.createDOM("div", { style: "margin-top: 12px;" })
     );
-    let saveBtn = this.createDOM("button", { class: "btn_blue save" }, "Save");
+    let saveBtn = this.createDOM(
+      "button",
+      { class: "btn_blue save" },
+      this.getTranslatedText(27)
+    );
     settingDiv.appendChild(this.keepOnPlanetDialog(null, saveBtn));
     settingDiv.appendChild(this.createDOM("hr"));
     let span = settingDiv.appendChild(
@@ -13600,7 +18263,7 @@ class OGInfinity {
           style:
             "display: flex;justify-content: space-between; align-items: center;",
         },
-        "Default mission (own)"
+        this.getTranslatedText(30)
       )
     );
     let missionDiv = span.appendChild(
@@ -13645,17 +18308,17 @@ class OGInfinity {
       this.saveData();
     });
     settingDiv.appendChild(this.createDOM("hr"));
-    span = settingDiv.appendChild(
+    optiondiv = settingDiv.appendChild(
       this.createDOM(
         "span",
         {
           style:
             "display: flex;justify-content: space-between; align-items: center;",
         },
-        "Default mission (others)"
+        this.getTranslatedText(31)
       )
     );
-    missionDiv = span.appendChild(
+    missionDiv = optiondiv.appendChild(
       this.createDOM("div", { style: "display:flex" })
     );
     none = missionDiv.appendChild(
@@ -13694,17 +18357,17 @@ class OGInfinity {
       this.json.options.foreignMission = 0;
     });
     settingDiv.appendChild(this.createDOM("hr"));
-    span = settingDiv.appendChild(
+    optiondiv = settingDiv.appendChild(
       this.createDOM(
         "span",
         {
           style:
             "display: flex;justify-content: space-between; align-items: center;",
         },
-        "Default mission (expedition)"
+        this.getTranslatedText(32)
       )
     );
-    missionDiv = span.appendChild(
+    missionDiv = optiondiv.appendChild(
       this.createDOM("div", { style: "display:flex" })
     );
     none = missionDiv.appendChild(
@@ -13746,14 +18409,61 @@ class OGInfinity {
     settingDiv.appendChild(this.createDOM("hr"));
 
     optiondiv = settingDiv.appendChild(
-      this.createDOM("span", {}, "Rentability value")
+      this.createDOM(
+        "span",
+        {
+          style:
+            "display: flex;justify-content: space-between; align-items: center;",
+        },
+        this.getTranslatedText(33)
+      )
+    );
+    let timerCheck = optiondiv.appendChild(
+      this.createDOM("input", { type: "checkbox" })
+    );
+    timerCheck.addEventListener("change", () => {
+      this.json.options.activitytimers = timerCheck.checked;
+      this.saveData();
+    });
+    if (this.json.options.activitytimers) {
+      timerCheck.checked = true;
+    }
+
+    settingDiv.appendChild(this.createDOM("hr"));
+
+    optiondiv = settingDiv.appendChild(
+      this.createDOM(
+        "span",
+        {
+          style:
+            "display: flex;justify-content: space-between; align-items: center;",
+        },
+        this.getTranslatedText(34)
+      )
+    );
+    let disableautofetchempirebox = optiondiv.appendChild(
+      this.createDOM("input", { type: "checkbox" })
+    );
+    disableautofetchempirebox.addEventListener("change", () => {
+      this.json.options.disableautofetchempire =
+        disableautofetchempirebox.checked;
+      this.saveData();
+    });
+    if (this.json.options.disableautofetchempire) {
+      disableautofetchempirebox.checked = true;
+    }
+
+    settingDiv.appendChild(this.createDOM("hr"));
+
+    optiondiv = settingDiv.appendChild(
+      this.createDOM("span", {}, this.getTranslatedText(35))
     );
     let rvalInput = optiondiv.appendChild(
       this.createDOM("input", {
         type: "text",
         class: "ogl-rvalInput ogl-formatInput tooltip",
-        value: this.json.options.rvalLimit,
-        title: this.getTranslatedText(6),
+        value: toFormatedNumber(this.json.options.rvalLimit),
+        title: this.getTranslatedText(105),
       })
     );
 
@@ -13793,10 +18503,12 @@ class OGInfinity {
 
     settingDiv.appendChild(saveBtn);
     saveBtn.addEventListener("click", () => {
-      this.json.options.rvalLimit = parseInt(
-        this.removeNumSeparator(rvalInput.value)
-      );
-      if (ptreInput.value && (ptreInput.value.replace(/-/g, "").length == 18 && ptreInput.value.indexOf("TM") == 0)) {
+      this.json.options.rvalLimit = fromFormatedNumber(rvalInput.value, true);
+      if (
+        ptreInput.value &&
+        ptreInput.value.replace(/-/g, "").length == 18 &&
+        ptreInput.value.indexOf("TM") == 0
+      ) {
         this.json.options.ptreTK = ptreInput.value;
       } else {
         this.json.options.ptreTK = "";
@@ -13807,6 +18519,7 @@ class OGInfinity {
         1,
         Math.min(expeditionDefaultTime.value, 16)
       );
+      this.json.needSync = true;
       this.saveData();
       document.querySelector(".ogl-dialog .close-tooltip").click();
     });
@@ -13864,6 +18577,7 @@ class OGInfinity {
           json.options.empire = false;
         }
         this.json = json;
+        this.json.needSync = false;
         this.saveData();
         document.location =
           document.location.origin +
@@ -13876,26 +18590,12 @@ class OGInfinity {
   updateFlyings() {
     const FLYING_PER_PLANETS = {};
     const eventTable = document.getElementById("eventContent");
-    const ACSrows = eventTable.querySelectorAll("tr.allianceAttack");
-    const unionTable = [];
-    ACSrows.forEach(acsRow => {
-      const union = Array.from(acsRow.classList)
-        .find(cl => cl.includes("union")).split("unionunion")[1];
-      unionTable.push([union, acsRow.querySelectorAll("td")[1].innerText]);
-    });
-    const unionArrivalTime = Object.fromEntries(unionTable);
-    const rows = eventTable.querySelectorAll("tr.eventFleet");
+    const rows = eventTable.querySelectorAll("tr");
     rows.forEach((row) => {
       const cols = row.querySelectorAll("td");
 
       const flying = {};
-      if (!row.classList.contains("partnerInfo")) {
-        flying.arrivalTime = cols[1].innerText;
-      } else {
-        const union = Array.from(row.classList)
-          .find(cl => cl.includes("union")).split("union")[1];
-        flying.arrivalTime = unionArrivalTime[union];
-      }
+      flying.arrivalTime = cols[1].innerText;
       flying.missionFleetIcon = cols[2].querySelector("img").src;
 
       // Get the mission title by removing the suffix "own fleet" and the "return" suffix (eg: "(R)")
@@ -14007,8 +18707,1250 @@ class OGInfinity {
     }
   }
 
+  getAllianceClass() {
+    let allyClassIcon = document.querySelector(".allianceclass");
+    if (allyClassIcon) {
+      if (allyClassIcon.classList.contains("trader")) this.json.allianceClass = ALLY_CLASS_MINER;
+      if (allyClassIcon.classList.contains("explorer")) this.json.allianceClass = ALLY_CLASS_EXPLORER;
+      if (allyClassIcon.classList.contains("warrior")) this.json.allianceClass = ALLY_CLASS_WARRIOR;
+      if (allyClassIcon.classList.contains("none")) this.json.allianceClass = ALLY_CLASS_NONE;
+      this.saveData();
+    }
+  }
+
+  roiPlasmatechnology(tolvl) {
+    let plasma = this.json.technology[122];
+    let plasmaBonus = [0.01, 0.0066, 0.0033].map((x) => x * (tolvl - plasma));
+    let tradeRate = this.json.options.tradeRate;
+    let prodDiffMSE = 0;
+    this.json.empire.forEach((planet) => {
+      let pos = planet.position;
+      let temp = planet.db_par2 + 40;
+      let prodDiff = [
+        this.minesProduction(1, planet[1], pos, temp) * plasmaBonus[0],
+        this.minesProduction(2, planet[2], pos, temp) * plasmaBonus[1],
+        this.minesProduction(3, planet[3], pos, temp) * plasmaBonus[2],
+      ];
+      prodDiffMSE += prodDiff
+        .map((x, n) => (x * tradeRate[0]) / tradeRate[n])
+        .reduce((sum, cur) => sum + cur, 0);
+    });
+    let reasearchCostMSE = 0;
+    for (let lvl = plasma + 1; lvl <= tolvl; lvl++) {
+      reasearchCostMSE += this.research(122, lvl, 1, false, false, false)
+        .cost.map((x, n) => (x * tradeRate[0]) / tradeRate[n])
+        .reduce((sum, cur) => sum + cur, 0);
+    }
+    return (reasearchCostMSE * 3600) / prodDiffMSE;
+  }
+
+  roiLfResearch(technoId, baselvl, tolvl, labs) {
+    // console.log(`roiLfResearch(${technoId}, ${baselvl}, ${tolvl}, ${labs})`);
+    if (!RESEARCH_INFO[technoId] || !RESEARCH_INFO[technoId].bonus) return;
+    let bonus = RESEARCH_INFO[technoId].bonus.map(
+      (x) => (x / 100) * (tolvl - baselvl + 1)
+    );
+    console.log(`bonus = ${bonus}`);
+    let tradeRate = this.json.options.tradeRate;
+    let prodDiffMSE = 0;
+    this.json.empire.forEach((planet) => {
+      let pos = planet.position;
+      let temp = planet.db_par2 + 40;
+      let prodDiff = [
+        this.minesProduction(1, planet[1], pos, temp) * bonus[0],
+        this.minesProduction(2, planet[2], pos, temp) * bonus[1],
+        this.minesProduction(3, planet[3], pos, temp) * bonus[2],
+      ];
+      prodDiffMSE += prodDiff
+        .map((x, n) => (x * tradeRate[0]) / tradeRate[n])
+        .reduce((sum, cur) => sum + cur, 0);
+      // console.log(`prodDiffMSE = ${prodDiffMSE}`);
+    });
+    let reasearchCostMSE = 0;
+    for (let lvl = baselvl; lvl <= tolvl; lvl++) {
+      reasearchCostMSE += this.research(
+        technoId,
+        lvl,
+        labs,
+        false,
+        false,
+        false
+      )
+        .cost.map((x, n) => (x * tradeRate[0]) / tradeRate[n])
+        .reduce((sum, cur) => sum + cur, 0);
+    }
+    // console.log(`reasearchCostMSE = ${reasearchCostMSE}`);
+    return (reasearchCostMSE * 3600) / prodDiffMSE;
+  }
+
+  roiAstrophysics(baselvl, tolvl) {
+    let tradeRate = this.json.options.tradeRate;
+    let numPlanets = Math.round((baselvl - 1) / 2) + 1;
+    let newNumPlanets = Math.round(tolvl / 2) + 1;
+    let newPlanets = newNumPlanets - numPlanets;
+    let researchCostMSE = 0;
+    for (let lvl = baselvl; lvl <= tolvl; lvl++) {
+      researchCostMSE += this.research(124, lvl, 1, false, false, false)
+        .cost.map((x, n) => (x * tradeRate[0]) / tradeRate[n])
+        .reduce((sum, cur) => sum + cur, 0);
+    }
+    if (!this.json.averageMines || !this.json.totalProd) {
+      this.getBestRoi();
+    }
+    let avgMineLvl = this.json.averageMines;
+    let totalProdMSE = this.json.totalProd
+      .map((x, n) => (x * tradeRate[0]) / tradeRate[n])
+      .reduce((sum, cur) => sum + cur, 0);
+    let constructionCostMSE = 0;
+    for (let lvl = 1; lvl <= avgMineLvl[0]; lvl++) {
+      constructionCostMSE += this.building(1, lvl, 0, 0)
+        .cost.map((x, n) => (x * tradeRate[0]) / tradeRate[n])
+        .reduce((sum, cur) => sum + cur, 0);
+    }
+    for (let lvl = 1; lvl <= avgMineLvl[1]; lvl++) {
+      constructionCostMSE += this.building(2, lvl, 0, 0)
+        .cost.map((x, n) => (x * tradeRate[0]) / tradeRate[n])
+        .reduce((sum, cur) => sum + cur, 0);
+    }
+    for (let lvl = 1; lvl <= avgMineLvl[2]; lvl++) {
+      constructionCostMSE += this.building(3, lvl, 0, 0)
+        .cost.map((x, n) => (x * tradeRate[0]) / tradeRate[n])
+        .reduce((sum, cur) => sum + cur, 0);
+    }
+    let totalCostMSE = researchCostMSE + constructionCostMSE * newPlanets;
+    let prodDiffMSE = (totalProdMSE / numPlanets) * newPlanets;
+    return (totalCostMSE * 3600) / prodDiffMSE;
+  }
+
+  roiMine(technoId, index, tolvl) {
+    let baseProd = [30 * this.json.speed, 15 * this.json.speed, 0];
+    let pos = this.json.empire[index].position;
+    let temp = this.json.empire[index].db_par2 + 40;
+    let plasmaBonus = [0.01, 0.0066, 0.0033].map(
+      (x) => x * this.json.technology[122]
+    );
+    let crawlerCount = this.json.options.limitCrawler
+      ? this.json.empire[index][217]
+      : 1000000;
+    let crawlerPercent = Math.min(
+      this.json.options.crawlerPercent || 1,
+      this.playerClass == PLAYER_CLASS_MINER ? 1.5 : 1
+    );
+    let currentMineLvls = [
+      Number(this.json.empire[index][1]),
+      Number(this.json.empire[index][2]),
+      Number(this.json.empire[index][3]),
+    ];
+    let currentMineSum = currentMineLvls.reduce((sum, cur) => sum + cur, 0);
+    let currentCrawlerCount = Math.min(
+      Math.floor(currentMineSum * 8) * (this.geologist ? 1.1 : 1),
+      crawlerCount
+    );
+    let currentCrawlerBonus =
+      currentCrawlerCount *
+      (this.playerClass == PLAYER_CLASS_MINER ? 0.0003 : 0.0002) *
+      crawlerPercent;
+
+    let currentMineProd = [
+      this.minesProduction(1, currentMineLvls[0], pos, temp),
+      this.minesProduction(2, currentMineLvls[1], pos, temp),
+      this.minesProduction(3, currentMineLvls[2], pos, temp),
+    ];
+    let currentPlasmaProd = [
+      Math.round(currentMineProd[0] * plasmaBonus[0]),
+      Math.round(currentMineProd[1] * plasmaBonus[1]),
+      Math.round(currentMineProd[2] * plasmaBonus[2]),
+    ];
+    let currentCrawlerProd = currentMineProd.map((x) =>
+      Math.round(x * currentCrawlerBonus)
+    );
+    let currentPlayerClassProd = currentMineProd.map((x) =>
+      Math.round(x * (this.playerClass == PLAYER_CLASS_MINER ? 0.25 : 0))
+    );
+    let currentGeologistProd = currentMineProd.map((x) =>
+      Math.round(x * (this.geologist ? 0.1 : 0))
+    );
+    let currentAllyClassProd = currentMineProd.map((x) =>
+      Math.round(x * (this.json.allianceClass == ALLY_CLASS_MINER ? 0.05 : 0))
+    );
+    let currentOfficersProd = currentMineProd.map((x) =>
+      Math.round(x * (this.allOfficers ? 0.02 : 0))
+    );
+    let currentTotalProd = [
+      Math.floor(
+        currentMineProd[0] +
+          currentPlasmaProd[0] +
+          currentCrawlerProd[0] +
+          currentPlayerClassProd[0] +
+          currentGeologistProd[0] +
+          currentAllyClassProd[0] +
+          currentOfficersProd[0] +
+          baseProd[0]
+      ),
+      Math.floor(
+        currentMineProd[1] +
+          currentPlasmaProd[1] +
+          currentCrawlerProd[1] +
+          currentPlayerClassProd[1] +
+          currentGeologistProd[1] +
+          currentAllyClassProd[1] +
+          currentOfficersProd[1] +
+          baseProd[1]
+      ),
+      Math.floor(
+        currentMineProd[2] +
+          currentPlasmaProd[2] +
+          currentCrawlerProd[2] +
+          currentPlayerClassProd[2] +
+          currentGeologistProd[2] +
+          currentAllyClassProd[2] +
+          currentOfficersProd[2] +
+          baseProd[2]
+      ),
+    ];
+    let newMineLvls = [...currentMineLvls];
+    newMineLvls[technoId - 1] = tolvl;
+    let newMineSum = newMineLvls.reduce((sum, cur) => sum + cur, 0);
+    let newCrawlerCount = Math.min(
+      Math.floor(newMineSum * 8) * (this.geologist ? 1.1 : 1),
+      crawlerCount
+    );
+    let newCrawlerBonus =
+      newCrawlerCount *
+      (this.playerClass == PLAYER_CLASS_MINER ? 0.0003 : 0.0002) *
+      crawlerPercent;
+    let newMineProd = [
+      this.minesProduction(1, newMineLvls[0], pos, temp),
+      this.minesProduction(2, newMineLvls[1], pos, temp),
+      this.minesProduction(3, newMineLvls[2], pos, temp),
+    ];
+    let newPlasmaProd = [
+      Math.round(newMineProd[0] * plasmaBonus[0]),
+      Math.round(newMineProd[1] * plasmaBonus[1]),
+      Math.round(newMineProd[2] * plasmaBonus[2]),
+    ];
+    let newCrawlerProd = newMineProd.map((x) =>
+      Math.round(x * newCrawlerBonus)
+    );
+    let newPlayerClassProd = newMineProd.map((x) =>
+      Math.round(x * (this.playerClass == PLAYER_CLASS_MINER ? 0.25 : 0))
+    );
+    let newGeologistProd = newMineProd.map((x) =>
+      Math.round(x * (this.geologist ? 0.1 : 0))
+    );
+    let newAllyClassProd = newMineProd.map((x) =>
+      Math.round(x * (this.json.allianceClass == ALLY_CLASS_MINER ? 0.05 : 0))
+    );
+    let newOfficersProd = newMineProd.map((x) =>
+      Math.round(x * (this.allOfficers ? 0.02 : 0))
+    );
+    let newTotalProd = [
+      Math.floor(
+        newMineProd[0] +
+          newPlasmaProd[0] +
+          newCrawlerProd[0] +
+          newPlayerClassProd[0] +
+          newGeologistProd[0] +
+          newAllyClassProd[0] +
+          newOfficersProd[0] +
+          baseProd[0]
+      ),
+      Math.floor(
+        newMineProd[1] +
+          newPlasmaProd[1] +
+          newCrawlerProd[1] +
+          newPlayerClassProd[1] +
+          newGeologistProd[1] +
+          newAllyClassProd[1] +
+          newOfficersProd[1] +
+          baseProd[1]
+      ),
+      Math.floor(
+        newMineProd[2] +
+          newPlasmaProd[2] +
+          newCrawlerProd[2] +
+          newPlayerClassProd[2] +
+          newGeologistProd[2] +
+          newAllyClassProd[2] +
+          newOfficersProd[2] +
+          baseProd[2]
+      ),
+    ];
+    let prodDiff = [
+      newTotalProd[0] - currentTotalProd[0],
+      newTotalProd[1] - currentTotalProd[1],
+      newTotalProd[2] - currentTotalProd[2],
+    ];
+    let tradeRate = this.json.options.tradeRate;
+    let prodDiffMSE = prodDiff
+      .map((x, n) => (x * tradeRate[0]) / tradeRate[n])
+      .reduce((sum, cur) => sum + cur, 0);
+    let buildingCostMSE = 0;
+    for (let lvl = currentMineLvls[technoId - 1] + 1; lvl <= tolvl; lvl++) {
+      buildingCostMSE += this.building(technoId, tolvl, 0, 0)
+        .cost.map((x, n) => (x * tradeRate[0]) / tradeRate[n])
+        .reduce((sum, cur) => sum + cur, 0);
+    }
+    return (buildingCostMSE * 3600) / prodDiffMSE;
+  }
+
+  getBestRoi() {
+    let that = this;
+    let astro = that.json.technology[124];
+    let roi = [];
+    let totalProd = { metal: 0, crystal: 0, deuterium: 0 };
+    let avgMineLvl = { metal: 0, crystal: 0, deuterium: 0 };
+    let maxMineLvl = { metal: 0, crystal: 0, deuterium: 0 };
+    let numPlanets = that.json.empire.length;
+
+    this.json.empire.forEach((planet, index) => {
+      let coords = planet.coordinates.slice(1, -1);
+      let planetProductionProgress = that.json.productionProgress[coords] || {
+        technoId: 0,
+        tolvl: 0,
+        endDate: new Date(),
+      };
+      let metalLvl = parseInt(planet[1]);
+      let crystalLvl = parseInt(planet[2]);
+      let deuteriumLvl = parseInt(planet[3]);
+
+      let baseProd = [30 * that.json.speed, 15 * that.json.speed, 0];
+      let pos = planet.position;
+      let temp = planet.db_par2;
+      let plasmaBonus = [0.01, 0.0066, 0.0033].map(
+        (x) => x * that.json.technology[122]
+      );
+      let crawlerCount = that.json.options.limitCrawler ? planet[217] : 1000000;
+      let crawlerPercent = Math.min(
+        that.json.options.crawlerPercent || 1,
+        that.playerClass == PLAYER_CLASS_MINER ? 1.5 : 1
+      );
+
+      let MineSum = metalLvl + crystalLvl + deuteriumLvl;
+      let CrawlerCount = Math.min(
+        Math.floor(MineSum * 8) * (that.geologist ? 1.1 : 1),
+        crawlerCount
+      );
+      let CrawlerBonus =
+        CrawlerCount *
+        (that.playerClass == PLAYER_CLASS_MINER ? 0.0003 : 0.0002) *
+        crawlerPercent;
+
+      let MineProd = [
+        that.minesProduction(1, metalLvl, pos, temp),
+        that.minesProduction(2, crystalLvl, pos, temp),
+        that.minesProduction(3, deuteriumLvl, pos, temp),
+      ];
+      let PlasmaProd = [
+        Math.round(MineProd[0] * plasmaBonus[0]),
+        Math.round(MineProd[1] * plasmaBonus[1]),
+        Math.round(MineProd[2] * plasmaBonus[2]),
+      ];
+      let CrawlerProd = MineProd.map((x) => Math.round(x * CrawlerBonus));
+      let PlayerClassProd = MineProd.map((x) =>
+        Math.round(x * (that.playerClass == PLAYER_CLASS_MINER ? 0.25 : 0))
+      );
+      let GeologistProd = MineProd.map((x) =>
+        Math.round(x * (that.geologist ? 0.1 : 0))
+      );
+      let AllyClassProd = MineProd.map((x) =>
+        Math.round(x * (that.json.allianceClass == ALLY_CLASS_MINER ? 0.05 : 0))
+      );
+      let OfficersProd = MineProd.map((x) =>
+        Math.round(x * (that.allOfficers ? 0.02 : 0))
+      );
+
+      totalProd.metal += Math.floor(
+        MineProd[0] +
+          PlasmaProd[0] +
+          CrawlerProd[0] +
+          PlayerClassProd[0] +
+          GeologistProd[0] +
+          AllyClassProd[0] +
+          OfficersProd[0] +
+          baseProd[0]
+      );
+      totalProd.crystal += Math.floor(
+        MineProd[1] +
+          PlasmaProd[1] +
+          CrawlerProd[1] +
+          PlayerClassProd[1] +
+          GeologistProd[1] +
+          AllyClassProd[1] +
+          OfficersProd[1] +
+          baseProd[1]
+      );
+      totalProd.deuterium += Math.floor(
+        MineProd[2] +
+          PlasmaProd[2] +
+          CrawlerProd[2] +
+          PlayerClassProd[2] +
+          GeologistProd[2] +
+          AllyClassProd[2] +
+          OfficersProd[2] +
+          baseProd[2]
+      );
+
+      avgMineLvl.metal += metalLvl;
+      avgMineLvl.crystal += crystalLvl;
+      avgMineLvl.deuterium += deuteriumLvl;
+
+      maxMineLvl.metal = Math.max(maxMineLvl.metal, metalLvl);
+      maxMineLvl.crystal = Math.max(maxMineLvl.crystal, crystalLvl);
+      maxMineLvl.deuterium = Math.max(maxMineLvl.deuterium, deuteriumLvl);
+
+      for (let lvl = metalLvl + 1; lvl <= maxMineLvl.metal + 5; lvl++) {
+        roi.push({
+          time: that.roiMine(1, index, lvl),
+          technoId: 1,
+          lvl: lvl,
+          coords: coords,
+          planetId: planet.id,
+          construction: planetProductionProgress.technoId != 0 ? true : false,
+          inConstruction:
+            planetProductionProgress.technoId == 1 &&
+            planetProductionProgress.tolvl == lvl
+              ? true
+              : false,
+          endDate: planetProductionProgress.endDate || new Date(),
+        });
+      }
+      for (let lvl = crystalLvl + 1; lvl <= maxMineLvl.crystal + 5; lvl++) {
+        roi.push({
+          time: that.roiMine(2, index, lvl),
+          technoId: 2,
+          lvl: lvl,
+          coords: coords,
+          planetId: planet.id,
+          construction: planetProductionProgress.technoId != 0 ? true : false,
+          inConstruction:
+            planetProductionProgress.technoId == 2 &&
+            planetProductionProgress.tolvl == lvl
+              ? true
+              : false,
+          endDate: planetProductionProgress.endDate || new Date(),
+        });
+      }
+      for (let lvl = deuteriumLvl + 1; lvl <= maxMineLvl.deuterium + 5; lvl++) {
+        roi.push({
+          time: that.roiMine(3, index, lvl),
+          technoId: 3,
+          lvl: lvl,
+          coords: coords,
+          planetId: planet.id,
+          construction: planetProductionProgress.technoId != 0 ? true : false,
+          inConstruction:
+            planetProductionProgress.technoId == 3 &&
+            planetProductionProgress.tolvl == lvl
+              ? true
+              : false,
+          endDate: planetProductionProgress.endDate || new Date(),
+        });
+      }
+    });
+    avgMineLvl.metal /= numPlanets;
+    avgMineLvl.crystal /= numPlanets;
+    avgMineLvl.deuterium /= numPlanets;
+
+    that.json.averageMines = [
+      avgMineLvl.metal,
+      avgMineLvl.crystal,
+      avgMineLvl.deuterium,
+    ];
+    that.json.totalProd = [
+      totalProd.metal,
+      totalProd.crystal,
+      totalProd.deuterium,
+    ];
+    that.saveData();
+
+    let researchProgress = this.json.researchProgress.technoId
+      ? this.json.researchProgress
+      : { technoId: 0, tolvl: 0, endDate: new Date() };
+    for (let l = (astro + 1) % 2 == 1 ? 1 : 2; l <= 10; l += 2) {
+      let newAstro = astro + l;
+      roi.push({
+        time: that.roiAstrophysics(astro + 1, newAstro),
+        technoId: 124,
+        lvl: newAstro,
+        coords:
+          researchProgress.technoId == 124 ? researchProgress.coords : null,
+        planetId:
+          researchProgress.technoId == 124 ? researchProgress.planetId : null,
+        construction: researchProgress.technoId != 0 ? true : false,
+        inConstruction:
+          researchProgress.technoId == 124 &&
+          (researchProgress.tolvl == newAstro ||
+            researchProgress.tolvl ==
+              newAstro - (researchProgress.tolvl % 2 ? 0 : 1))
+            ? true
+            : false,
+        endDate: researchProgress.endDate,
+      });
+    }
+
+    for (let l = 1; l <= 5; l++) {
+      let newLvl = that.json.technology[122] + l;
+      roi.push({
+        time: that.roiPlasmatechnology(newLvl),
+        technoId: 122,
+        lvl: newLvl,
+        coords:
+          researchProgress.technoId == 122 ? researchProgress.coords : null,
+        planetId:
+          researchProgress.technoId == 122 ? researchProgress.planetId : null,
+        construction: researchProgress.technoId != 0 ? true : false,
+        inConstruction:
+          researchProgress.technoId == 122 && researchProgress.tolvl == newLvl
+            ? true
+            : false,
+        endDate: researchProgress.endDate,
+      });
+    }
+
+    return roi.sort((a, b) => a.time - b.time);
+  }
+
+  updateProductionProgress() {
+    let now = new Date();
+    document.querySelectorAll(".planet-koords").forEach((planet) => {
+      let elem = this.json.productionProgress[planet.innerText];
+      if (elem && new Date(elem.endDate) < now) {
+        planet.parentElement.classList.add("finished");
+      } else {
+        planet.parentElement.classList.remove("finished");
+      }
+    });
+
+    if (
+      document.querySelector("#productionboxbuildingcomponent") &&
+      !this.current.isMoon
+    ) {
+      let coords = this.current.coords;
+      let building = document.querySelector(
+        "#productionboxbuildingcomponent .queuePic"
+      );
+      if (building) {
+        let technoId =
+          building.getAttribute("alt").split("_")[1] ||
+          building.parentElement
+            .getAttribute("onclick")
+            .split("(")[1]
+            .split(", ")[0];
+        let tolvl = document
+          .querySelector("#productionboxbuildingcomponent .level")
+          .innerText.replace(/[^0-9]/g, "");
+        let datestring = document.querySelector(
+          "#productionboxbuildingcomponent .ogl-date"
+        ).innerText;
+        let date = datestring.split(" ")[0].split(".");
+        let time = datestring.split(" ")[1].split(":");
+        let endDate = new Date(
+          2000 + parseInt(date[2]),
+          parseInt(date[1]) - 1,
+          parseInt(date[0]),
+          time[0],
+          time[1],
+          time[2]
+        );
+        this.json.productionProgress[coords] = {
+          technoId: technoId,
+          tolvl: tolvl,
+          endDate: endDate,
+        };
+      } else {
+        delete this.json.productionProgress[coords];
+      }
+    }
+    if (
+      document.querySelector("#productionboxlfbuildingcomponent") &&
+      !this.current.isMoon
+    ) {
+      let coords = this.current.coords;
+      let lfbuilding = document.querySelector(
+        "#productionboxlfbuildingcomponent .queuePic"
+      );
+      if (lfbuilding) {
+        let technoId = lfbuilding.classList[2].replace("lifeformTech", "");
+        let tolvl = document
+          .querySelector("#productionboxlfbuildingcomponent .level")
+          .innerText.replace(/[^0-9]/g, "");
+        let datestring = document.querySelector(
+          "#productionboxlfbuildingcomponent .ogl-date"
+        ).innerText;
+        let date = datestring.split(" ")[0].split(".");
+        let time = datestring.split(" ")[1].split(":");
+        let endDate = new Date(
+          2000 + parseInt(date[2]),
+          parseInt(date[1]) - 1,
+          parseInt(date[0]),
+          time[0],
+          time[1],
+          time[2]
+        );
+        this.json.lfProductionProgress[coords] = {
+          technoId: technoId,
+          tolvl: tolvl,
+          endDate: endDate,
+        };
+      } else {
+        delete this.json.lfProductionProgress[coords];
+      }
+    }
+    if (document.querySelector("#productionboxresearchcomponent")) {
+      let research = document.querySelector(
+        "#productionboxresearchcomponent .queuePic"
+      );
+      if (research) {
+        let technoId =
+          research.getAttribute("alt").split("_")[1] ||
+          research.parentElement
+            .getAttribute("onclick")
+            .split("(")[1]
+            .split(", ")[0];
+        let tolvl = document
+          .querySelector("#productionboxresearchcomponent .level")
+          .innerText.replace(/[^0-9]/g, "");
+        let coords = document
+          .querySelector("#productionboxresearchcomponent .tooltip")
+          .getAttribute("onclick")
+          .split("[")[1]
+          .split("]")[0];
+        let datestring = document.querySelector(
+          "#productionboxresearchcomponent .ogl-date"
+        ).innerText;
+        let date = datestring.split(" ")[0].split(".");
+        let time = datestring.split(" ")[1].split(":");
+        let endDate = new Date(
+          2000 + parseInt(date[2]),
+          parseInt(date[1]) - 1,
+          parseInt(date[0]),
+          time[0],
+          time[1],
+          time[2]
+        );
+        this.json.researchProgress = {
+          technoId: technoId,
+          coords: coords,
+          tolvl: tolvl,
+          planetId: this.current.id,
+          endDate: endDate,
+        };
+      } else {
+        this.json.researchProgress = {};
+      }
+    }
+    if (document.querySelector("#productionboxlfresearchcomponent")) {
+      let coords = this.current.coords;
+      let lfresearch = document.querySelector(
+        "#productionboxlfresearchcomponent .queuePic"
+      );
+      if (lfresearch) {
+        let technoId = lfresearch.classList[2].replace("lifeformTech", "");
+        let tolvl = document
+          .querySelector("#productionboxlfresearchcomponent .level")
+          .innerText.replace(/[^0-9]/g, "");
+        let datestring = document.querySelector(
+          "#productionboxlfresearchcomponent .ogl-date"
+        ).innerText;
+        let date = datestring.split(" ")[0].split(".");
+        let time = datestring.split(" ")[1].split(":");
+        let endDate = new Date(
+          2000 + parseInt(date[2]),
+          parseInt(date[1]) - 1,
+          parseInt(date[0]),
+          time[0],
+          time[1],
+          time[2]
+        );
+        this.json.lfResearchProgress[coords] = {
+          technoId: technoId,
+          tolvl: tolvl,
+          endDate: endDate,
+        };
+      } else {
+        delete this.json.lfResearchProgress[coords];
+      }
+    }
+    this.saveData();
+  }
+
+  checkRedirect() {
+    let url = new URL(window.location.href);
+    let satsNeeded = url.searchParams.get("sats");
+    let technoDetails = url.searchParams.get("technoDetails");
+
+    if (satsNeeded) {
+      waitForElementToDisplay(".solarSatellite.hasDetails span", () =>
+        document.querySelector(".solarSatellite.hasDetails span").click()
+      );
+      waitForElementToDisplay(
+        "#technologydetails[data-technology-id='212']",
+        () => {
+          let satsInput = document.querySelector("#build_amount");
+          satsInput.focus();
+          satsInput.value = satsNeeded;
+          satsInput.dispatchEvent(
+            new KeyboardEvent("keyup", { code: "ArrowDown" })
+          );
+        }
+      );
+    }
+
+    if (technoDetails) {
+      let selector = `.technology[data-technology='${technoDetails}'] span`;
+      waitForElementToDisplay(selector, () =>
+        document.querySelector(selector).click()
+      );
+    }
+  }
+
+  showStorageTimers() {
+    if (this.page == "overview") {
+      let currentDate = new Date();
+      let metalStorage = resourcesBar.resources.metal.storage;
+      let metalResources = resourcesBar.resources.metal.amount;
+      let metalProduction = this.current.isMoon
+        ? 0
+        : Math.floor(this.json.empire[this.current.index].production.hourly[0]);
+      let metalTime = (metalStorage - metalResources) / metalProduction;
+      let metalDate = new Date(currentDate.getTime() + metalTime * 3600 * 1000);
+      let metalFull = metalResources >= metalStorage;
+      if (metalFull) metalProduction = 0;
+      let crystalStorage = resourcesBar.resources.crystal.storage;
+      let crystalResources = resourcesBar.resources.crystal.amount;
+      let crystalProduction = this.current.isMoon
+        ? 0
+        : Math.floor(this.json.empire[this.current.index].production.hourly[1]);
+      let crystalTime = (crystalStorage - crystalResources) / crystalProduction;
+      let crystalDate = new Date(
+        currentDate.getTime() + crystalTime * 3600 * 1000
+      );
+      let crystalFull = crystalResources >= crystalStorage;
+      if (crystalFull) crystalProduction = 0;
+      let deuteriumStorage = resourcesBar.resources.deuterium.storage;
+      let deuteriumResources = resourcesBar.resources.deuterium.amount;
+      let deuteriumProduction = this.current.isMoon
+        ? 0
+        : Math.floor(this.json.empire[this.current.index].production.hourly[2]);
+      let deuteriumTime =
+        (deuteriumStorage - deuteriumResources) / deuteriumProduction;
+      let deuteriumDate = new Date(
+        currentDate.getTime() + deuteriumTime * 3600 * 1000
+      );
+      let deuteriumFull = deuteriumResources >= deuteriumStorage;
+      if (deuteriumFull) deuteriumProduction = 0;
+      let table = document.querySelector("#planetDetails tbody");
+      let metal_1 = table.insertBefore(this.createDOM("tr"), table.children[0]);
+      metal_1.appendChild(
+        this.createDOM(
+          "td",
+          { class: "desc" },
+          `${this.getTranslatedText(22, "tech")}`
+        )
+      );
+      metal_1.appendChild(
+        this.createDOM(
+          "td",
+          { class: "data" },
+          `<span class="${
+            metalProduction > 0 ? "undermark" : "overmark"
+          }">(+${toFormatedNumber(metalProduction)})</span><span class="${
+            metalResources >= metalStorage ? " overmark" : ""
+          }" id="metal-storage"> ${toFormatedNumber(
+            Math.floor(metalResources)
+          )}/${toFormatedNumber(metalStorage)}</span>`
+        )
+      );
+      let metal_2 = table.insertBefore(this.createDOM("tr"), table.children[1]);
+      metal_2.appendChild(this.createDOM("td", { class: "desc" }, ""));
+      metal_2.appendChild(
+        this.createDOM(
+          "td",
+          { class: "data" },
+          `<span class="${
+            metalTime > 0 && metalTime != Infinity ? "ogl-date" : "overmark"
+          }"> ${
+            metalTime > 0 && metalTime != Infinity
+              ? getFormatedDate(
+                metalDate.getTime(),
+                "[d].[m].[y] <strong> [G]:[i]:[s]</strong>"
+              )
+              : "-"
+          }</span>`
+        )
+      );
+      let crystal_1 = table.insertBefore(
+        this.createDOM("tr"),
+        table.children[2]
+      );
+      crystal_1.appendChild(
+        this.createDOM(
+          "td",
+          { class: "desc" },
+          `${this.getTranslatedText(23, "tech")} `
+        )
+      );
+      crystal_1.appendChild(
+        this.createDOM(
+          "td",
+          { class: "data" },
+          `<span class="${
+            crystalProduction > 0 ? "undermark" : "overmark"
+          }"> (+${toFormatedNumber(crystalProduction)})</span><span class="${
+            crystalResources >= crystalStorage ? " overmark" : ""
+          }" id="crystal-storage"> ${toFormatedNumber(
+            Math.floor(crystalResources)
+          )}/${toFormatedNumber(crystalStorage)}</span>`
+        )
+      );
+      let crystal_2 = table.insertBefore(
+        this.createDOM("tr"),
+        table.children[3]
+      );
+      crystal_2.appendChild(this.createDOM("td", { class: "desc" }, ""));
+      crystal_2.appendChild(
+        this.createDOM(
+          "td",
+          { class: "data" },
+          `<span class="${
+            crystalTime > 0 && crystalTime != Infinity ? "ogl-date" : "overmark"
+          }"> ${
+            crystalTime > 0 && crystalTime != Infinity
+              ? getFormatedDate(
+                crystalDate.getTime(),
+                "[d].[m].[y] <strong> [G]:[i]:[s]</strong>"
+              )
+              : "-"
+          }</span></span>`
+        )
+      );
+      let deuterium_1 = table.insertBefore(
+        this.createDOM("tr"),
+        table.children[4]
+      );
+      deuterium_1.appendChild(
+        this.createDOM(
+          "td",
+          { class: "desc" },
+          `${this.getTranslatedText(24, "tech")} `
+        )
+      );
+      deuterium_1.appendChild(
+        this.createDOM(
+          "td",
+          { class: "data" },
+          `<span class="${
+            deuteriumProduction > 0 ? "undermark" : "overmark"
+          }"> (+${toFormatedNumber(deuteriumProduction)})</span><span class="${
+            deuteriumResources >= deuteriumStorage ? " overmark" : ""
+          }" id = "deuterium-storage" > ${toFormatedNumber(
+            Math.floor(deuteriumResources)
+          )} /${toFormatedNumber(deuteriumStorage)}</span>`
+        )
+      );
+      let deuterium_2 = table.insertBefore(
+        this.createDOM("tr"),
+        table.children[5]
+      );
+      deuterium_2.appendChild(this.createDOM("td", { class: "desc" }, ""));
+      deuterium_2.appendChild(
+        this.createDOM(
+          "td",
+          { class: "data" },
+          `<span class="${
+            deuteriumTime > 0 && deuteriumTime != Infinity
+              ? "ogl-date"
+              : "overmark"
+          }"> ${
+            deuteriumTime > 0 && deuteriumTime != Infinity
+              ? getFormatedDate(
+                deuteriumDate.getTime(),
+                "[d].[m].[y] <strong> [G]:[i]:[s]</strong>"
+              )
+              : "-"
+          }</span></span>`
+        )
+      );
+      let updater = setInterval(() => {
+        let updateTime = new Date().getTime();
+        if (
+          (updateTime > metalDate.getTime() && !metalFull) ||
+          (updateTime > crystalDate.getTime() && !crystalFull) ||
+          (updateTime > deuteriumDate.getTime() && !deuteriumFull)
+        ) {
+          clearInterval(updater);
+          location.reload();
+        }
+        if (metalProduction + crystalProduction + deuteriumProduction > 0) {
+          document.querySelector(
+            "#metal-storage"
+          ).innerText = ` ${toFormatedNumber(
+            Math.floor(resourcesBar.resources.metal.amount)
+          )}/${toFormatedNumber(metalStorage)}`;
+          document.querySelector(
+            "#crystal-storage"
+          ).innerText = ` ${toFormatedNumber(
+            Math.floor(resourcesBar.resources.crystal.amount)
+          )}/${toFormatedNumber(crystalStorage)}`;
+          document.querySelector(
+            "#deuterium-storage"
+          ).innerText = ` ${toFormatedNumber(
+            Math.floor(resourcesBar.resources.deuterium.amount)
+          )}/${toFormatedNumber(deuteriumStorage)}`;
+        } else {
+          clearInterval(updater);
+        }
+      }, 100);
+    }
+  }
+
+  collect() {
+    if (
+      this.page == "fleetdispatch" &&
+      fleetDispatcher.shipsOnPlanet.length !== 0 &&
+      !fleetDispatcher.isOnVacation
+    ) {
+      this.json.href = undefined;
+      this.saveData();
+      let cargoChoice = this.createDOM("div", { class: "ogk-collect-cargo" });
+      let btnCollect = document
+        .querySelector("#allornone .secondcol")
+        .appendChild(
+          this.createDOM("button", {
+            class: `ogl-collect ${
+              this.json.options.collect.mission == 4 ? "statio" : ""
+            } ${
+              this.json.options.collect.ship == 202
+                ? "smallCargo"
+                : this.json.options.collect.ship == 219
+                  ? "pathFinder"
+                  : "largeCargo"
+            }`,
+          })
+        );
+      let sc = cargoChoice.appendChild(
+        this.createDOM("div", {
+          class: 'ogl-option ogl-fleet-ship choice ogl-fleet-202',
+        })
+      );
+      let lc = cargoChoice.appendChild(
+        this.createDOM("div", {
+          class: 'ogl-option ogl-fleet-ship choice ogl-fleet-203',
+        })
+      );
+      let pf = cargoChoice.appendChild(
+        this.createDOM("div", {
+          class: 'ogl-option ogl-fleet-ship choice ogl-fleet-219',
+        })
+      );
+      let tr = cargoChoice.appendChild(
+        this.createDOM("div", {
+          class: 'ogl-option choice-mission-icon ogl-mission-3',
+        })
+      );
+      let dp = cargoChoice.appendChild(
+        this.createDOM("div", {
+          class: 'ogl-option choice-mission-icon ogl-mission-4',
+        })
+      );
+      let tgt = cargoChoice.appendChild(
+        this.createDOM("div", {
+          class: `ogl-option choice-target ${
+            this.json.options.collect.target.type == 3 ? "moon" : "planet"
+          }`,
+        })
+      );
+
+      let updateCollectTooltipIcon = () => {
+        let remove =
+          this.json.options.collect.target.type == 1 ? "moon" : "planet";
+        let add =
+          this.json.options.collect.target.type == 3 ? "moon" : "planet";
+        let classList = cargoChoice.querySelector(".choice-target").classList;
+        if (classList.contains(remove)) classList.remove(remove);
+        if (!classList.contains(add)) classList.add(add);
+      };
+      let updateDefaultCollectShip = (id) => {
+        this.json.options.collect.ship = id;
+        this.saveData();
+        location.reload();
+      };
+      let updateDefaultCollectMission = (mission) => {
+        this.json.options.collect.mission = mission;
+        this.saveData();
+        location.reload();
+      };
+      sc.addEventListener("click", () => updateDefaultCollectShip(202));
+      lc.addEventListener("click", () => updateDefaultCollectShip(203));
+      pf.addEventListener("click", () => updateDefaultCollectShip(219));
+      tr.addEventListener("click", () => updateDefaultCollectMission(3));
+      dp.addEventListener("click", () => updateDefaultCollectMission(4));
+      tgt.addEventListener("click", () => {
+        let container = this.openPlanetList(
+          (planet) => {
+            this.json.options.collect.target = planet;
+            document
+              .querySelector(".ogl-dialogOverlay")
+              .classList.remove("ogl-active");
+            this.saveData();
+            updateCollectTooltipIcon();
+          },
+          this.json.options.collect.target,
+          this.json.options.collect.mission
+        );
+        this.popup(false, container);
+        this.saveData();
+      });
+      btnCollect.addEventListener("mouseover", () =>
+        this.tooltip(btnCollect, cargoChoice, false, false, 500)
+      );
+      btnCollect.addEventListener("click", () => {
+        document.querySelector("#resetall").click();
+        this.collect = true;
+        this.expedition = false;
+        this.json.href = undefined;
+        this.saveData();
+        document.querySelector(".ogl-cargo a.send_none").click();
+        document.querySelector(".ogl-cargo a.select-most").click();
+        fleetDispatcher.resetShips();
+        this.selectBestCargoShip(this.json.options.collect.ship);
+        let inputs = document.querySelectorAll(".ogl-coords input");
+        inputs[0].value = this.json.options.collect.target.galaxy;
+        inputs[1].value = this.json.options.collect.target.system;
+        inputs[2].value = this.json.options.collect.target.position;
+        fleetDispatcher.targetPlanet = this.json.options.collect.target;
+        this.planetList.forEach((planet) => {
+          let targetCoords = planet
+            .querySelector(".planet-koords")
+            .textContent.split(":");
+          planet.querySelector(".planetlink").classList.remove("ogl-target");
+          planet.querySelector(".moonlink") &&
+            planet.querySelector(".moonlink").classList.remove("ogl-target");
+          planet.querySelector(".planetlink").classList.remove("mission-3");
+          planet.querySelector(".moonlink") &&
+            planet.querySelector(".moonlink").classList.remove("mission-4");
+          if (
+            fleetDispatcher.targetPlanet.galaxy == targetCoords[0] &&
+            fleetDispatcher.targetPlanet.system == targetCoords[1] &&
+            fleetDispatcher.targetPlanet.position == targetCoords[2]
+          ) {
+            if (fleetDispatcher.targetPlanet.type == 1) {
+              planet.querySelector(".planetlink").classList.add("ogl-target");
+              planet
+                .querySelector(".planetlink")
+                .classList.add(`mission-${fleetDispatcher.mission}`);
+            } else if (planet.querySelector(".moonlink")) {
+              planet.querySelector(".moonlink").classList.add("ogl-target");
+              planet
+                .querySelector(".moonlink")
+                .classList.add(`mission-${fleetDispatcher.mission}`);
+            }
+          }
+        });
+        fleetDispatcher.refreshTarget();
+        fleetDispatcher.updateTarget();
+        fleetDispatcher.fetchTargetPlayerData();
+        fleetDispatcher.selectMission(this.json.options.collect.mission);
+        fleetDispatcher.refresh();
+        let nextId = this.current.planet.nextElementSibling.id
+          ? this.current.planet.nextElementSibling.id.split("-")[1]
+          : document.querySelectorAll(".smallplanet")[0].id.split("-")[1];
+        if (this.current.isMoon) {
+          nextId = new URL(
+            document.querySelector(`#planet-${nextId} .moonlink`).href
+          ).searchParams.get("cp");
+        }
+        this.json.href =
+          "https://" +
+          window.location.host +
+          window.location.pathname +
+          `?page=ingame&component=fleetdispatch&cp=${nextId}&galaxy=${this.json.options.collect.target.galaxy}&system=${this.json.options.collect.target.system}&position=${this.json.options.collect.target.position}&type=${this.json.options.collect.target.type}&mission=${this.json.options.collect.mission}&oglMode=0`;
+        this.saveData();
+        document.querySelector(".ogl-cargo a.select-most").click();
+      });
+    }
+  }
+
+  selectBestCargoShip = (preveredShipId = null) => {
+    if (
+      fleetDispatcher.currentPage == 'fleet1' &&
+      fleetDispatcher.shipsOnPlanet.length != 0
+    ) {
+      let metalAvailable = Math.max(0, fleetDispatcher.metalOnPlanet);
+      let crystalAvailable = Math.max(0, fleetDispatcher.crystalOnPlanet);
+      let deutAvailable = Math.max(0, fleetDispatcher.deuteriumOnPlanet);
+      let metalFiller = document.querySelector(".resourceIcon.metal+input");
+      let crystalFiller = document.querySelector(".resourceIcon.crystal+input");
+      let deutFiller = document.querySelector(".resourceIcon.deuterium+input");
+      let metal = Number(metalFiller.value.split(".").join(""));
+      if (metal > metalAvailable)
+        metalFiller.value = toFormatedNumber(metalAvailable, 0);
+      let crystal = Number(crystalFiller.value.split(".").join(""));
+      if (crystal > crystalAvailable)
+        crystalFiller.value = toFormatedNumber(crystalAvailable, 0);
+      let deut = Number(deutFiller.value.split(".").join(""));
+      if (deut > deutAvailable)
+        deutFiller.value = toFormatedNumber(
+          Math.max(0, deutAvailable - fleetDispatcher.getConsumption()),
+          0
+        );
+      let resources =
+        Math.min(metal, metalAvailable) +
+        Math.min(crystal, crystalAvailable) +
+        Math.min(deut, deutAvailable);
+      let cargoShipsOnPlanet = {};
+      let cargoIds = [];
+      if (preveredShipId) cargoIds.push(preveredShipId);
+      [202, 203, 219, 209].forEach((id) => {
+        if (!cargoIds.includes(id)) cargoIds.push(id);
+      });
+      if (this.json.ships[210].cargoCapacity != 0 && !cargoIds.includes(210))
+        cargoIds.push(210);
+      fleetDispatcher.shipsOnPlanet.forEach((ship) => {
+        if (cargoIds.includes(ship.id))
+          cargoShipsOnPlanet[ship.id] = ship.number || 0;
+      });
+      let enoughCargo = false;
+      let selectedCargoShip;
+      let neededShips;
+      cargoIds.forEach((cargoShip) => {
+        if (!enoughCargo) {
+          neededShips = this.calcNeededShips({
+            fret: cargoShip,
+            resources: resources,
+          });
+          if (neededShips <= cargoShipsOnPlanet[cargoShip]) {
+            selectedCargoShip = cargoShip;
+            enoughCargo = true;
+            return;
+          }
+        }
+      });
+      if (enoughCargo) {
+        this.selectShips(selectedCargoShip, neededShips);
+      } else {
+        cargoIds.forEach((ship) => {
+          if (cargoShipsOnPlanet[ship]) {
+            let numShips = Math.min(
+              this.calcNeededShips({ fret: ship, resources: resources }),
+              cargoShipsOnPlanet[ship]
+            );
+            this.selectShips(ship, numShips);
+            resources -=
+              fleetDispatcher.fleetHelper.shipsData[ship].cargoCapacity *
+              numShips;
+            if (resources <= 0) {
+              enoughCargo = true;
+              return;
+            }
+          }
+        });
+      }
+      if (!enoughCargo) fadeBox(this.getTranslatedText(107), true);
+    }
+  };
+
+  showTabTimer() {
+    let title = document.title;
+    let update = setInterval(function () {
+      let loadDate = new Date(window.performance.timing.loadEventEnd);
+      let time = (new Date() - loadDate) / 1000;
+      if (time > 24 * 60 * 60) {
+        time = 0;
+        clearInterval(update);
+      }
+      document.title = `${title} ${formatTimeWrapper(
+        time,
+        2,
+        true,
+        " ",
+        false,
+        ""
+      )}`;
+    }, 1000);
+  }
+
+  navigationArrows() {
+    if (this.isMobile) {
+      let navPanel = document
+        .querySelector("#links")
+        .appendChild(this.createDOM("div", { class: "ogk-navPanel" }));
+      let left = navPanel.appendChild(
+        this.createDOM("div", { class: "galaxy_icons ogk-nav left" })
+      );
+      left.addEventListener("click", () =>
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", { code: "ArrowLeft", ctrlKey: "true" })
+        )
+      );
+      let right = navPanel.appendChild(
+        this.createDOM("div", { class: "galaxy_icons ogk-nav right" })
+      );
+      right.addEventListener("click", () =>
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", { code: "ArrowRight", ctrlKey: "true" })
+        )
+      );
+      let up = navPanel.appendChild(
+        this.createDOM("div", { class: "galaxy_icons ogk-nav up" })
+      );
+      up.addEventListener("click", () =>
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", { code: "ArrowUp", ctrlKey: "true" })
+        )
+      );
+      let down = navPanel.appendChild(
+        this.createDOM("div", { class: "galaxy_icons ogk-nav down" })
+      );
+      down.addEventListener("click", () =>
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", { code: "ArrowDown", ctrlKey: "true" })
+        )
+      );
+    }
+  }
+
+  markLifeforms() {
+    document.querySelectorAll(".smallplanet a").forEach((elem) => {
+      let lifeforms = [
+        {
+          name: "Menschen",
+          image: "lifeform1",
+        },
+        {
+          name: "Rock’tal",
+          image: "lifeform2",
+        },
+        {
+          name: "Mechas",
+          image: "lifeform3",
+        },
+        {
+          name: "Kaelesh",
+          image: "lifeform4",
+        },
+      ];
+      lifeforms.forEach((lf) => {
+        if (String(elem.getAttribute("title")).includes(lf.name)) {
+          elem.appendChild(
+            this.createDOM("div", {
+              class: `lifeform-item-icon small ${lf.image}`,
+            })
+          );
+        }
+      });
+    });
+  }
+
   listenKeyboard() {
-    window.addEventListener("keydown", (e) => {
+    if (this.page == "fleetdispatch") {
+      document
+        .querySelectorAll('form[name="shipsChosen"] input')
+        .forEach((i) => i.classList.add("ogl-formatInput"));
+    }
+    let listener = this.isMobile ? "input" : "keyup";
+    window.addEventListener(listener, (e) => {
       const element = document.activeElement;
       if (!element) return;
 
@@ -14028,23 +19970,33 @@ class OGInfinity {
         (element.classList.contains("ogl-formatInput") ||
           element.classList.contains("checkThousandSeparator"))
       ) {
-        if (CODE === "ArrowUp" || CODE === "ArrowDown" || CODE === "KeyK") {
-          const value = Number(element.value.replaceAll(/[,.']/g, ""));
-          const add = e.ctrlKey ? 100 : e.shiftKey ? 10 : 1;
-          switch (CODE) {
+        if (this.isMobile) {
+          if (e.data === "K" || e.data === "k" || e.data === "0k") {
+            element.value = toFormatedNumber(1000);
+          } else {
+              let value =
+              fromFormatedNumber(element.value.replace("k", "000")) || 0;
+            element.value = toFormatedNumber(value);
+            }
+        } else {
+          if (CODE === "ArrowUp" || CODE === "ArrowDown" || CODE === "KeyK") {
+            const value = fromFormatedNumber(element.value.replace("k", "")) || 0
+            const add = e.ctrlKey ? 100 : e.shiftKey ? 10 : 1;
+            switch (CODE) {
             case "ArrowUp":
-              element.value = value + add;
+              element.value = toFormatedNumber(value + add);
               break;
             case "ArrowDown":
-              element.value = Math.max(value - add, 0);
+                element.value = toFormatedNumber(Math.max(value - add, 0));
               break;
             case "KeyK":
-              element.value = value * 1000;
+                let factor = (value > 0 && element.classList.contains("checkThousandSeparator")) ? 1 : 1000;
+                element.value = toFormatedNumber((value || 1) * factor);
               break;
+            }
           }
         }
       }
-
       debounce(() => {
         if (window.fleetDispatcher) {
           fleetDispatcher.NO_UPDATE_MISSIONS = false;

--- a/ogkush.js
+++ b/ogkush.js
@@ -3142,6 +3142,7 @@ class OGInfinity {
 
   keepOnPlanetDialog(coords, btn) {
     let kept;
+    let lifeforms = document.querySelector(".lifeform") != null;
     if (coords) {
       kept = this.json.options.kept[coords];
     }
@@ -3204,6 +3205,23 @@ class OGInfinity {
         value: toFormatedNumber(kept[2]) || toFormatedNumber(0),
       })
     );
+    let foodInput;
+    if (lifeforms){
+      prod.appendChild(
+        this.createDOM(
+          "span",
+          {},
+          '<a class="resourceIcon food"></a>'
+        )
+      );
+      foodInput = prod.appendChild(
+        this.createDOM("input", {
+          class: "ogl-formatInput food",
+          type: "text",
+          value: toFormatedNumber(kept[3]) || toFormatedNumber(0),
+        })
+      );
+    }
     box.appendChild(this.createDOM("hr"));
     box.appendChild(this.createDOM("h1", {}, this.getTranslatedText(29)));
     let fleet = box.appendChild(
@@ -3245,6 +3263,7 @@ class OGInfinity {
       kept[0] = fromFormatedNumber(metInput.value, true);
       kept[1] = fromFormatedNumber(criInput.value, true);
       kept[2] = fromFormatedNumber(deutInput.value, true);
+      if (lifeforms) kept[3] = fromFormatedNumber(foodInput.value, true);
       if (coords) {
         this.json.options.kept[coords] = kept;
       } else {
@@ -7342,6 +7361,15 @@ class OGInfinity {
         value: toFormatedNumber(adjustments[2]),
       })
     );
+    if (lifeforms) {
+      let foodInput = prod.appendChild(
+        this.createDOM("input", {
+          class: "ogl-formatInput food",
+          type: "text",
+          value: toFormatedNumber(adjustments[3]),
+        })
+    );
+    }
     if (onValidate) {
       let btn = box.appendChild(
         this.createDOM("button", { class: "btn_blue" }, "OK")
@@ -7351,6 +7379,7 @@ class OGInfinity {
           fromFormatedNumber(metInput.value, true),
           fromFormatedNumber(criInput.value, true),
           fromFormatedNumber(deutInput.value, true),
+          fromFormatedNumber(foodInput.value || 0, true),
         ]);
       });
     }
@@ -10825,7 +10854,7 @@ class OGInfinity {
       ) {
         if (fleetDispatcher.mission) selectedMission = fleetDispatcher.mission;
       }
-      let lifeforms = document.querySelector(".lifeforms-enabled") != null;
+      let lifeforms = document.querySelector(".lifeform") != null;
       let foodAvailable = Math.max(0, fleetDispatcher.foodOnPlanet);
 
       let needCargo = (fret) => {
@@ -11766,6 +11795,7 @@ class OGInfinity {
         })
       );
       if (!this.isMobile) {
+        (lifeforms ?
         [
           metalFiller,
           document.querySelector("input#metal"),
@@ -11774,7 +11804,16 @@ class OGInfinity {
           deutFiller,
           document.querySelector("input#deuterium"),
           document.querySelector("input#food")
-        ].forEach(elem => {
+        ] :
+                [
+          metalFiller,
+          document.querySelector("input#metal"),
+          crystalFiller,
+          document.querySelector("input#crystal"),
+          deutFiller,
+          document.querySelector("input#deuterium"),
+        ]
+        ).forEach(elem => {
           elem.addEventListener("keyup", (event) => {
             const CODE = event.code;
             let value =
@@ -11798,15 +11837,25 @@ class OGInfinity {
           });
         });
       } else {
-        [
-          metalFiller,
-          document.querySelector("input#metal"),
-          crystalFiller,
-          document.querySelector("input#crystal"),
-          deutFiller,
-          document.querySelector("input#deuterium"),
-          document.querySelector("input#food")
-        ].forEach(elem => {
+        (lifeforms ?
+          [
+            metalFiller,
+            document.querySelector("input#metal"),
+            crystalFiller,
+            document.querySelector("input#crystal"),
+            deutFiller,
+            document.querySelector("input#deuterium"),
+            document.querySelector("input#food")
+          ] :
+                  [
+            metalFiller,
+            document.querySelector("input#metal"),
+            crystalFiller,
+            document.querySelector("input#crystal"),
+            deutFiller,
+            document.querySelector("input#deuterium"),
+          ]
+          ).forEach(elem => {
           elem.addEventListener("input", (event) => {
             if (event.data == "K" || event.data == "k" || event.data == "0k") {
               event.target.value = toFormatedNumber(1000);

--- a/ogkush.js
+++ b/ogkush.js
@@ -20028,7 +20028,7 @@ class OGInfinity {
 
   markLifeforms() {
     if (!this.hasLifeforms) return
-    document.querySelectorAll(".smallplanet a").forEach((elem) => {
+    document.querySelectorAll(".smallplanet a.planetlink").forEach((elem) => {
       let lf = String(elem.getAttribute("title").split("<br/>")[1].split(":")[1].trim());
       switch (lf){
         case "Rock’tal":

--- a/ogkush.js
+++ b/ogkush.js
@@ -169,8 +169,10 @@ function fromFormatedNumber(value, int = false) {
   let locale = document
     .querySelector("#cookiebanner")
     .getAttribute("data-locale");
-  let decimalSeparator = getSeparator(locale, "decimal");
-  let groupSeparator = getSeparator(locale, "group");
+  // let decimalSeparator = getSeparator(locale, "decimal");
+  // let groupSeparator = getSeparator(locale, "group");
+  let decimalSeparator = LocalizationStrings["decimalPoint"];
+  let groupSeparator = LocalizationStrings["thousandSeperator"];
   let order = 1;
   if (value.includes("T")) {
     order = 1e12;

--- a/ogkush.js
+++ b/ogkush.js
@@ -3827,8 +3827,6 @@ class OGInfinity {
             ) {
               let arrival = movement.back ? movement.origin : movement.dest;
               let coords = "[" + arrival.slice(0, -1) + "]";
-              let current =
-                this.current.coords + (this.current.isMoon ? "M" : "P");
               this.json.empire.forEach((planet) => {
                 if (
                   (arrival.slice(-1) == "M" && planet.moon) ||
@@ -3836,16 +3834,14 @@ class OGInfinity {
                 ) {
                   let object = arrival.slice(-1) == "M" ? planet.moon : planet;
                   if (object.coordinates == coords) {
-                    object.metal += movement.metal;
-                    object.crystal += movement.crystal;
-                    object.deuterium += movement.deuterium;
-                    if (current != arrival) {
-                      if (this.json.options.autofetchempire) {
-                        update = true;
-                      } else {
-                        object.invalidate = true;
-                        this.updateresourceDetail();
-                      }
+                    if (movement.metal) object.metal += movement.metal;
+                    if (movement.crystal) object.crystal += movement.crystal;
+                    if (movement.deuterium) object.deuterium += movement.deuterium;
+                    if (this.json.options.autofetchempire) {
+                      update = true;
+                    } else {
+                      object.invalidate = true;
+                      this.updateresourceDetail();
                     }
                   }
                   this.saveData();

--- a/ogkush.js
+++ b/ogkush.js
@@ -18492,7 +18492,7 @@ class OGInfinity {
       this.createDOM(
         "div",
         { class: "ogi-checkbox" },
-        `<label for="fleet-activity">{this.getTranslatedText(134)}</label>\n        <input type="checkbox" id="fleet-activity" name="fleet-activity" ${
+        `<label for="fleet-activity">${this.getTranslatedText(134)}</label>\n        <input type="checkbox" id="fleet-activity" name="fleet-activity" ${
           this.json.options.fleetActivity ? "checked" : ""
         }>`
       )

--- a/ogkush.js
+++ b/ogkush.js
@@ -17969,6 +17969,11 @@ class OGInfinity {
           en: "Contribute or bug report",
           fr: "Contribuer ou signaler un bogue"
         },
+        /*134*/ {
+          de: "Flottenaktivität der Planeten anzeigen",
+          en: "Display planets fleet activity",
+          fr: "Afficher l'activité de la flotte des planètes"
+        }
       ],
     };
     return translation[type][id][language];
@@ -18487,7 +18492,7 @@ class OGInfinity {
       this.createDOM(
         "div",
         { class: "ogi-checkbox" },
-        `<label for="fleet-activity">Display planets fleet activity</label>\n        <input type="checkbox" id="fleet-activity" name="fleet-activity" ${
+        `<label for="fleet-activity">{this.getTranslatedText(134)}</label>\n        <input type="checkbox" id="fleet-activity" name="fleet-activity" ${
           this.json.options.fleetActivity ? "checked" : ""
         }>`
       )


### PR DESCRIPTION
### Use empire data instead of myMines and myRes

### Improved the input with shortcuts
arrow up/down: +/- 1
shift + arrow up/down: +/- 10
ctrl + arrow up/down: +/- 100
k -> *1000
checkInputs() removed, listenKeyboard() adapted

### Expedition and Collect
one button for expedition, can change default ship
one button for collect, can change ship/target and mission
after collection fleet sent, moves to next planet

### Improved control via hotkeys
ctrl + arrow to navigate planets / moons
fleet1 shortkeys:
KeyE: expedition -> fleet2
KeyC: collect -> fleet2
KeyA: all ships
keyM: most ships
KeyN: no ships
enter: -> fleet2
fleet2 shortkeys:
KeyE: expedition
KeyS: espionage
KeyD: deployment
KeyT: transport
KeyH: hold
KeyC: colonisation
KeyR: recycle
KeyX: attack
alt + KeyX: ACS attack
ctrl + KeyX: moon destruction
shift + KeyP: planet
shift + KeyM: moon
shift + KeyD: debris
KeyA: all resources
KeyM: most resources
KeyN: no resources
enter: send fleet

### Planet list
ctr + arrow: navigate planet list
added navigation arrows to navigate planet list

### Improved building/research details
buildings and research improved to calculate costs and times
buildungProduction changed to calculate production with position bonus
data for buildings / research stored in constants BUILDING_INFO and RESEARCH_INFO

### Content
Lifeform building / research progress details
better classification of flying fleet
overview of transported resources as tooltip for flying fleet icon
changed icons to fit ships / defense and also fit with lifeforms
tooltips for numbers
storage timers like in AntigameReborn

### Improved Missing Lock
changed to also work if you add multiple buildings

### Technology details
also demolishment is now displayed correctly
shows amortisation time for mines, plasma and astro
small solar satellite icon with number of needed sats is shown for mines and research

### Fleetdispatcher
needed ships for transport if no ships on planet/moon
target highlighting
collect button and expedition buttons changed
fleet2 remove handles and rappers and add overview of selected ships
adaption for lifeforms(added food resource)
fixed problem with planet specific kept ships

### Overview
mines overview shows storage fill times as tooltip
fleet/defence overviews now links to moons if moons selected

### Statistics
general stats improved (storage level needed for daily production as tooltip, transport capacity)
new production overview
added return on investment (roi) tab to statistics (currently no lifeforms)

### List of changes to data structure
removed:
- this.json.apiTechData
- this.json.ptFret
- this.json.gtFret
- this.json.pfFret
- this.json.cyFret
- this.json.pbFret
- this.json.myMines
- this.json.lastResUpdate
- this.json.myRes
- this.json.tech114
- this.json.tech113
- this.json.tech122
- this.json.tech124
- this.json.tech108
added:
- this.technocrat
- this.admiral
- this.engineer
- this.allOfficers
- this.current.id
- this.json.technology
- this.json.ships
- this.json.allianceClass
- this.json.productionProgress
- this.json.lfProductionProgress
- this.json.researchProgress
- this.json.lfResearchProgress
- this.json.needSync
- this.json.flying.ids
- this.json.options.collect
- this.json.options.maxCrawler
- this.json.options.crawlerPercent
- this.json.options.tradeRate