### PR TITLE
fix(ptre): Add country and universe to PTRE endpoints

### DIFF
--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -3950,7 +3950,7 @@ class OGInfinity {
     pageContextRequest("ptre", "galaxy", data.changes, data.ptreKey, data.serverTime)
       .then((value) => {
         if (Object.keys(value.response).length > 0) {
-          ptreService.updateGalaxy(value.response);
+          ptreService.updateGalaxy(this.gameLang, this.universe, value.response);
         }
       })
       .finally(() => "nothing");
@@ -3971,7 +3971,7 @@ class OGInfinity {
       ptreJSON[coords].main = mainPlanet.coords === coords || false;
     }
 
-    fetch("https://ptre.chez.gg/scripts/oglight_import_player_activity.php?tool=infinity", {
+    fetch("https://ptre.chez.gg/scripts/oglight_import_player_activity.php?tool=infinity&country=" + this.gameLang + "&univers=" + this.universe, {
       priority: "low",
       method: "POST",
       body: JSON.stringify(ptreJSON),
@@ -5042,7 +5042,7 @@ class OGInfinity {
     }
 
     let cleanPlayerName = encodeURIComponent(player.name);
-    ptreService.getPlayerInfos(this.json.options.ptreTK, cleanPlayerName, player.id, frame).then((result) => {
+    ptreService.getPlayerInfos(this.gameLang, this.universe, this.json.options.ptreTK, cleanPlayerName, player.id, frame).then((result) => {
       if (result.code == 1) {
         let arrData = result.activity_array.succes == 1 ? JSON.parse(result.activity_array.activity_array) : null;
         let checkData = result.activity_array.succes == 1 ? JSON.parse(result.activity_array.check_array) : null;
@@ -13611,7 +13611,7 @@ class OGInfinity {
       this.sortTable(this.reportList);
     }
     if (Object.keys(ptreJSON).length > 0) {
-      ptreService.importPlayerActivity(ptreJSON).finally(() => "Do nothing");
+      ptreService.importPlayerActivity(this.gameLang, this.universe, ptreJSON).finally(() => "Do nothing");
     }
   }
 

--- a/src/util/service.ptre.js
+++ b/src/util/service.ptre.js
@@ -31,9 +31,11 @@ function _buildQueryString(params, data = undefined) {
 /**
  * @return {Promise<PtreResponse>}
  */
-export function getPlayerInfos(teamKey, cleanPlayerName, playerId, frame) {
+export function getPlayerInfos(country, universe, teamKey, cleanPlayerName, playerId, frame) {
   const url = new URL(PTRE_URL.concat("oglight_get_player_infos.php"));
   _buildQueryString(url.searchParams, {
+    country: country,
+    univers: universe,
     team_key: teamKey,
     pseudo: cleanPlayerName,
     player_id: playerId,
@@ -55,9 +57,12 @@ export function getPlayerInfos(teamKey, cleanPlayerName, playerId, frame) {
 /**
  * @return {Promise<PtreResponse>}
  */
-export function updateGalaxy(position) {
+export function updateGalaxy(country, universe, position) {
   const url = new URL(PTRE_URL.concat("api_galaxy_import_infos.php"));
-  _buildQueryString(url.searchParams);
+  _buildQueryString(url.searchParams, {
+    country: country,
+    univers: universe,
+  });
 
   return fetch(url, {
     method: "POST",
@@ -82,9 +87,12 @@ export function updateGalaxy(position) {
 /**
  * @return {Promise<PtreResponse>}
  */
-export function importPlayerActivity(activity) {
+export function importPlayerActivity(country, universe, activity) {
   const url = new URL(PTRE_URL.concat("oglight_import_player_activity.php"));
-  _buildQueryString(url.searchParams);
+  _buildQueryString(url.searchParams, {
+    country: country,
+    univers: universe,
+  });
 
   return fetch(url, {
     method: "POST",


### PR DESCRIPTION
First PTRE endpoints used `HTTP_REFERER` to guess source country and universe.

As some browsers (Brave, i think) dont set `HTTP_REFERER`, some background requests to PTRE fail.

This PR aims to add thoses parameters to each PTRE requests as GET parameters.