### PR TITLE
partial fix for v11.3.0 empire production data changes

### DIFF
--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -11735,6 +11735,7 @@ class OGInfinity {
   updateEmpireProduction() {
     this.json.empire.forEach((planet) => {
 
+      planet.production.productionFactor = 1; // temporary, TODO: change use in fleetDispatcher with computed factor
       planet.production.generalIncoming = {
         0: METAL_GENERAL_INCOMING * METAL_POS_BONUS[planet.position - 1] * this.json.speed,
         1: CRYSTAL_GENERAL_INCOMING * CRYSTAL_POS_BONUS[planet.position - 1] * this.json.speed,


### PR DESCRIPTION
partial fix that enables ogi to not be broken by v11.3.0

- production data it is only right with ALL 100% production factors
- production factors calculation still to be implemented
- items production still to be implemented
- crawler production will be wrong in some cases

