### PR TITLE
Feature: Universe Expiration request and universe storage with TTL

### DIFF
--- a/src/ctxcontent/helpers/universe.data.js
+++ b/src/ctxcontent/helpers/universe.data.js
@@ -1,4 +1,3 @@
-import { getLogger } from "../../util/logger.js";
 import { isUniverseExpired, setUniverseExpiration } from "../services/universe.expirations.js";
 import { universeStorageOperator, universeStorageSupplier } from "../services/universe.storage.js";
 import { requestOGameServerData } from "../services/request.ogameServerData.js";
@@ -17,8 +16,12 @@ export function getUniverseData(universe, force) {
 
   const flowRequest = async function () {
     const response = await requestOGameServerData(universe);
+    /** @type {UniverseResponse} */
     const uniInformation = await toUniverseInformation(response);
-    return storage(uniInformation).then();
+    return storage(uniInformation).then((data) => {
+      setUniverseExpiration(universe, STORAGE_KEY, response.expires);
+      return data;
+    });
   };
 
   const dataPromise = async function (isExpired) {

--- a/src/ctxcontent/helpers/universe.data.js
+++ b/src/ctxcontent/helpers/universe.data.js
@@ -1,0 +1,191 @@
+import { getLogger } from "../../util/logger.js";
+import { isUniverseExpired, setUniverseExpiration } from "../services/universe.expirations.js";
+import { universeStorageOperator, universeStorageSupplier } from "../services/universe.storage.js";
+import { requestOGameServerData } from "../services/request.ogameServerData.js";
+
+const STORAGE_KEY = "universe-data";
+
+/**
+ * @param {string} universe
+ * @param {boolean?} force
+ * @return {Promise<UniverseResponse>}
+ */
+export function getUniverseData(universe, force) {
+  const isExpire = force ? Promise.resolve(true) : isUniverseExpired(universe, STORAGE_KEY);
+  const retrieve = universeStorageSupplier(universe, STORAGE_KEY);
+  const storage = universeStorageOperator(universe, STORAGE_KEY);
+
+  const flowRequest = async function () {
+    const response = await requestOGameServerData(universe);
+    const uniInformation = await toUniverseInformation(response);
+    return storage(uniInformation).then();
+  };
+
+  const dataPromise = async function (isExpired) {
+    return isExpired ? await flowRequest() : await retrieve();
+  };
+
+  return isExpire.then(dataPromise);
+}
+
+/**
+ * @param {FetchResponse<Document>} response
+ * @return {UniverseResponse}
+ */
+function toUniverseInformation(response) {
+  const doc = response.document.documentElement;
+
+  /** @type {UniverseData} */
+  const universeData = {
+    timestamp: Number(doc.getAttribute("timestamp")) * 1e3,
+    serverId: doc.getAttribute("serverId"),
+  };
+
+  const nodeLifeforms = doc.getElementsByTagName("lifeformSettings");
+  let lifeformsData = toLifeforms(nodeLifeforms[0] ?? null);
+  if (nodeLifeforms.length > 0) {
+    doc.removeChild(nodeLifeforms[0]);
+  }
+
+  Array.from(doc.childNodes).reduce((acc, node) => {
+    acc[node.nodeName] = node.textContent;
+    return acc;
+  }, universeData);
+
+  return {
+    universe: universeData,
+    lifeforms: lifeformsData,
+  };
+}
+
+/**
+ * @param {HTMLElement?} e
+ * @return {Map<number, LifeformSettings>}
+ */
+function toLifeforms(e) {
+  /** @type {Map<number, LifeformSettings>} */
+  const result = new Map();
+  if (!e) {
+    return result;
+  }
+
+  // TODO: Need mapping implementation to lifeforms
+  //
+
+  return result;
+}
+
+/**
+ * @typedef {Object} UniverseResponse
+ * @property {UniverseData} universe
+ * @property {Map<number, LifeformSettings>} lifeforms
+ */
+
+/**
+ * @typedef {Object} UniverseData
+ * @property {number} timestamp
+ * @property {string} serverId
+ * @property {string} name Bermuda
+ * @property {number} number 801
+ * @property {string} language en
+ * @property {string} timezone Europe/London
+ * @property {string} timezoneOffset +00:00
+ * @property {string} domain s801-en.ogame.gameforge.com
+ * @property {string} version 11.7.0-rc2
+ * @property {number} speed 10
+ * @property {number} speedFleetPeaceful 10
+ * @property {number} speedFleetWar 10
+ * @property {number} speedFleetHolding 10
+ * @property {number} galaxies 9
+ * @property {number} systems 499
+ * @property {boolean} acs 1
+ * @property {boolean} rapidFire 1
+ * @property {boolean} defToTF 1
+ * @property {number} debrisFactor 0.7
+ * @property {number} debrisFactorDef 0.5
+ * @property {number} repairFactor 0.7
+ * @property {number} newbieProtectionLimit 500000
+ * @property {number} newbieProtectionHigh 50000
+ * @property {number} topScore 3.4166543381971E+16
+ * @property {number} bonusFields 0
+ * @property {boolean} donutGalaxy 1
+ * @property {boolean} donutSystem 1
+ * @property {boolean} wfEnabled 1
+ * @property {number} wfMinimumRessLost 150000
+ * @property {number} wfMinimumLossPercentage 5
+ * @property {number} wfBasicPercentageRepairable 45
+ * @property {number} globalDeuteriumSaveFactor 1
+ * @property {boolean} bashingSystemEnabled [default: false]
+ * @property {number} bashlimit 6
+ * @property {number} probeCargo 5
+ * @property {number} researchDurationDivisor 1
+ * @property {number} darkMatterNewAcount 10000000
+ * @property {number} cargoHyperspaceTechMultiplier 2
+ * @property {boolean} deuteriumInDebris 1
+ * @property {boolean} fleetIgnoreEmptySystems 1
+ * @property {boolean} fleetIgnoreInactiveSystems 1
+ * @property {boolean} marketplaceEnabled 0
+ * @property {number} marketplaceBasicTradeRatioMetal 2.5
+ * @property {number} marketplaceBasicTradeRatioCrystal 1.5
+ * @property {number} marketplaceBasicTradeRatioDeuterium 1
+ * @property {number} marketplacePriceRangeLower 0.3
+ * @property {number} marketplacePriceRangeUpper 1
+ * @property {number} marketplaceTaxNormalUser 0.1
+ * @property {number} marketplaceTaxAdmiral 0.05
+ * @property {number} marketplaceTaxCancelOffer 0.15
+ * @property {number} marketplaceTaxNotSold 0.15
+ * @property {number} marketplaceOfferTimeout 3
+ * @property {boolean} characterClassesEnabled 1
+ * @property {number} minerBonusResourceProduction 0.25
+ * @property {number} minerBonusFasterTradingShips 1
+ * @property {number} minerBonusIncreasedCargoCapacityForTradingShips 0.25
+ * @property {number} minerBonusAdditionalFleetSlots 0
+ * @property {number} minerBonusAdditionalMarketSlots 2
+ * @property {number} minerBonusAdditionalCrawler 0.5
+ * @property {number} minerBonusMaxCrawler 0.1
+ * @property {number} minerBonusEnergy 0.1
+ * @property {number} minerBonusOverloadCrawler 1
+ * @property {number} resourceBuggyProductionBoost 0.0002
+ * @property {number} resourceBuggyMaxProductionBoost 0.5
+ * @property {number} resourceBuggyEnergyConsumptionPerUnit 50
+ * @property {number} warriorBonusFasterCombatShips 1
+ * @property {number} warriorBonusFasterRecyclers 1
+ * @property {number} warriorBonusFuelConsumption 0.25
+ * @property {number} warriorBonusRecyclerFuelConsumption 0
+ * @property {number} warriorBonusRecyclerCargoCapacity 0.2
+ * @property {number} warriorBonusAdditionalFleetSlots 2
+ * @property {number} warriorBonusAdditionalMoonFields 5
+ * @property {number} warriorBonusFleetHalfSpeed 1
+ * @property {number} warriorBonusAttackerWreckfield 1
+ * @property {number} combatDebrisFieldLimit 0.25
+ * @property {number} explorerBonusIncreasedResearchSpeed 0.25
+ * @property {number} explorerBonusIncreasedExpeditionOutcome 0.5
+ * @property {number} explorerBonusLargerPlanets 0.1
+ * @property {number} explorerUnitItemsPerDay 2
+ * @property {number} explorerBonusPhalanxRange 0.2
+ * @property {number} explorerBonusPlunderInactive 1
+ * @property {number} explorerBonusExpeditionEnemyReduction 0.5
+ * @property {number} explorerBonusAdditionalExpeditionSlots 2
+ * @property {number} resourceProductionIncreaseCrystalDefault 0
+ * @property {number} resourceProductionIncreaseCrystalPos1 0.3
+ * @property {number} resourceProductionIncreaseCrystalPos2 0.225
+ * @property {number} resourceProductionIncreaseCrystalPos3 0.15
+ * @property {number} exodusRatioMetal 2.5
+ * @property {number} exodusRatioCrystal 1.5
+ * @property {number} exodusRatioDeuterium 1
+ */
+
+/**
+ * @typedef LifeformSettings
+ * @property {number} lifeformId
+ * @property {Map<number, LifeformBonus<any>>} buildings
+ * @property {Map<number, LifeformBonus<any>>} researches
+ */
+
+/**
+ * @template F
+ * @typedef {Object} LifeformBonus
+ * @property {number} id
+ * @property {string} type
+ * @property {F} factors
+ */

--- a/src/ctxcontent/services/request.ogameServerData.js
+++ b/src/ctxcontent/services/request.ogameServerData.js
@@ -1,0 +1,10 @@
+import { fetchXml } from "../../util/fetching.js";
+
+/**
+ * @param {string} universe
+ * @return {Promise<FetchResponse<Document>>}
+ */
+export function requestOGameServerData(universe) {
+  const url = new URL(`https://${universe}.ogame.gameforge.com/api/serverData.xml`);
+  return fetchXml(url, { method: "GET" });
+}

--- a/src/ctxcontent/services/universe.expirations.js
+++ b/src/ctxcontent/services/universe.expirations.js
@@ -1,0 +1,85 @@
+import { fromNative, toNative } from "../../util/json.js";
+
+/**
+ * @type {Map<string, Map<string, number>>}
+ * @private
+ */
+const _temp = new Map();
+
+const expiryUniverseKeyBuilder = (universe) => `${universe}-expirations`;
+
+/**
+ * @param {string} universeExpiryKey
+ * @param {string} expiryName
+ * @return {function(Object): undefined|number}
+ * @private
+ */
+const _fetchTimestamp = (universeExpiryKey, expiryName) => {
+  return (result) => {
+    if (!Object.hasOwn(result, universeExpiryKey)) {
+      return undefined;
+    }
+
+    /** @type {Map<string, number>} */
+    const expirations = fromNative(result[universeExpiryKey]);
+    _temp.set(universeExpiryKey, expirations);
+    return expirations.get(expiryName);
+  };
+};
+
+/**
+ * Function to check if a universe has expired key.
+ * @param {string} universe
+ * @param {string} name
+ * @return {Promise<boolean>}
+ */
+export function isUniverseExpired(universe, name) {
+  const universeExpiryName = expiryUniverseKeyBuilder(universe);
+
+  if (_temp.has(universeExpiryName) && _temp.get(universeExpiryName).has(name)) {
+    const now = new Date().getTime();
+    return Promise.resolve(now > _temp.get(universeExpiryName).get(name));
+  }
+
+  return chrome.storage.local
+    .get(uni)
+    .then(_fetchTimestamp(universeExpiryName, name), (_) => undefined)
+    .then((expiryTimestamp) => {
+      if (!expiryTimestamp) {
+        return true;
+      }
+      const now = new Date().getTime();
+      return now > expiryTimestamp;
+    });
+}
+
+/**
+ * Function to set an expiry date for a universe key
+ * @param {string} universe
+ * @param {string} key
+ * @param {number|Date} date
+ * @return {Promise<void>}
+ */
+export async function setUniverseExpiration(universe, key, date) {
+  const universeExpiryName = expiryUniverseKeyBuilder(universe);
+
+  const timestamp = Number(date);
+  if (!_temp.has(universeExpiryName)) {
+    _temp.set(universeExpiryName, new Map());
+  }
+
+  _temp.get(universeExpiryName).set(key, timestamp);
+  chrome.storage.local.set({ [universe]: toNative(_temp.get(universe)) }).then((_) => void 0);
+}
+
+/**
+ * Function to set the Time to Live (TTL) for a universe's expiration key.
+ * @param {string} universe
+ * @param {string} key
+ * @param {number} ttl
+ * @return {Promise<void>}
+ */
+export function setUniverseExpirationTTL(universe, key, ttl) {
+  const date = new Date().getTime() + ttl;
+  return setUniverseExpiration(universe, key, date);
+}

--- a/src/ctxcontent/services/universe.expirations.js
+++ b/src/ctxcontent/services/universe.expirations.js
@@ -42,7 +42,7 @@ export function isUniverseExpired(universe, name) {
   }
 
   return chrome.storage.local
-    .get(uni)
+    .get(universeExpiryName)
     .then(_fetchTimestamp(universeExpiryName, name), (_) => undefined)
     .then((expiryTimestamp) => {
       if (!expiryTimestamp) {
@@ -69,7 +69,7 @@ export async function setUniverseExpiration(universe, key, date) {
   }
 
   _temp.get(universeExpiryName).set(key, timestamp);
-  chrome.storage.local.set({ [universe]: toNative(_temp.get(universe)) }).then((_) => void 0);
+  chrome.storage.local.set({ [universeExpiryName]: toNative(_temp.get(universeExpiryName)) }).then((_) => void 0);
 }
 
 /**

--- a/src/ctxcontent/services/universe.storage.js
+++ b/src/ctxcontent/services/universe.storage.js
@@ -1,0 +1,42 @@
+import { fromJSON, toJSON } from "../../util/json.js";
+
+const storageUniverseKeyBuilder = (universe, key) => `${universe}-${key}-information`;
+
+/**
+ * Saves the provided data to Chrome's local storage.
+ * @template V
+ * @param {string} universe - The universe associated with the data.
+ * @param {string} key - The key associated with the data.
+ * @return {(function(V): Promise<V>)|V} - Returns a promise that will be resolved with the provided data after
+ * saving it in storage.
+ */
+export function universeStorageOperator(universe, key) {
+  const universeStorageKey = storageUniverseKeyBuilder(universe, key);
+  return async (data) => {
+    const json = toJSON(data);
+    const plainObject = JSON.parse(json);
+    chrome.storage.local.set({ [universeStorageKey]: plainObject }).then((_) => void 0);
+    return data;
+  };
+}
+
+/**
+ * Retrieves data from Chrome's local storage.
+ * @template V
+ * @param {string} universe - The universe whose data is to be retrieved.
+ * @param {string} key - The key whose data is to be retrieved.
+ * @return {(function(): Promise<V|undefined>)|V} - Returns a promise that will be resolved with the retrieved data
+ * or "undefined" if no data was found.
+ */
+export function universeStorageSupplier(universe, key) {
+  const universeStorageKey = storageUniverseKeyBuilder(universe, key);
+  return async () => {
+    const result = await chrome.storage.local.get(universeStorageKey);
+    if (Object.hasOwn(result, universeStorageKey)) {
+      const plainObjet = result[universeStorageKey];
+      return fromJSON(JSON.stringify(plainObjet));
+    }
+
+    return undefined;
+  };
+}

--- a/src/ctxcontent/services/universe.storage.js
+++ b/src/ctxcontent/services/universe.storage.js
@@ -1,4 +1,4 @@
-import { fromJSON, toJSON } from "../../util/json.js";
+import { fromNative, toNative } from "../../util/json.js";
 
 const storageUniverseKeyBuilder = (universe, key) => `${universe}-${key}-information`;
 
@@ -13,9 +13,7 @@ const storageUniverseKeyBuilder = (universe, key) => `${universe}-${key}-informa
 export function universeStorageOperator(universe, key) {
   const universeStorageKey = storageUniverseKeyBuilder(universe, key);
   return async (data) => {
-    const json = toJSON(data);
-    const plainObject = JSON.parse(json);
-    chrome.storage.local.set({ [universeStorageKey]: plainObject }).then((_) => void 0);
+    chrome.storage.local.set({ [universeStorageKey]: toNative(data) }).then((_) => void 0);
     return data;
   };
 }
@@ -33,8 +31,7 @@ export function universeStorageSupplier(universe, key) {
   return async () => {
     const result = await chrome.storage.local.get(universeStorageKey);
     if (Object.hasOwn(result, universeStorageKey)) {
-      const plainObjet = result[universeStorageKey];
-      return fromJSON(JSON.stringify(plainObjet));
+      return fromNative(result[universeStorageKey]);
     }
 
     return undefined;

--- a/src/util/fetching.js
+++ b/src/util/fetching.js
@@ -9,6 +9,8 @@ export class FetchResponse {
   document;
   /** @type {Headers}  */
   headers;
+  /** @type {number} */
+  #expirationTimestamp = -1;
 
   /**
    * @param {T} document
@@ -17,11 +19,15 @@ export class FetchResponse {
   constructor(document, headers) {
     this.document = document;
     this.headers = headers;
+
+    if (headers.has("Expires")) {
+      this.#expirationTimestamp = new Date(headers.get("Expires")).getTime();
+    }
   }
 
-  /** @return {string|number} */
+  /** @return {number} */
   get expires() {
-    return this.headers.get("Expires") ?? -1;
+    return this.#expirationTimestamp;
   }
 }
 

--- a/src/util/json.js
+++ b/src/util/json.js
@@ -1,0 +1,63 @@
+const DATA_TYPE_KEY = "@DT";
+const DATA_VALUE_KEY = "@v";
+
+const _dtv = (k, v) => ({ [DATA_TYPE_KEY]: k, [DATA_VALUE_KEY]: v });
+
+function _json_replacer(key, value) {
+  if (value instanceof Map) {
+    return _dtv("map", Array.from(value.entries()));
+  } else if (value instanceof Set) {
+    return _dtv("set", Array.from(value.values()));
+  }
+
+  return value;
+}
+
+function _json_reviver(key, value) {
+  if (typeof value === "object" && value !== null && Object.hasOwn(value, DATA_TYPE_KEY)) {
+    if (value[DATA_TYPE_KEY] === "map") {
+      return new Map(value[DATA_VALUE_KEY]);
+    } else if (value[DATA_TYPE_KEY] === "set") {
+      return new Set(value[DATA_VALUE_KEY]);
+    }
+  }
+
+  return value;
+}
+
+/**
+ * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
+ * @param {any} value A JavaScript value, usually an object or array, to be converted.
+ * @param {string|number?} space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
+ * @return {string}
+ */
+export function toJSON(value, space) {
+  return JSON.stringify(value, _json_replacer, space);
+}
+
+/**
+ * Converts a JavaScript Object Notation (JSON) string into an object.
+ * @param text A valid JSON string.
+ * @return {any}
+ */
+export function fromJSON(text) {
+  return JSON.parse(text, _json_reviver);
+}
+
+/**
+ * @param {any} value A JavaScript value, usually an object or array, to be converted.
+ * @return {any}
+ */
+export function toNative(value) {
+  const plain = toJSON(value);
+  return JSON.parse(plain);
+}
+
+/**
+ * @param native A valid native object to convert.
+ * @return {*}
+ */
+export function fromNative(native) {
+  const text = JSON.stringify(native);
+  return fromJSON(text);
+}


### PR DESCRIPTION

1. A new service was added to request data from the OGame server, which contains information about the game universe.

2. *Add expiry utility for fetch requests*: A private field is introduced for the fetch utility to store the expiry timestamp, initially set to -1. This private field is populated based on the 'Expires' header if available.

3. *Adds functionality to handle JSON with advanced types: Introduces a new file containing functionality to transform advanced data types to JSON and vice versa.

4. *Adds functionality to manage universe storage: Introduces new functionality to save and retrieve data associated with a universe and a key in Chrome storage.

5. *Adds functionality to manage universe expirations*: Introduces new functions to set an expiry date for a universe key, to check if a universe has expired its key and to set the Time To Live (TTL) for a universe's expiry key.