### PR TITLE
Improvement/data fetch rationalization part1

### DIFF
--- a/main.js
+++ b/main.js
@@ -235,7 +235,7 @@ class DataHelper {
 
   async update() {
     if (this.loading) return;
-    if (isNaN(this.lastUpdate) || new Date() - this.lastUpdate > 5 * 60 * 1e3) {
+    if (isNaN(this.lastUpdate) || new Date() - this.lastUpdate > 30 * 60 * 1e3) {
       this.loading = true;
       let players = {};
       await this._updateHighscore(players)

--- a/ogkush.js
+++ b/ogkush.js
@@ -1577,6 +1577,7 @@ class OGInfinity {
     let forceEmpire = document.querySelectorAll("div[id*=planet-").length != this.json.empire.length;
     this.updateServerSettings();
     this.updateEmpireData(forceEmpire);
+    this.initializeLFTypeName();
     if (this.json.needLifeformUpdate[this.current.id]) this.updateLifeform();
 
     if (UNIVERSVIEW_LANGS.includes(this.gameLang)) {
@@ -3148,7 +3149,7 @@ class OGInfinity {
   async updateServerSettings(force = false) {
     const timeSinceServerTimeStamp =
       document.querySelector("[name='ogame-timestamp']").content - this.json.serverSettingsTimeStamp;
-    if ((timeSinceServerTimeStamp <  24 * 3600) && !force) return;
+    if (timeSinceServerTimeStamp < 24 * 3600 && !force) return;
     let settingsUrl = `https://s${this.universe}-${this.gameLang}.ogame.gameforge.com/api/serverData.xml`;
     return fetch(settingsUrl)
       .then((rep) => rep.text())
@@ -11906,7 +11907,7 @@ class OGInfinity {
       window.onbeforeunload = function (e) {
         abortController.abort();
       };
-      fetch(this.current.planet.querySelector(".moonlink").href, { signal: abortController.signal } ); 
+      fetch(this.current.planet.querySelector(".moonlink").href, { signal: abortController.signal });
     }
   }
 
@@ -17379,49 +17380,49 @@ class OGInfinity {
           en: "Discoveries",
           es: "Exploración",
           fr: "Exploration",
-          tr: "Keşifler"        
+          tr: "Keşifler",
         },
         /*140*/ {
           de: "Menschen",
           en: "Human",
           es: "Humanos",
           fr: "Les humains",
-          tr: "İnsanlar"
+          tr: "İnsanlar",
         },
         /*141*/ {
           de: "Rock’tal",
           en: "Rock’tal",
           es: "Rock`tal",
           fr: "Roctas",
-          tr: "Rock’tal"
+          tr: "Rock’tal",
         },
         /*142*/ {
           de: "Mechas",
           en: "Mechas",
           es: "Mecas",
           fr: "Mécas",
-          tr: "Mekalar"
+          tr: "Mekalar",
         },
         /*143*/ {
           de: "Kaelesh",
           en: "Kaelesh",
           es: "Kaelesh",
           fr: "Kaeleshs",
-          tr: "Kaelesh"
+          tr: "Kaelesh",
         },
         /*144*/ {
           de: "Erfahrung",
           en: "Experience",
           es: "Experiencia",
           fr: "Expérience",
-          tr: "Deneyim"
+          tr: "Deneyim",
         },
         /*145*/ {
           de: "Artefakte",
           en: "Artefacts",
           es: "Artefactos",
           fr: "Artéfacts",
-          tr: "Artefaktlar"    
+          tr: "Artefaktlar",
         },
         /*146*/ {
           de: "Abgeschlossenen Vorgang anzeigen",
@@ -19132,20 +19133,23 @@ class OGInfinity {
     }
   }
 
-  async initializeLFTypeName() {
-    fetch("/game/index.php?page=ingame&component=lfoverview")
-      .then((rep) => rep.text())
-      .then((str) => {
-        let htmlDocument = new window.DOMParser().parseFromString(str, "text/html");
-        let lfdiv = htmlDocument.querySelector("div[id='lfoverviewcomponent']");
-        let listName = lfdiv.querySelectorAll("h3");
-        listName.forEach((lfName, index) => {
-          if (index != 0) {
-            this.json.lfTypeNames["lifeform" + index] = lfName.innerText;
-          }
+  initializeLFTypeName() {
+    if (!this.hasLifeforms) return;
+    if (!this.json.lfTypeNames["lifeform1"]) {
+      fetch("/game/index.php?page=ingame&component=lfoverview")
+        .then((rep) => rep.text())
+        .then((str) => {
+          let htmlDocument = new window.DOMParser().parseFromString(str, "text/html");
+          let lfdiv = htmlDocument.querySelector("div[id='lfoverviewcomponent']");
+          let listName = lfdiv.querySelectorAll("h3");
+          listName.forEach((lfName, index) => {
+            if (index != 0) {
+              this.json.lfTypeNames["lifeform" + index] = lfName.textContent;
+            }
+          });
+          this.saveData();
         });
-        this.saveData();
-      });
+    }
   }
 
   async markLifeforms() {

--- a/ogkush.js
+++ b/ogkush.js
@@ -12833,7 +12833,7 @@ class OGInfinity {
     let svg =
       '<svg width="80px" height="30px" viewBox="0 0 187.3 93.7" preserveAspectRatio="xMidYMid meet">\n                <path stroke="#3c536c" id="outline" fill="none" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10"\n                  d="M93.9,46.4c9.3,9.5,13.8,17.9,23.5,17.9s17.5-7.8,17.5-17.5s-7.8-17.6-17.5-17.5c-9.7,0.1-13.3,7.2-22.1,17.1\n                    c-8.9,8.8-15.7,17.9-25.4,17.9s-17.5-7.8-17.5-17.5s7.8-17.5,17.5-17.5S86.2,38.6,93.9,46.4z" />\n                <path id="outline-bg" opacity="0.1" fill="none" stroke="#eee" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" stroke-miterlimit="10" d="\n                M93.9,46.4c9.3,9.5,13.8,17.9,23.5,17.9s17.5-7.8,17.5-17.5s-7.8-17.6-17.5-17.5c-9.7,0.1-13.3,7.2-22.1,17.1\n                c-8.9,8.8-15.7,17.9-25.4,17.9s-17.5-7.8-17.5-17.5s7.8-17.5,17.5-17.5S86.2,38.6,93.9,46.4z" />\n\t\t\t\t      </svg>';
     document.querySelector("#countColonies").appendChild(this.createDOM("div", { class: "spinner" }, svg));
-    return this.getEmpireInfo().then(async (json) => {
+    return this.getEmpireInfo().then((json) => {
       this.json.empire = json;
       this.json.lastEmpireUpdate = new Date();
       this.json.empire.forEach((planet) => {

--- a/ogkush.js
+++ b/ogkush.js
@@ -1474,6 +1474,7 @@ class OGInfinity {
       ids: [],
     };
     this.json.coordsHistory = this.json.coordsHistory || [];
+    this.json.serverSettingsTimeStamp = this.json.serverSettingsTimeStamp || 0;
     this.json.trashsimSettings = this.json.trashsimSettings || false;
     this.json.universeSettingsTooltip = this.json.universeSettingsTooltip || {};
     this.json.topScore = this.json.topScore || 0;
@@ -3143,13 +3144,16 @@ class OGInfinity {
     }
   }
 
-  async updateServerSettings() {
-    if (this.json.trashsimSettings && !this.json.updateSettings) return;
+  async updateServerSettings(force = false) {
+    const timeSinceServerTimeStamp =
+      document.querySelector("[name='ogame-timestamp']").content - this.json.serverSettingsTimeStamp;
+    if ((timeSinceServerTimeStamp <  24 * 3600) && !force) return;
     let settingsUrl = `https://s${this.universe}-${this.gameLang}.ogame.gameforge.com/api/serverData.xml`;
     return fetch(settingsUrl)
       .then((rep) => rep.text())
       .then((str) => new window.DOMParser().parseFromString(str, "text/xml"))
       .then((xml) => {
+        this.json.serverSettingsTimeStamp = xml.querySelector("serverData").getAttribute("timestamp");
         this.json.topScore = Number(xml.querySelector("topScore").innerHTML);
         this.json.speed = Number(xml.querySelector("speed").innerHTML);
         this.json.speedResearch =
@@ -17530,8 +17534,7 @@ class OGInfinity {
     let srvDatasBtn = this.createDOM("button", { class: "btn_blue update" }, this.getTranslatedText(23));
     srvDatas.appendChild(srvDatasBtn);
     srvDatasBtn.addEventListener("click", async () => {
-      this.json.updateSettings = true;
-      this.updateServerSettings();
+      this.updateServerSettings(true);
       await this.updateLifeform();
       document.querySelector(".ogl-dialog .close-tooltip").click();
     });

--- a/ogkush.js
+++ b/ogkush.js
@@ -18600,7 +18600,6 @@ class OGInfinity {
           time[1],
           time[2]
         );
-        if (this.json.options.timeZone) endDate = new Date(endDate - this.json.timezoneDiff * 1e3);
         this.json.productionProgress[coords] = {
           technoId: technoId,
           tolvl: tolvl,
@@ -18630,7 +18629,6 @@ class OGInfinity {
           time[1],
           time[2]
         );
-        if (this.json.options.timeZone) endDate = new Date(endDate - this.json.timezoneDiff * 1e3);
         this.json.lfProductionProgress[coords] = {
           technoId: technoId,
           tolvl: tolvl,
@@ -18666,7 +18664,6 @@ class OGInfinity {
           time[1],
           time[2]
         );
-        if (this.json.options.timeZone) endDate = new Date(endDate - this.json.timezoneDiff * 1e3);
         this.json.researchProgress = {
           technoId: technoId,
           coords: coords,
@@ -18698,7 +18695,6 @@ class OGInfinity {
           time[1],
           time[2]
         );
-        if (this.json.options.timeZone) endDate = new Date(endDate - this.json.timezoneDiff * 1e3);
         this.json.lfResearchProgress[coords] = {
           technoId: technoId,
           tolvl: tolvl,


### PR DESCRIPTION
- change updateServerSettings() to update settings once a day
- change LF bonus fetching to per planet as default when needed in every refresh
- lfbonus fetching is now independent of empire update
- empire production update is now a separate method from getEmpireInfo()
- allianceClass fetching temporary moved to settings update button
- fix  updateProductionProgress() regression with timezoneDiff shift
- modify initializeLFTypeName() for use in init as in #167 for later implement lfbonus update needs when planet changes

