### PR TITLE
Add player marker functionality

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -2831,6 +2831,121 @@ div[data-raw-depletion="4"] + .msgHead a.txt_link{
   color: rgb(208, 129, 62) !important;
 }
 
+#highscoreContent .ogi-highscore-flag {
+  float: left;
+}
+
+#highscoreContent .ogi-ready[data-marked] td[class*="movement"], 
+#highscoreContent .ogi-ready[data-marked] td[class*="sendmsg"], 
+#highscoreContent .ogi-ready[data-marked] td[class*="name"],
+#highscoreContent .ogi-ready[data-marked] td[class*="score"] {
+  box-shadow: rgba(0, 0, 0, 0.5) 0px 63.8px 0px inset;
+}
+
+#highscoreContent .ogi-ready[data-marked="red"] td[class*="movement"] {
+  background: linear-gradient(to left, #b13434, transparent) !important;
+}
+
+#highscoreContent .ogi-ready[data-marked="yellow"] td[class*="movement"] {
+  background: linear-gradient(to left, #907923, #1a202b) !important;
+}
+
+#highscoreContent .ogi-ready[data-marked="green"] td[class*="movement"] {
+  background: linear-gradient(to left, #24777b, #1a202b) !important;
+}
+
+#highscoreContent .ogi-ready[data-marked="blue"] td[class*="movement"] {
+  background: linear-gradient(to left, #355084, #1a202b) !important;
+}
+
+#highscoreContent .ogi-ready[data-marked="violet"] td[class*="movement"] {
+  background: linear-gradient(to left, #a833da, #1a202b) !important;
+}
+
+#highscoreContent .ogi-ready[data-marked="gray"] td[class*="movement"] {
+  background: linear-gradient(to left, #8a8a8a, #1a202b) !important;
+}
+
+#highscoreContent .ogi-ready[data-marked="orange"] td[class*="movement"] {
+  background: linear-gradient(to left, #ff956b, #1a202b) !important;
+}
+
+#highscoreContent .ogi-ready[data-marked="brown"] td[class*="movement"] {
+  background: linear-gradient(to left, #c6622d, #1a202b) !important;
+}
+
+#highscoreContent .ogi-ready[data-marked="red"] td[class*="sendmsg"],
+#highscoreContent .ogi-ready[data-marked="red"] td[class*="name"] {
+  background-color: #b13434 !important;
+}
+
+#highscoreContent .ogi-ready[data-marked="yellow"] td[class*="sendmsg"],
+#highscoreContent .ogi-ready[data-marked="yellow"] td[class*="name"] {
+  background-color:#907923 !important;
+}
+
+#highscoreContent .ogi-ready[data-marked="green"] td[class*="sendmsg"],
+#highscoreContent .ogi-ready[data-marked="green"] td[class*="name"] {
+  background-color:#24777b !important;
+}
+
+#highscoreContent .ogi-ready[data-marked="blue"] td[class*="sendmsg"],
+#highscoreContent .ogi-ready[data-marked="blue"] td[class*="name"] {
+  background-color:#355084 !important;
+}
+
+#highscoreContent .ogi-ready[data-marked="violet"] td[class*="sendmsg"],
+#highscoreContent .ogi-ready[data-marked="violet"] td[class*="name"] {
+  background-color:#a833da !important;
+}
+
+#highscoreContent .ogi-ready[data-marked="gray"] td[class*="sendmsg"],
+#highscoreContent .ogi-ready[data-marked="gray"] td[class*="name"] {
+  background-color:#8a8a8a !important;
+}
+
+#highscoreContent .ogi-ready[data-marked="orange"] td[class*="sendmsg"],
+#highscoreContent .ogi-ready[data-marked="orange"] td[class*="name"] {
+  background-color:#ff956b !important;
+}
+
+#highscoreContent .ogi-ready[data-marked="brown"] td[class*="sendmsg"],
+#highscoreContent .ogi-ready[data-marked="brown"] td[class*="name"] {
+  background-color:#c6622d !important;
+}
+
+#highscoreContent .ogi-ready[data-marked="red"] td[class*="score"] {
+  background: linear-gradient(to right, #b13434, transparent) !important;
+}
+
+#highscoreContent .ogi-ready[data-marked="yellow"] td[class*="score"] {
+  background: linear-gradient(to right, #907923, #1a202b) !important;
+}
+
+#highscoreContent .ogi-ready[data-marked="green"] td[class*="score"] {
+  background: linear-gradient(to right, #24777b, #1a202b) !important;
+}
+
+#highscoreContent .ogi-ready[data-marked="blue"] td[class*="score"] {
+  background: linear-gradient(to right, #355084, #1a202b) !important;
+}
+
+#highscoreContent .ogi-ready[data-marked="violet"] td[class*="score"] {
+  background: linear-gradient(to right, #a833da, #1a202b) !important;
+}
+
+#highscoreContent .ogi-ready[data-marked="gray"] td[class*="score"] {
+  background: linear-gradient(to right, #8a8a8a, #1a202b) !important;
+}
+
+#highscoreContent .ogi-ready[data-marked="orange"] td[class*="score"] {
+  background: linear-gradient(to right, #ff956b, #1a202b) !important;
+}
+
+#highscoreContent .ogi-ready[data-marked="brown"] td[class*="score"] {
+  background: linear-gradient(to right, #c6622d, #1a202b) !important;
+}
+
 .ogk-stats h1 {
   display: flex;
   font-size: 18px;

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -13657,7 +13657,7 @@ class OGInfinity {
                 class: "ogi-highscore-flag ogl-colors",
                 "data-context": "players-highscore",
               });
