### PR TITLE
Fix/v11 cosmetic issues directives & fleet2 resource buttons

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -1355,21 +1355,6 @@ input[type="file"] {
   z-index: -1;
 }
 
-#tutorialiconcomponent #helper a {
-  transform: scale(0.5);
-  left: 20px !important;
-  top: -20px !important;
-  opacity: 0.5;
-}
-
-#tutorialiconcomponent #helper a:hover {
-  opacity: 1;
-}
-
-#toolbarcomponent {
-  margin-top: -30px;
-}
-
 #pageReloader {
   background: rgba(0, 0, 0, 0.44);
   border-radius: 50px;

--- a/src/global.css
+++ b/src/global.css
@@ -1244,31 +1244,11 @@ input[type="password"]::selection {
   text-align: right;
 }
 
-#fleet3 #sendfleet #resources .res_wrap {
-  width: 150px !important;
-  z-index: 10;
-}
-
-#fleet3 #sendfleet .res input {
-  width: 93px !important;
-}
-
-#fleet3 #sendfleet #resources #mostresources {
-  position: absolute;
-  top: 10px;
-  left: 35px;
-}
-
-#fleet3 #sendfleet #resources a#allresources {
-  margin-left: 55px !important;
-}
-
-#loadAllResources .select-most {
-  margin: -42px 0 0 20px !important;
-}
-
-#loadAllResources .send_none a {
-  margin: -42px 17px 0 0 !important;
+#fleet2 #resources .allResourcesWrap {
+  display: grid;
+  grid-gap: 2px;
+  grid-template-columns: repeat(3, 1fr);
+  width: min-content !important;
 }
 
 .ogi-actions {

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -10302,7 +10302,7 @@ class OGInfinity {
       $("#selectMaxMetal").after(createDOM("span", { class: "ogi-metalLeft" }, "-"));
       $("#selectMaxCrystal").after(createDOM("span", { class: "ogi-crystalLeft" }, "-"));
       $("#selectMaxDeuterium").after(createDOM("span", { class: "ogi-deuteriumLeft" }, "-"));
-      $("#allresources").after(createDOM("a", { class: "select-most" }));
+      $("#allresources").before(createDOM("a", { class: "select-most" }));
       $("#allresources").after(createDOM("a", { class: "send_none" }).appendChild(createDOM("a")).parentElement);
       $("#loadAllResources .select-most").on("click", () => {
         $("#selectMinDeuterium").click();


### PR DESCRIPTION
before:

![imagen](https://github.com/ogame-infinity/web-extension/assets/13818551/a93c9536-1960-48cb-8a18-e879a3d1cf10)
![imagen](https://github.com/ogame-infinity/web-extension/assets/13818551/651c389a-df5b-407a-8c21-5684d50bfd4e)

after:

![imagen](https://github.com/ogame-infinity/web-extension/assets/13818551/e080cd59-0c68-4d2f-ba2f-234629e7a974)
![imagen](https://github.com/ogame-infinity/web-extension/assets/13818551/102cf1f8-4070-4bcf-91ff-f09e2f5f340c)

- removed old now useless page fleet3 rules for resource buttons area and change the current ones to a grid rule working with new version changes
- removed the left menu displacement and help component minimization as with the new newbie system it can be hidden with native options