### PR TITLE
overhaul keyboardActions() in fleet page

### DIFF
--- a/ogkush.js
+++ b/ogkush.js
@@ -15065,9 +15065,25 @@ class OGInfinity {
     };
     if (this.page == "fleetdispatch") {
       document.addEventListener("keydown", (event) => {
+        if (document.activeElement.classList && document.activeElement.classList.contains("chat_box_textarea")) return;
         if (fleetDispatcher.currentPage == "fleet1") {
           if (document.querySelector("#fleetTemplatesEdit")) {
             if (document.querySelector("#fleetTemplatesEdit").classList.contains("overlayDiv")) return;
+          }
+          const input = document.querySelector("#systemInput");
+          if (document.activeElement == input || document.activeElement.tagName == "BODY") {
+            if (fleetDispatcher.loading == false) {
+              if (event.code == "ArrowUp") {
+                input.value = Number(input.value) + 1;
+                fleetDispatcher.updateTarget();
+                fleetDispatcher.fetchTargetPlayerData();
+              }
+              if (event.code == "ArrowDown") {
+                input.value = Number(input.value) - 1;
+                fleetDispatcher.updateTarget();
+                fleetDispatcher.fetchTargetPlayerData();
+              }
+            }
           }
           if (document.activeElement.tagName != "INPUT") {
             if (event.code == "KeyE") {
@@ -15081,32 +15097,7 @@ class OGInfinity {
             if (event.code == "KeyN") document.querySelector("#resetall").click();
             if (event.code == "KeyA") document.querySelector("#sendall").click();
             if (event.code == "KeyM") document.querySelector("span.select-most").click();
-          } else {
-            const input = document.querySelector("#systemInput");
-            if (document.activeElement == input) {
-              if (event.code == "ArrowUp") {
-                input.value = Number(input.value) + 1;
-                fleetDispatcher.updateTarget();
-                fleetDispatcher.fetchTargetPlayerData();
-              }
-              if (event.code == "ArrowDown") {
-                input.value = Number(input.value) - 1;
-                fleetDispatcher.updateTarget();
-                fleetDispatcher.fetchTargetPlayerData();
-              }
-            }
           }
-          if (event.code == "KeyC") {
-            document.querySelector(".ogl-collect").click();
-            document.querySelector("#continueToFleet2").click();
-          }
-          if (event.code == "KeyN") document.querySelector("#resetall").click();
-          if (event.code == "KeyA") document.querySelector("#sendall").click();
-          if (event.code == "KeyM") document.querySelector("span.select-most").click();
-          if (event.code == "ArrowUp")
-            document.querySelector("#systemInput").value = Number(document.querySelector("#systemInput").value) + 1;
-          if (event.code == "ArrowDown")
-            document.querySelector("#systemInput").value = Number(document.querySelector("#systemInput").value) - 1;
         } else if (fleetDispatcher.currentPage == "fleet2") {
           if (event.code == "KeyA") document.querySelector("#loadAllResources img").click();
           if (event.code == "KeyM" && !event.shiftKey) document.querySelector("#loadAllResources .select-most").click();


### PR DESCRIPTION
- fixed system change in fleet 1 page with up&down arrows (works in the system input box and with nothing selected): now work correctly (without fleetDispatcher errors) with key pressed
- exclude key shorcuts in fleet page when chatbox area is the active element
- removed some duplicate shortcuts calling -> no errors with fleetDispatcher