### PR TITLE
change expeditionGraph precision to workaround a bug in chartjs until…

### DIFF
--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -6330,6 +6330,7 @@ class OGInfinity {
               fontSize: 12,
               fontStyle: "bold",
               fontColor: "#0d1117",
+              precision: 1,
               render: "percentage",
             },
           ],


### PR DESCRIPTION
… updated

With low % (below 1) it seems that the chart from chartjs has a bug and display sometimes negative values. Changing precision to 1 decimal seems to avoid that bug. Workaround until chartjs libs are updated. Or we may keep the precision with one decimal as it gives useful information at low %.