-              const spanScore = createDOM("span", { class: "ogi-highscore-score" }, tdScore.innerText);
+              const spanScore = createDOM("span", { class: "ogi-highscore-score" }, tdScore.textContent);
               tdScore.replaceChildren(colors, spanScore);
               this.addPlayerMarkerUI(colors, playerId);
 

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -3770,7 +3770,7 @@ class OGInfinity {
         }
         this.saveData();
       }
-      else if(this.json.playerMarkers  && this.json.playerMarkers[playerId]){
+      else if(this.json.playerMarkers && this.json.playerMarkers[playerId]){
         //there is no marker fore these coord but there is a marker for this player
 
         //Auto add marker

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -13670,17 +13670,14 @@ class OGInfinity {
                 position.setAttribute("data-marked", this.json.playerMarkers[highscorePlayerId].color);
               }
 
-              const mail = position.querySelector(".sendmsg_content > a");
-              if (mail) {
-                dataHelper.getPlayer(highscorePlayerId).then((p) => {
-                  let statusClass = this.getPlayerStatus(p.status);
-                  if (playerDiv.getAttribute("class").includes("status_abbr_honorableTarget")) {
-                    statusClass = "status_abbr_honorableTarget";
-                  }
-                  playerDiv.replaceChildren(createDOM("span", { class: `${statusClass}` }, `${p.name}`));
-                  this.stalk(playerDiv, p);
-                });
-              }
+              dataHelper.getPlayer(highscorePlayerId).then((p) => {
+                let statusClass = this.getPlayerStatus(p.status);
+                if (playerDiv.getAttribute("class").includes("status_abbr_honorableTarget")) {
+                  statusClass = "status_abbr_honorableTarget";
+                }
+                playerDiv.replaceChildren(createDOM("span", { class: `${statusClass}` }, `${p.name}`));
+                this.stalk(playerDiv, p);
+              });
             }
           }
         });

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -3750,10 +3750,10 @@ class OGInfinity {
 
       let coords = galaxy + ":" + system + ":" + Number(index + 1);
       let playerDiv = element.querySelector(".cellPlayerName > span.tooltipRel");
-      let id = playerDiv && playerDiv.getAttribute("rel") ? playerDiv.getAttribute("rel").replace("player", "") : null;
+      let playerId = playerDiv && playerDiv.getAttribute("rel") ? playerDiv.getAttribute("rel").replace("player", "") : null;
       if (this.json.markers[coords]) {
-        //console.log('JSONID:' + this.json.markers[coords].id + ' Id:' + id);
-        if (!id || this.json.markers[coords].id != id) {
+        //console.log('JSONID:' + this.json.markers[coords].id + ' Id:' + playerId);
+        if (!playerId || this.json.markers[coords].id != playerId) {
           delete this.json.markers[coords];
           this.markedPlayers = this.getMarkedPlayers(this.json.markers);
           if (this.json.options.targetList) {
@@ -3768,6 +3768,22 @@ class OGInfinity {
           this.json.markers[coords].moon = element.querySelector(".cellMoon .tooltipRel") ? true : false;
         }
         this.saveData();
+      }
+      else if(this.json.playerMarkers  && this.json.playerMarkers[playerId]){
+        //there is no marker fore these coord but there is a marker for this player
+
+        //Auto add marker
+        this.json.markers[coords] = {
+          color: this.json.playerMarkers[playerId].color,
+          id: playerId
+        };
+        
+        //Save data
+        this.saveData();
+
+        //Update UI
+        element.classList.add("ogl-marked");
+        element.setAttribute("data-marked", this.json.playerMarkers[playerId].color);
       }
     });
   }
@@ -12524,6 +12540,10 @@ class OGInfinity {
     }
   }
 
