### PR TITLE
disable auto LFBonusUpdates in moons

### DIFF
--- a/ogkush.js
+++ b/ogkush.js
@@ -1578,7 +1578,7 @@ class OGInfinity {
     this.updateServerSettings();
     this.updateEmpireData(forceEmpire);
     this.initializeLFTypeName();
-    if (this.json.needLifeformUpdate[this.current.id]) this.updateLifeform();
+    if (this.json.needLifeformUpdate[this.current.id] && !this.current.isMoon) this.updateLifeform();
 
     if (UNIVERSVIEW_LANGS.includes(this.gameLang)) {
       this.univerviewLang = this.gameLang;


### PR DESCRIPTION
Until a proper code is done in updateProductionProgress() and/or LFBonusUpdate process, disable auto LF bonus updates in moon to avoid endless needs of more updates in next pages until the update is done in the planet.

This is becase in updateProductionProgress() there is marking of needed update always until do the update in a planet and the progress mark get deleted. This is also a potential race condition, the lfupdate is async, seems to be executed later and clears the needs of more updates previously marked. **That has to be fixed to avoid potential future problems.**