### PR TITLE
fix: Expedition max total calculation for explorer class

### DIFF
--- a/ogkush.js
+++ b/ogkush.js
@@ -11647,12 +11647,11 @@ class OGInfinity {
         minPT = 1223;
         minGT = 417;
       }
-      maxTotal *=
-        2 *
-        (1 +
-          (this.playerClass == PLAYER_CLASS_EXPLORER
-            ? this.json.explorerBonusIncreasedExpeditionOutcome * this.json.speed
-            : 0));
+      maxTotal *= 2; // Pathfinder bonus on expedition
+      if (this.playerClass == PLAYER_CLASS_EXPLORER) {
+        maxTotal *= (1 + this.json.explorerBonusIncreasedExpeditionOutcome) * this.json.speed;
+      }
+
       if (this.json.lifeformBonus && this.json.lifeformBonus[this.current.id])
         maxTotal *= 1 + this.json.lifeformBonus[this.current.id].expeditionBonus || 0;
       let maxPT = Math.max(minPT, this.calcNeededShips({ fret: 202, resources: maxTotal }));


### PR DESCRIPTION
Regression was introduced in commit fd6d50a : for an explorer, `maxTotal` calculation changed from (probably because of a style change ?)
```
maxTotal *= 2 [pathfinder boost] * (1 + 0.5[explorerBonusIncreasedExpeditionOutcome]) * speed
```
To
```
maxTotal *= 2 [pathfinder boost] * (1 + 0.5[explorerBonusIncreasedExpeditionOutcome] * speed)
```

Which resulted in incorrect total (on speed 2, you'd get 20M max instead of the correct 30M, for example).

I took the liberty of splitting the code into separate statements for clarity purpose.