### PR TITLE
fix: send message when Deactivate chat bar enable

### DIFF
--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -4252,9 +4252,8 @@ class OGInfinity {
   }
 
   chat() {
-    this.tchat = true;
-    if (!document.querySelector("#chatBar")) {
-      this.tchat = false;
+    this.json.tchat = !!document.querySelector("#chatBar");
+    if (!this.json.tchat) {
       return;
     }
     let toggleChat = () => {
@@ -12488,7 +12487,7 @@ class OGInfinity {
   }
 
   sendMessage(id) {
-    if (this.tchat) {
+    if (this.json.tchat) {
       ogame.chat.loadChatLogWithPlayer(Number(id));
     } else {
       document.location = `https://s${this.universe}-${OgamePageData.gameLang}.ogame.gameforge.com/game/index.php?page=chat&playerId=${id}`;


### PR DESCRIPTION
When 
![image](https://github.com/user-attachments/assets/2493974d-760a-4fc0-94e2-9c9504862df1)
is enable
If you already have a chat with someone, 
![image](https://github.com/user-attachments/assets/1c61911e-e618-4a4d-ae92-45b53f43a0d7)
This button don't work

=> patched 