### PR TITLE
The options are extracted from the main init

### DIFF
--- a/src/ctxpage/conf-options.js
+++ b/src/ctxpage/conf-options.js
@@ -1,0 +1,177 @@
+/**
+ * @typedef {Object} OptionExpedition
+ * @property {number} cargoShip
+ * @property {number} combatShip
+ * @property {number} defaultTime
+ * @property {number} limitCargo 1 to 100
+ * @property {boolean} rotation
+ * @property {number} rotationAfter
+ * @property {boolean} sendCombat
+ * @property {boolean} sendProbe
+ * @property {boolean} standardFleet
+ * @property {boolean} standardFleetId
+ */
+
+/**
+ * @typedef {Object} OptionCollect_Target
+ * @property {number} galaxy
+ * @property {number} system
+ * @property {number} position
+ * @property {number} type
+ */
+
+/**
+ * @typedef {Object} OptionCollect
+ * @property {OptionCollect_Target} target
+ * @property {number} mission
+ * @property {number} ship
+ */
+
+const _options = {
+  maxCrawler: false,
+  crawlerPercent: 1.5,
+  tradeRate: [2.5, 1.5, 1, 0],
+  dispatcher: false,
+  sideStalkVisible: true,
+  eventBoxExps: true,
+  eventBoxKeep: false,
+  empire: false,
+  targetList: false,
+  fret: 202,
+  spyFret: 202,
+  expeditionMission: 15,
+  foreignMission: 3,
+  harvestMission: 4,
+  activitytimers: 0,
+  planetIcons: false,
+  disableautofetchempire: false,
+  autofetchempire: true,
+  spyFilter: "DATE",
+  ptreTK: "",
+  pantryKey: "",
+  simulator: "",
+  rvalLimit: undefined,
+  spyTableEnable: true,
+  spyTableAppend: true,
+  compactViewEnable: true,
+  autoDeleteEnable: false,
+  kept: {},
+  defaultKept: {},
+  hiddenTargets: {},
+  timeZone: true,
+  collect: {
+    ship: 202,
+    mission: 3,
+    target: {
+      galaxy: 0,
+      system: 0,
+      position: 0,
+      type: 1,
+    },
+  },
+  expedition: {
+    cargoShip: 202,
+    combatShip: 218,
+    defaultTime: 1,
+    limitCargo: 1,
+    rotation: false,
+    rotationAfter: 3,
+    sendCombat: true,
+    sendProbe: true,
+    standardFleet: false,
+    standardFleetId: 0,
+  },
+};
+
+export function initConfOptions(options) {
+  if (undefined === options) {
+    options = {};
+  }
+
+  const collect = options?.collect || _options.collect;
+  delete options["collect"];
+
+  const expedition = options?.expedition || _options.expedition;
+  delete options["expedition"];
+
+  /** @type {string} */
+  const ptreTK = options.ptreTK || _options.ptreTK;
+  options.ptreTK = "";
+  if (ptreTK && ptreTK.replace(/-/g, "").length === 18 && ptreTK.startsWith("TM")) {
+    options.ptreTK = ptreTK;
+  }
+
+  Object.assign(_options, options);
+  Object.assign(_options.collect, collect);
+  Object.assign(_options.expedition, expedition);
+}
+
+/** @type {ProxyHandler} */
+const handlerProxy = {
+  set(target, prop, newValue, receiver) {
+    if (typeof prop !== "string") {
+      return Reflect.set(...arguments);
+    }
+
+    if (Object.hasOwn(target, prop)) {
+      target[prop] = newValue;
+    }
+    return true;
+  },
+  get(target, prop, receiver) {
+    return Reflect.get(...arguments);
+  },
+  ownKeys(target) {
+    return Reflect.ownKeys(target);
+  },
+  has(target, prop) {
+    return Reflect.has(target, prop);
+  },
+
+  preventExtensions(_) {
+    return false;
+  },
+  isExtensible(_) {
+    return false;
+  },
+
+  defineProperty(target, prop, _) {
+    if (Object.hasOwn(target, prop)) {
+      return true;
+    }
+
+    throw new Error(`Not allowed to define '${prop}' configuration property from option proxy`);
+  },
+
+  deleteProperty(target, prop) {
+    throw new Error(`Not allowed to delete '${prop}' configuration property from option proxy`);
+  },
+};
+
+const proxyOptions = new Proxy(_options, handlerProxy);
+
+/**
+ * @return {typeof _options} Proxy
+ */
+export function getOptions() {
+  return proxyOptions;
+}
+
+/**
+ * @param {string} name
+ * @return {*|undefined}
+ */
+export function getOption(name) {
+  if (Object.hasOwn(_options, name)) {
+    return _options[name];
+  }
+  return undefined;
+}
+
+/**
+ * @param {string} name
+ * @param {*} value
+ */
+export function setOption(name, value) {
+  _options[name] = value;
+}

