### PR TITLE
feat(activities): Track right-pinned player activities

### DIFF
--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -3891,11 +3891,10 @@ class OGInfinity {
         }
 
         // PTRE activities
-        if (
-          this.json.options.ptreTK &&
-          playerId > -1 &&
-          (this.json.sideStalk.indexOf(playerId) > -1 || this.markedPlayers.indexOf(playerId) > -1)
-        ) {
+        if ( this.json.options.ptreTK && playerId > -1 &&
+            (this.json.sideStalk.indexOf(playerId) > -1 || 
+             this.markedPlayers.indexOf(playerId) > -1 || 
+             playerId == this.json.searchHistory[this.json.searchHistory.length - 1].id) ) {
           let planetActivity = row.querySelector("[data-planet-id] .activity.minute15")
             ? "*"
             : row.querySelector("[data-planet-id] .activity")?.textContent.trim() || 60;
@@ -3982,6 +3981,11 @@ class OGInfinity {
           document
             .querySelectorAll(`.ogl-stalkPlanets [data-coords^="${systemCoords[0]}:${systemCoords[1]}:"]`)
             .forEach((e) => {
+              if (!e.classList.contains(".ptre_updated")) {
+                e.classList.add("ptre_updated");
+              }
+            });
+            document.querySelectorAll(`.ogl-active [data-coords^="${systemCoords[0]}:${systemCoords[1]}:"]`).forEach((e) => {
               if (!e.classList.contains(".ptre_updated")) {
                 e.classList.add("ptre_updated");
               }


### PR DESCRIPTION
When using player search (in right panel), we want to track activities for selected player in historic. 

Every time a player is selected in historic, he is added as last element of this list `searchHistory`. This PR aims to test last element of `searchHistory` and push activities as a if it was a regular target in `sideStalk`. 