### PR TITLE
use previous planetName width size in galaxy

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -3604,7 +3604,7 @@ button.build-it_premium:hover {
 }
 
 #galaxyContent .cellPlanetName {
-  max-width: 162px;
+  max-width: 145px;
 }
 
 #galaxyContent .ctContentRow .cellMoon .moon,
@@ -7251,7 +7251,7 @@ table.fleetinfo tr:nth-last-child(1),
 }
 
 .expeditionDebrisSlotBox div:first-of-type {
-  max-width: 221px;
+  max-width: 204px;
 }
 
 .expeditionDebrisSlotBox li {


### PR DESCRIPTION
Revert planetName max-width size to the previous one to avoid really long player names to split in two lines.

before:

![imagen](https://github.com/ogame-infinity/web-extension/assets/13818551/f969952e-1d8e-4ae4-ae40-83e8f4ffcea4)


after:

![imagen](https://github.com/ogame-infinity/web-extension/assets/13818551/a9d420c6-83b7-4f3a-84c7-9dbcd89fb2d7)