+  addPlayerMarkerUI(parent, id) {
+    markerui.addPlayer(parent, id);
+  }
+
   addMarkerUI(coords, parent, id) {
     markerui.add(coords, parent, id);
   }
@@ -13622,17 +13642,38 @@ class OGInfinity {
                 document.createTextNode(` ${countDiv.textContent.trim()}`)
               );
             }
-            const mail = position.querySelector(".sendmsg_content > a");
-            if (mail) {
-              const id = mail.getAttribute("rel").match(/[0-9]+$/)[0];
-              dataHelper.getPlayer(id).then((p) => {
-                let statusClass = this.getPlayerStatus(p.status);
-                if (playerDiv.getAttribute("class").includes("status_abbr_honorableTarget")) {
-                  statusClass = "status_abbr_honorableTarget";
-                }
-                playerDiv.replaceChildren(createDOM("span", { class: `${statusClass}` }, `${p.name}`));
-                this.stalk(playerDiv, p);
-              });
+
+            if(playerDiv) {
+              //Reset player marker
+              position.classList.remove("ogl-marked");
+              position.removeAttribute("data-marked");
+            
+              const playerId = position.getAttribute("id").match(/[0-9]+$/)[0];
+
+              /*get score cell and add marker ui*/
+              const tdScore = position.querySelector(".score");
+              let colors = createDOM("div", { class: "ogi-highscore-flag ogl-colors", "data-context": "players-highscore" });
+              const spanScore = createDOM("span", { class:"ogi-highscore-score" }, tdScore.innerText);
+              tdScore.replaceChildren(colors, spanScore);
+              this.addPlayerMarkerUI(colors, playerId);
+
+              // Update UI with player marker
+              if (this.json.playerMarkers[playerId]) {
+                  position.classList.add("ogl-marked");
+                  position.setAttribute("data-marked", this.json.playerMarkers[playerId].color);
+              }            
+
+              const mail = position.querySelector(".sendmsg_content > a");
+              if (mail) {
+                dataHelper.getPlayer(playerId).then((p) => {
+                  let statusClass = this.getPlayerStatus(p.status);
+                  if (playerDiv.getAttribute("class").includes("status_abbr_honorableTarget")) {
+                    statusClass = "status_abbr_honorableTarget";
+                  }
+                  playerDiv.replaceChildren(createDOM("span", { class: `${statusClass}` }, `${p.name}`));
+                  this.stalk(playerDiv, p);
+                });
+              }
             }
           }
         });

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -3739,7 +3739,7 @@ class OGInfinity {
         let id =
           (playerDiv && playerDiv.getAttribute("rel") && playerDiv.getAttribute("rel").replace("player", "")) || 99999;
         let coords = galaxy + ":" + system + ":" + Number(index + 1);
-        let colors = createDOM("div", { class: "ogl-colors", "data-coords": coords, "data-context": "galaxy" });
+        const colors = DOM.createDOM("div", { class: "ogl-colors", "data-coords": coords, "data-context": "galaxy" });
         //console.log('Coord: ' + coords + ' parent:' + colors + ' Id:' + id + ' Moon:' + moon);
         element.insertBefore(colors, element.firstChild);
         this.addMarkerUI(coords, colors, id, moon);
@@ -3751,7 +3751,7 @@ class OGInfinity {
 
       let coords = galaxy + ":" + system + ":" + Number(index + 1);
       let playerDiv = element.querySelector(".cellPlayerName > span.tooltipRel");
-      let playerId = playerDiv && playerDiv.getAttribute("rel") ? playerDiv.getAttribute("rel").replace("player", "") : null;
+      const playerId = playerDiv?.getAttribute("rel")?.replace("player", "");
       if (this.json.markers[coords]) {
         //console.log('JSONID:' + this.json.markers[coords].id + ' Id:' + playerId);
         if (!playerId || this.json.markers[coords].id != playerId) {
@@ -3769,16 +3769,15 @@ class OGInfinity {
           this.json.markers[coords].moon = element.querySelector(".cellMoon .tooltipRel") ? true : false;
         }
         this.saveData();
-      }
-      else if(this.json.playerMarkers && this.json.playerMarkers[playerId]){
-        //there is no marker fore these coord but there is a marker for this player
+      } else if (this.json.playerMarkers && this.json.playerMarkers[playerId]) {
+        //there is no marker for these coord but there is a marker for this player
 
         //Auto add marker
         this.json.markers[coords] = {
           color: this.json.playerMarkers[playerId].color,
-          id: playerId
+          id: playerId,
         };
-        
+
         //Save data
         this.saveData();
 
@@ -13645,25 +13644,28 @@ class OGInfinity {
               );
             }
 
-            if(playerDiv) {
+            if (playerDiv) {
               //Reset player marker
               position.classList.remove("ogl-marked");
               position.removeAttribute("data-marked");
-            
+
               const playerId = position.getAttribute("id").match(/[0-9]+$/)[0];
 
               /*get score cell and add marker ui*/
               const tdScore = position.querySelector(".score");
-              let colors = createDOM("div", { class: "ogi-highscore-flag ogl-colors", "data-context": "players-highscore" });
-              const spanScore = createDOM("span", { class:"ogi-highscore-score" }, tdScore.innerText);
+              const colors = createDOM("div", {
+                class: "ogi-highscore-flag ogl-colors",
+                "data-context": "players-highscore",
+              });
+              const spanScore = createDOM("span", { class: "ogi-highscore-score" }, tdScore.innerText);
               tdScore.replaceChildren(colors, spanScore);
               this.addPlayerMarkerUI(colors, playerId);
 
               // Update UI with player marker
               if (this.json.playerMarkers[playerId]) {
-                  position.classList.add("ogl-marked");
-                  position.setAttribute("data-marked", this.json.playerMarkers[playerId].color);
-              }            
+                position.classList.add("ogl-marked");
+                position.setAttribute("data-marked", this.json.playerMarkers[playerId].color);
+              }
 
               const mail = position.querySelector(".sendmsg_content > a");
               if (mail) {

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -1475,6 +1475,7 @@ class OGInfinity {
     this.json.autoHarvest = this.json.autoHarvest || ["0:0:0", 3];
     this.json.myActivities = this.json.myActivities || {};
     this.json.sideStalk = this.json.sideStalk || [];
+    this.json.playerMarkers = this.json.playerMarkers || {};
     this.json.markers = this.json.markers || {};
     this.json.locked = this.json.locked || {};
     this.json.missing = this.json.missing || {};
@@ -12872,6 +12873,7 @@ class OGInfinity {
       mainSyncJsonObj.search = this?.json?.search;
       mainSyncJsonObj.sideStalk = this?.json?.sideStalk;
       mainSyncJsonObj.locked = this?.json?.locked;
+      mainSyncJsonObj.playerMarkers = this?.json?.playerMarkers;
       mainSyncJsonObj.markers = this?.json?.markers;
       mainSyncJsonObj.sideStargetTabstalk = this?.json?.targetTabs;
       mainSyncJsonObj.missing = this?.json?.missing;

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -3753,7 +3753,6 @@ class OGInfinity {
       let playerDiv = element.querySelector(".cellPlayerName > span.tooltipRel");
       const playerId = playerDiv?.getAttribute("rel")?.replace("player", "");
       if (this.json.markers[coords]) {
-        //console.log('JSONID:' + this.json.markers[coords].id + ' Id:' + playerId);
         if (!playerId || this.json.markers[coords].id != playerId) {
           delete this.json.markers[coords];
           this.markedPlayers = this.getMarkedPlayers(this.json.markers);
@@ -13639,7 +13638,7 @@ class OGInfinity {
               let count = countDiv.getAttribute("title") || countDiv.getAttribute("data-tooltip-title");
               count = count.split(":")[1].trim();
               countDiv.replaceChildren(
-                createDOM("span", { class: "ogi-highscore-ships" }, `(${count})`),
+                DOM.createDOM("span", { class: "ogi-highscore-ships" }, `(${count})`),
                 document.createTextNode(` ${countDiv.textContent.trim()}`)
               );
             }
@@ -13656,11 +13655,11 @@ class OGInfinity {
 
               /*get score cell and add marker ui*/
               const tdScore = position.querySelector(".score");
-              const colors = createDOM("div", {
+              const colors = DOM.createDOM("div", {
                 class: "ogi-highscore-flag ogl-colors",
                 "data-context": "players-highscore",
               });
-              const spanScore = createDOM("span", { class: "ogi-highscore-score" }, tdScore.textContent);
+              const spanScore = DOM.createDOM("span", { class: "ogi-highscore-score" }, tdScore.textContent);
               tdScore.replaceChildren(colors, spanScore);
               this.addPlayerMarkerUI(colors, highscorePlayerId);
 
@@ -13675,7 +13674,7 @@ class OGInfinity {
                 if (playerDiv.getAttribute("class").includes("status_abbr_honorableTarget")) {
                   statusClass = "status_abbr_honorableTarget";
                 }
-                playerDiv.replaceChildren(createDOM("span", { class: `${statusClass}` }, `${p.name}`));
+                playerDiv.replaceChildren(DOM.createDOM("span", { class: `${statusClass}` }, `${p.name}`));
                 this.stalk(playerDiv, p);
               });
             }

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -13649,7 +13649,10 @@ class OGInfinity {
               position.classList.remove("ogl-marked");
               position.removeAttribute("data-marked");
 
-              const playerId = position.getAttribute("id").match(/[0-9]+$/)[0];
+              const highscorePlayerId = position.getAttribute("id").match(/[0-9]+$/)[0];
+
+              // exclude own player
+              if (highscorePlayerId == playerId) return;
 
               /*get score cell and add marker ui*/
               const tdScore = position.querySelector(".score");
@@ -13659,17 +13662,17 @@ class OGInfinity {
               });
               const spanScore = createDOM("span", { class: "ogi-highscore-score" }, tdScore.textContent);
               tdScore.replaceChildren(colors, spanScore);
-              this.addPlayerMarkerUI(colors, playerId);
+              this.addPlayerMarkerUI(colors, highscorePlayerId);
 
               // Update UI with player marker
-              if (this.json.playerMarkers[playerId]) {
+              if (this.json.playerMarkers[highscorePlayerId]) {
                 position.classList.add("ogl-marked");
-                position.setAttribute("data-marked", this.json.playerMarkers[playerId].color);
+                position.setAttribute("data-marked", this.json.playerMarkers[highscorePlayerId].color);
               }
 
               const mail = position.querySelector(".sendmsg_content > a");
               if (mail) {
-                dataHelper.getPlayer(playerId).then((p) => {
+                dataHelper.getPlayer(highscorePlayerId).then((p) => {
                   let statusClass = this.getPlayerStatus(p.status);
                   if (playerDiv.getAttribute("class").includes("status_abbr_honorableTarget")) {
                     statusClass = "status_abbr_honorableTarget";

--- a/src/util/OGIData.js
+++ b/src/util/OGIData.js
@@ -30,6 +30,7 @@ class OGIData {
   get playerMarkers() {
     return this._json.playerMarkers;
   }
+  
   set playerMarkers(playerMarkers) {
     this._json.playerMarkers = playerMarkers;
 

--- a/src/util/OGIData.js
+++ b/src/util/OGIData.js
@@ -26,6 +26,16 @@ class OGIData {
 
     this.#save();
   }
+
+  get playerMarkers() {
+    return this._json.playerMarkers;
+  }
+  set playerMarkers(playerMarkers) {
+    this._json.playerMarkers = playerMarkers;
+
+    this.#save();
+  }
+  
   get markers() {
     return this._json.markers;
   }

--- a/src/util/markerui.js
+++ b/src/util/markerui.js
@@ -8,7 +8,7 @@ const colors = ["red", "orange", "yellow", "green", "blue", "violet", "gray", "b
 
 function addPlayer(parent, playerId) {
   const div = createDOM("div", { class: "ogl-colorChoice" });
-  let playerMarkers = OGIData.playerMarkers;
+  const playerMarkers = OGIData.playerMarkers;
 
   colors.forEach((color) => {
     const circle = div.appendChild(createDOM("div", { "data-marker": color }));
@@ -86,7 +86,7 @@ function addPlayer(parent, playerId) {
 function displayPlayer(parent, id) {
   const element = parent.closest("tr");
 
-  let playerMarkers = OGIData.playerMarkers;
+  const playerMarkers = OGIData.playerMarkers;
   if (playerMarkers[id]) {
     element.classList.add("ogl-marked");
     element.setAttribute("data-marked", playerMarkers[id].color);
@@ -162,6 +162,7 @@ function display(parent, coords) {
 }
 
 export default {
-  add, addPlayer,
+  add, 
+  addPlayer,
   display,
 };

--- a/src/util/markerui.js
+++ b/src/util/markerui.js
@@ -9,9 +9,6 @@ const colors = ["red", "orange", "yellow", "green", "blue", "violet", "gray", "b
 function addPlayer(parent, playerId) {
   const div = createDOM("div", { class: "ogl-colorChoice" });
   let playerMarkers = OGIData.playerMarkers;
-  if(playerMarkers === null || playerMarkers === undefined) {
-    playerMarkers = {};
-  }
 
   colors.forEach((color) => {
     const circle = div.appendChild(createDOM("div", { "data-marker": color }));
@@ -89,10 +86,6 @@ function displayPlayer(parent, id) {
   const element = parent.closest("tr");
 
   let playerMarkers = OGIData.playerMarkers;
-  if(playerMarkers === null || playerMarkers === undefined) {
-    playerMarkers = {};
-  }
-
   if (playerMarkers[id]) {
     element.classList.add("ogl-marked");
     element.setAttribute("data-marked", playerMarkers[id].color);

--- a/src/util/markerui.js
+++ b/src/util/markerui.js
@@ -21,9 +21,7 @@ function addPlayer(parent, playerId) {
     circle.addEventListener("click", () => {
       div.querySelectorAll("div[data-marker]").forEach((e) => e.classList.remove("ogl-active"));
       Player.get(playerId).then((player) => {
-        
         if (playerMarkers[playerId] && playerMarkers[playerId].color === color) {
-
           // Remove marker for player
           delete playerMarkers[playerId];
 
@@ -33,7 +31,7 @@ function addPlayer(parent, playerId) {
             coordsMarkers[planet.coords] = coordsMarkers[planet.coords] || {};
 
             // if marker is set at these coords and is the same color and player
-            if(coordsMarkers[planet.coords].color === color && coordsMarkers[planet.coords].id === playerId) {
+            if (coordsMarkers[planet.coords].color === color && coordsMarkers[planet.coords].id === playerId) {
               delete coordsMarkers[planet.coords];
             }
           });
@@ -47,7 +45,7 @@ function addPlayer(parent, playerId) {
           // Add marker for player
           playerMarkers[playerId] = playerMarkers[playerId] || {};
           playerMarkers[playerId].color = color;
-                  
+
           /// Set markers for each planet
           const coordsMarkers = OGIData.markers;
           player.planets.forEach((planet) => {
@@ -95,7 +93,6 @@ function displayPlayer(parent, id) {
     element.removeAttribute("data-marked");
   }
 }
-
 
 function add(coords, parent, id) {
   const div = createDOM("div", { class: "ogl-colorChoice" });
@@ -162,7 +159,7 @@ function display(parent, coords) {
 }
 
 export default {
-  add, 
+  add,
   addPlayer,
   display,
 };

--- a/src/util/markerui.js
+++ b/src/util/markerui.js
@@ -13,6 +13,7 @@ function addPlayer(parent, playerId) {
   colors.forEach((color) => {
     const circle = div.appendChild(createDOM("div", { "data-marker": color }));
     div.appendChild(circle);
+
     if (playerMarkers[playerId] && playerMarkers[playerId].color === color) {
       circle.classList.add("ogl-active");
     }

--- a/src/util/markerui.js
+++ b/src/util/markerui.js
@@ -6,6 +6,103 @@ import * as stalk from "./stalk.js";
 
 const colors = ["red", "orange", "yellow", "green", "blue", "violet", "gray", "brown"];
 
+function addPlayer(parent, playerId) {
+  const div = createDOM("div", { class: "ogl-colorChoice" });
+  let playerMarkers = OGIData.playerMarkers;
+  if(playerMarkers === null || playerMarkers === undefined) {
+    playerMarkers = {};
+  }
+
+  colors.forEach((color) => {
+    const circle = div.appendChild(createDOM("div", { "data-marker": color }));
+    div.appendChild(circle);
+    if (playerMarkers[playerId] && playerMarkers[playerId].color === color) {
+      circle.classList.add("ogl-active");
+    }
+
+    circle.addEventListener("click", () => {
+      div.querySelectorAll("div[data-marker]").forEach((e) => e.classList.remove("ogl-active"));
+      Player.get(playerId).then((player) => {
+        
+        if (playerMarkers[playerId] && playerMarkers[playerId].color === color) {
+
+          // Remove marker for player
+          delete playerMarkers[playerId];
+
+          //remove markers for each planet is marked with the same color (colors can be overridden)
+          const coordsMarkers = OGIData.markers;
+          player.planets.forEach((planet) => {
+            coordsMarkers[planet.coords] = coordsMarkers[planet.coords] || {};
+
+            // if marker is set at these coords and is the same color and player
+            if(coordsMarkers[planet.coords].color === color && coordsMarkers[planet.coords].id === playerId) {
+              delete coordsMarkers[planet.coords];
+            }
+          });
+          OGIData.markers = coordsMarkers;
+
+          // Update UI
+          if (parent.getAttribute("data-context") === "players-highscore") {
+            parent.closest(".ogi-ready").removeAttribute("data-marked");
+          }
+        } else {
+          // Add marker for player
+          playerMarkers[playerId] = playerMarkers[playerId] || {};
+          playerMarkers[playerId].color = color;
+                  
+          /// Set markers for each planet
+          const coordsMarkers = OGIData.markers;
+          player.planets.forEach((planet) => {
+            coordsMarkers[planet.coords] = coordsMarkers[planet.coords] || {};
+            coordsMarkers[planet.coords].id = playerId;
+            coordsMarkers[planet.coords].color = color;
+            coordsMarkers[planet.coords].moon = planet.moon !== null && planet.moon !== undefined;
+          });
+          OGIData.markers = coordsMarkers;
+
+          // Update UI
+          circle.classList.add("ogl-active");
+          if (parent.getAttribute("data-context") === "galaxy") {
+            parent.closest(".galaxyRow").setAttribute("data-marked", color);
+          }
+        }
+        document.querySelector(".ogl-tooltip").classList.remove("ogl-active");
+        document.querySelector(".ogl-targetIcon").classList.remove("ogl-targetsReady");
+
+        if (parent.getAttribute("data-context") !== "galaxy") {
+          displayPlayer(parent, playerId);
+        }
+
+        OGIData.playerMarkers = playerMarkers;
+
+        stalk.side();
+      });
+    });
+  });
+
+  parent.addEventListener("ontouchstart" in document.documentElement ? "touchstart" : "mouseenter", () => {
+    tooltip(parent, div);
+  });
+}
+
+function displayPlayer(parent, id) {
+  const element = parent.closest("tr");
+
+  let playerMarkers = OGIData.playerMarkers;
+  if(playerMarkers === null || playerMarkers === undefined) {
+    playerMarkers = {};
+  }
+
+  if (playerMarkers[id]) {
+    element.classList.add("ogl-marked");
+    element.setAttribute("data-marked", playerMarkers[id].color);
+  } else {
+    element.classList.remove("ogl-marked");
+    element.removeAttribute("data-marked");
+  }
+}
+
+
 function add(coords, parent, id) {
   const div = createDOM("div", { class: "ogl-colorChoice" });
   const markers = OGIData.markers;
@@ -71,6 +168,6 @@ function display(parent, coords) {
 }
 
 export default {
-  add,
+  add, addPlayer,
   display,
 };


### PR DESCRIPTION
Allow to mark a player with a color:
 - All coords are marked with the chosen color
 - It's possible to mark a coords as usual with another color

When the player marke is removed:
 - all coords of the player color are removed
 - other coords remain untouched

When navigating in the galaxy view:
 - if an unmarked coord is encoutered for a marker player, this coord is automatically marked withe the player color
 
Need advice for cleaning data when a player id is remove (banned user, removed account, etc.)

![image](https://github.com/user-attachments/assets/6c70645d-5365-412c-a0f9-dc57b6e104fd)