--- a/src/ctxpage/conf-options.js
+++ b/src/ctxpage/conf-options.js
@@ -43,7 +43,7 @@ const _options = {
   foreignMission: 3,
   harvestMission: 4,
   activitytimers: false,
-  autofetchempire: true,
+  lessAggressiveEmpireAutomaticUpdate: false,
   spyFilter: "DATE",
   ptreTK: "",
   pantryKey: "",

--- a/src/ctxpage/conf-options.js
+++ b/src/ctxpage/conf-options.js
@@ -43,7 +43,6 @@ const _options = {
   foreignMission: 3,
   harvestMission: 4,
   activitytimers: false,
-  disableautofetchempire: false,
   autofetchempire: true,
   spyFilter: "DATE",
   ptreTK: "",

--- a/src/ctxpage/conf-options.js
+++ b/src/ctxpage/conf-options.js
@@ -3,13 +3,13 @@
  * @property {number} cargoShip
  * @property {number} combatShip
  * @property {number} defaultTime
- * @property {number} limitCargo 1 to 100
+ * @property {number} limitCargo 1 to 500 (is percentage)
  * @property {boolean} rotation
  * @property {number} rotationAfter
  * @property {boolean} sendCombat
  * @property {boolean} sendProbe
  * @property {boolean} standardFleet
- * @property {boolean} standardFleetId
+ * @property {number} standardFleetId
  */
 
 /**
@@ -42,15 +42,14 @@ const _options = {
   expeditionMission: 15,
   foreignMission: 3,
   harvestMission: 4,
-  activitytimers: 0,
-  planetIcons: false,
+  activitytimers: false,
   disableautofetchempire: false,
   autofetchempire: true,
   spyFilter: "DATE",
   ptreTK: "",
   pantryKey: "",
   simulator: "",
-  rvalLimit: undefined,
+  rvalLimit: 1e6, // needs revision to consider the speed of the universe.
   spyTableEnable: true,
   spyTableAppend: true,
   compactViewEnable: true,

--- a/src/ctxpage/conf-options.js
+++ b/src/ctxpage/conf-options.js
@@ -92,13 +92,6 @@ export function initConfOptions(options) {
   const expedition = options?.expedition || _options.expedition;
   delete options["expedition"];
 
-  /** @type {string} */
-  const ptreTK = options.ptreTK || _options.ptreTK;
-  options.ptreTK = "";
-  if (ptreTK && ptreTK.replace(/-/g, "").length === 18 && ptreTK.startsWith("TM")) {
-    options.ptreTK = ptreTK;
-  }
-
   Object.assign(_options, options);
   Object.assign(_options.collect, collect);
   Object.assign(_options.expedition, expedition);

--- a/src/ctxpage/conf-options.js
+++ b/src/ctxpage/conf-options.js
@@ -151,6 +151,7 @@ const handlerProxy = {
 const proxyOptions = new Proxy(_options, handlerProxy);
 
 /**
+ * Gets all declared options.
  * @return {typeof _options} Proxy
  */
 export function getOptions() {
@@ -158,6 +159,7 @@ export function getOptions() {
 }
 
 /**
+ * Gets the value of an existing option.
  * @param {string} name
  * @return {*|undefined}
  */
@@ -169,6 +171,7 @@ export function getOption(name) {
 }
 
 /**
+ * Allows to set the value of a previously existing or non-existing option.
  * @param {string} name
  * @param {*} value
  */

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -1688,7 +1688,7 @@ class OGInfinity {
       force ||
       isNaN(new Date(this.json.lastEmpireUpdate)) ||
       (timeSinceLastUpdate > 5 * 60 * 1e3 && this.json.needsUpdate) ||
-      (timeSinceLastUpdate > 1 * 60 * 1e3 && this.json.options.autofetchempire)
+      (timeSinceLastUpdate > 1 * 60 * 1e3 && !this.json.options.lessAggressiveEmpireAutomaticUpdate)
     ) {
       await this.updateInfo();
     }
@@ -3401,7 +3401,7 @@ class OGInfinity {
                     if (movement.metal) object.metal += movement.metal;
                     if (movement.crystal) object.crystal += movement.crystal;
                     if (movement.deuterium) object.deuterium += movement.deuterium;
-                    if (this.json.options.autofetchempire) {
+                    if (!this.json.options.lessAggressiveEmpireAutomaticUpdate) {
                       update = true;
                     } else {
                       object.invalidate = true;
@@ -16300,11 +16300,11 @@ class OGInfinity {
           tr: "Etkinlik zamanlayıcılarını göster",
         },
         /*34*/ {
-          de: "Automatisches Abrufen von Imperium deaktivieren",
-          en: "Disable auto fetch Empire",
-          es: "Desactivar la actualización automática del Imperio",
-          fr: "Désactiver la récupération automatique de l'Empire",
-          tr: "İmparatorluğu otomatik getirmeyi devre dışı bırak",
+          de: "Weniger aggressives automatisches Empire-Update",
+          en: "Less aggressive empire automatic update",
+          es: "Actualización automática del Imperio menos agresiva",
+          fr: "Récupération automatique de l'Empire moins agressif",
+          tr: "Daha az agresif imparatorluk otomatik güncellemesi",
         },
         /*35*/ {
           de: "Rentabilitätswert",
@@ -17410,13 +17410,13 @@ class OGInfinity {
         this.getTranslatedText(34)
       )
     );
-    let disableautofetchempirebox = optiondiv.appendChild(createDOM("input", { type: "checkbox" }));
-    disableautofetchempirebox.addEventListener("change", () => {
-      this.json.options.autofetchempire = !disableautofetchempirebox.checked;
+    let lessAggressiveEmpireAutomaticUpdateBox = optiondiv.appendChild(createDOM("input", { type: "checkbox" }));
+    lessAggressiveEmpireAutomaticUpdateBox.addEventListener("change", () => {
+      this.json.options.lessAggressiveEmpireAutomaticUpdate = lessAggressiveEmpireAutomaticUpdateBox.checked;
       this.saveData();
     });
-    if (!this.json.options.autofetchempire) {
-      disableautofetchempirebox.checked = true;
+    if (this.json.options.lessAggressiveEmpireAutomaticUpdate) {
+      lessAggressiveEmpireAutomaticUpdateBox.checked = true;
     }
     let fleetActivity = featureSettings.appendChild(
       this.createDOM(

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -1,4 +1,5 @@
 /// Page Context Imports
+import { initConfOptions, getOptions } from "./ctxpage/conf-options.js";
 import ctxMessageAnalyzer from "./ctxpage/messages-analyzer/index.js";
 import * as DOM from "./util/dom.js";
 import { getLogger } from "./util/logger.js";
@@ -1455,6 +1456,14 @@ class OGInfinity {
     this.json.tchat = this.json.tchat || false;
     this.json.needSync = this.json.needSync || false;
     this.json.timezoneDiff = this.json.timezoneDiff || 0;
+
+    initConfOptions(this.json.options);
+    // set a proxy for compatibility, important for saving configuration.
+    this.json.options = getOptions();
+
+    /// TODO: Remove this region when test of options is approved
+    /// region this.json.options declaration
+    /*
     this.json.options = this.json.options || {};
     this.json.options.collect = this.json.options.collect || {
       target: { galaxy: 0, system: 0, position: 0, type: 1 },
@@ -1512,6 +1521,9 @@ class OGInfinity {
     this.json.options.defaultKept = this.json.options.defaultKept || {};
     this.json.options.hiddenTargets = this.json.options.hiddenTargets || {};
     this.json.options.timeZone = this.json.options.timeZone === false ? false : true;
+    */
+    /// endregion options
+
     this.json.selectedLifeforms = this.json.selectedLifeforms || {};
     this.json.lifeformBonus = this.json.lifeformBonus || null;
     this.json.lifeformPlanetBonus = this.json.lifeformPlanetBonus || {};
@@ -3888,8 +3900,8 @@ class OGInfinity {
 
         // PTRE activities
         if ( this.json.options.ptreTK && playerId > -1 &&
-            (this.json.sideStalk.indexOf(playerId) > -1 || 
-             this.markedPlayers.indexOf(playerId) > -1 || 
+            (this.json.sideStalk.indexOf(playerId) > -1 ||
+             this.markedPlayers.indexOf(playerId) > -1 ||
              (this.json.searchHistory.length > 0 && playerId == this.json.searchHistory[this.json.searchHistory.length - 1].id)) ) {
           let planetActivity = row.querySelector("[data-planet-id] .activity.minute15")
             ? "*"

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -1461,69 +1461,6 @@ class OGInfinity {
     // set a proxy for compatibility, important for saving configuration.
     this.json.options = getOptions();
 
-    /// TODO: Remove this region when test of options is approved
-    /// region this.json.options declaration
-    /*
-    this.json.options = this.json.options || {};
-    this.json.options.collect = this.json.options.collect || {
-      target: { galaxy: 0, system: 0, position: 0, type: 1 },
-      mission: 3, // 3 = transport, 4 = deployment
-      ship: 202, // 202 = small cargo, 203 = large cargo
-    };
-    this.json.options.maxCrawler = this.json.options.limitCrawler || false;
-    this.json.options.crawlerPercent = this.json.options.crawlerPercent || 1.5;
-    this.json.options.tradeRate = this.json.options.tradeRate || [2.5, 1.5, 1, 0];
-    this.json.options.dispatcher = this.json.options.dispatcher === true ? true : false;
-    this.json.options.sideStalkVisible = this.json.options.sideStalkVisible === false ? false : true;
-    this.json.options.eventBoxExps = this.json.options.eventBoxExps === false ? false : true;
-    this.json.options.eventBoxKeep = this.json.options.eventBoxKeep === true ? true : false;
-    this.json.options.empire = this.json.options.empire === true ? true : false;
-    this.json.options.targetList = this.json.options.targetList === true ? true : false;
-    this.json.options.fret = this.json.options.fret || 202;
-    this.json.options.spyFret = this.json.options.spyFret || 202;
-    this.json.options.expeditionMission = this.json.options.expeditionMission || 15;
-    this.json.options.foreignMission = this.json.options.foreignMission || 3;
-    this.json.options.harvestMission = this.json.options.harvestMission || 4;
-    this.json.options.expedition = this.json.options.expedition || {};
-    this.json.options.expedition.cargoShip = this.json.options.expedition.cargoShip || 202; // small cargo
-    this.json.options.expedition.combatShip = this.json.options.expedition.combatShip || 218; // reaper
-    this.json.options.expedition.defaultTime = this.json.options.expedition.defaultTime || 1; // 1 hour
-    this.json.options.expedition.limitCargo = this.json.options.expedition.limitCargo || 1; // 100 %
-    this.json.options.expedition.rotation = this.json.options.expedition.rotation === true ? true : false;
-    this.json.options.expedition.rotationAfter = this.json.options.expedition.rotationAfter || 3;
-    this.json.options.expedition.sendCombat = this.json.options.expedition.sendCombat === false ? false : true;
-    this.json.options.expedition.sendProbe = this.json.options.expedition.sendProbe === false ? false : true;
-    this.json.options.expedition.standardFleet = this.json.options.expedition.standardFleet === true ? true : false;
-    this.json.options.expedition.standardFleetId = this.json.options.expedition.standardFleetId || 0;
-    this.json.options.activitytimers = this.json.options.activitytimers === true ? true : false;
-    this.json.options.planetIcons = this.json.options.planetIcons === true ? true : false;
-    this.json.options.disableautofetchempire = this.json.options.disableautofetchempire === true ? true : false;
-    this.json.options.autofetchempire = this.json.options.disableautofetchempire === true ? false : true;
-    this.json.options.spyFilter = this.json.options.spyFilter || "DATE";
-    if (
-      this.json.options.ptreTK &&
-      this.json.options.ptreTK.replace(/-/g, "").length == 18 &&
-      this.json.options.ptreTK.indexOf("TM") == 0
-    ) {
-      this.json.options.ptreTK = this.json.options.ptreTK || "";
-    } else {
-      this.json.options.ptreTK = "";
-      // TODO: Remove ptreTK from LocalStorage (it has wrong format)
-    }
-    this.json.options.pantryKey = this.json.options.pantryKey || "";
-    this.json.options.simulator = this.json.options.simulator || "";
-    this.json.options.rvalLimit = this.json.options.rvalLimit || 4e5 * this.json.speed;
-    this.json.options.spyTableEnable = this.json.options.spyTableEnable === false ? false : true;
-    this.json.options.spyTableAppend = this.json.options.spyTableAppend === false ? false : true;
-    this.json.options.compactViewEnable = this.json.options.compactViewEnable === false ? false : true;
-    this.json.options.autoDeleteEnable = this.json.options.autoDeleteEnable === true ? true : false;
-    this.json.options.kept = this.json.options.kept || {};
-    this.json.options.defaultKept = this.json.options.defaultKept || {};
-    this.json.options.hiddenTargets = this.json.options.hiddenTargets || {};
-    this.json.options.timeZone = this.json.options.timeZone === false ? false : true;
-    */
-    /// endregion options
-
     this.json.selectedLifeforms = this.json.selectedLifeforms || {};
     this.json.lifeformBonus = this.json.lifeformBonus || null;
     this.json.lifeformPlanetBonus = this.json.lifeformPlanetBonus || {};
@@ -17768,7 +17705,7 @@ class OGInfinity {
     settingDiv.appendChild(saveBtn);
     saveBtn.addEventListener("click", () => {
       this.json.options.rvalLimit = fromFormatedNumber(rvalInput.value, true);
-      if (ptreInput.value && ptreInput.value.replace(/-/g, "").length == 18 && ptreInput.value.indexOf("TM") == 0) {
+      if (ptreInput.value && ptreInput.value.replace(/-/g, "").length === 18 && ptreInput.value.startsWith("TM")) {
         this.json.options.ptreTK = ptreInput.value;
       } else {
         this.json.options.ptreTK = "";

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -17412,10 +17412,10 @@ class OGInfinity {
     );
     let disableautofetchempirebox = optiondiv.appendChild(createDOM("input", { type: "checkbox" }));
     disableautofetchempirebox.addEventListener("change", () => {
-      this.json.options.disableautofetchempire = disableautofetchempirebox.checked;
+      this.json.options.autofetchempire = !disableautofetchempirebox.checked;
       this.saveData();
     });
-    if (this.json.options.disableautofetchempire) {
+    if (!this.json.options.autofetchempire) {
       disableautofetchempirebox.checked = true;
     }
     let fleetActivity = featureSettings.appendChild(


### PR DESCRIPTION
The options _(OGInfinity.json.options)_ are extracted from the main build and declared in _./ctxpage/conf-options.js_.

The new implementation allows to get the configuration from different parts without the need to transport the OGInfinity instance.

In this implementation there are three exposed functions.

```ts
/// file: src/ctxpage/conf-options.js

/** Gets all declared options.  */
getOptions() : ProxyOptions;

/** Gets the value of an existing option */
getOption(name: string) : any | undefined;

/* Allows to set the value of a previously existing or non-existing option. */
setOption(name: string, value: any) : void;

```
In the case of `getOptions()` the proxy used prevents new options from being declared directly. If you need to add a new option it is recommended to add it directly in the `_options` constant.

> To avoid future conflicts it is recommended to use native values and avoid nesting objects.
