### PR TITLE
Fix date in espionage overview for timezones other than UK whilst having timezone comp enabled

### DIFF
--- a/ogkush.js
+++ b/ogkush.js
@@ -14234,7 +14234,8 @@ class OGInfinity {
       let dateDetail = `\n${report.cleanDate.toLocaleDateString()}<br>\n${report.cleanDate.toLocaleTimeString()}<br>\n${this.getTranslatedText(
         137
       )} : ${report.activity}\n`;
-      let dateText = `${this.timeSince(report.cleanDate)}<br>`;
+      const timeZoneChange = this.json.options.timeZone ? this.json.timezoneDiff * 1e3 : 0;
+      let dateText = `${this.timeSince(report.cleanDate - timeZoneChange)}<br>`;
       let date = line.appendChild(this.createDOM("td", { class: "tooltipLeft ogl-date", title: dateDetail }, dateText));
       if (report.activity <= 15) date.classList.add("ogl-danger");
       else if (report.activity < 60) date.classList.add("ogl-care");


### PR DESCRIPTION
So this was an issue I noticed in the espionage overview. It showed as `Just now` for the whole hour because I am at +1 timezone.

If the timezone comp was off there was no issue. This should only affect users with timezone comp on.