### PR TITLE
Add prettier overview functionality with toggle buttons for details and buff bar

### DIFF
--- a/src/ctxpage/conf-options.js
+++ b/src/ctxpage/conf-options.js
@@ -87,6 +87,8 @@ const _options = {
     standardFleet: false,
     standardFleetId: 0,
   },
+  overview_display_planet_details: true,
+  overview_display_planet_buffBar: true,
 };
 
 export function initConfOptions(options) {

--- a/src/ctxpage/overview/OverviewPage.js
+++ b/src/ctxpage/overview/OverviewPage.js
@@ -1,77 +1,71 @@
-
 import { getOption, setOption } from "../conf-options.js";
 import { createDOM } from "../../util/dom.js";
 import { getLogger } from "../../util/logger.js";
 import OGIData from "../../util/OGIData.js";
 
 class OverviewPage {
+  logger;
 
-    logger;
+  constructor() {
+    this.logger = getLogger("OverviewPage");
+  }
 
-    constructor() {
-        this.logger = getLogger("OverviewPage");
+  UpdatePlanetOverviewDisplay(toggle, partName) {
+    const optionName = `overview_display_planet_${partName}`;
+    const attributeName = `${partName}-active`;
+
+    // get the current display status
+    const display = getOption(optionName);
+
+    if (toggle) {
+      const options = OGIData.options;
+
+      //toggle the display
+      planet.setAttribute(attributeName, !display);
+
+      //save the display preference
+      setOption(optionName, !display);
+      options[optionName] = !display;
+      OGIData.options = options;
+    } else {
+      planet.setAttribute(attributeName, display);
     }
+  }
 
-    UpdatePlanetOverviewDisplay(toggle, partName) {
-        const optionName = `overview_display_planet_${partName}`;
-        const attributeName = `${partName}-active`;
+  MakePrettierOverview(currentPage) {
+    if (currentPage !== "overview") return;
 
-        // get the current display status
-        const display = getOption(optionName);
+    try {
+      const planet = document.querySelector("#overviewcomponent #planet");
+      const detailWrapper = planet.querySelector("#detailWrapper");
 
-        if (toggle) {
-            const options = OGIData.options;
+      // create the toggle planet details button
+      const togglePlanetDataButton = createDOM("div", { class: "togglePlanetDetails" });
+      togglePlanetDataButton.addEventListener("click", () => {
+        this.UpdatePlanetOverviewDisplay(true, "details");
+      });
 
-            //toggle the display
-            planet.setAttribute(attributeName, !display);
+      // add the toggle planet details button to the header
+      detailWrapper.querySelector("#header_text").appendChild(togglePlanetDataButton);
 
-            //save the display preference
-            setOption(optionName, !display);
-            options[optionName] = !display;
-            OGIData.options = options;
-        }
-        else {
-            planet.setAttribute(attributeName, display);
-        }
+      // create the toggle buff bar button, and add it instead of the spaceObjectHeaderActionIcons
+      const toggleBuffBarButton = createDOM("div", { id: "toggleBuffBar" });
+      toggleBuffBarButton.addEventListener("click", () => {
+        this.UpdatePlanetOverviewDisplay(true, "buffBar");
+      });
+      planet.insertBefore(toggleBuffBarButton, detailWrapper);
+
+      const spaceObjectHeaderActionIcons = planet.querySelector("#spaceObjectHeaderActionIcon");
+      planet.removeChild(spaceObjectHeaderActionIcons);
+
+      // init the display of the planet details and buff bar
+      this.UpdatePlanetOverviewDisplay(false, "details");
+      this.UpdatePlanetOverviewDisplay(false, "buffBar");
+    } catch (e) {
+      // it would be a shame if a UI error break the game...
+      this.logger.error(e);
     }
-
-    MakePrettierOverview(currentPage) {
-        if (currentPage !== "overview") return;
-
-        try {
-
-            const planet = document.querySelector('#overviewcomponent #planet');
-            const detailWrapper = planet.querySelector('#detailWrapper');
-
-            // create the toggle planet details button
-            const togglePlanetDataButton = createDOM('div', { class: 'togglePlanetDetails' });
-            togglePlanetDataButton.addEventListener("click", () => {
-                this.UpdatePlanetOverviewDisplay(true, "details");
-            });
-
-            // add the toggle planet details button to the header
-            detailWrapper.querySelector('#header_text').appendChild(togglePlanetDataButton);
-
-            // create the toggle buff bar button, and add it instead of the spaceObjectHeaderActionIcons
-            const toggleBuffBarButton = createDOM('div', { id: "toggleBuffBar" });
-            toggleBuffBarButton.addEventListener("click", () => {
-                this.UpdatePlanetOverviewDisplay(true, "buffBar");
-            });
-            planet.insertBefore(toggleBuffBarButton, detailWrapper);
-
-            const spaceObjectHeaderActionIcons = planet.querySelector('#spaceObjectHeaderActionIcon');
-            planet.removeChild(spaceObjectHeaderActionIcons);
-
-            // init the display of the planet details and buff bar
-            this.UpdatePlanetOverviewDisplay(false, "details");
-            this.UpdatePlanetOverviewDisplay(false, "buffBar");
-
-        }
-        catch (e) {
-            // it would be a shame if a UI error break the game...
-            this.logger.error(e);
-        }
-    }
+  }
 }
 
 export default OverviewPage;

--- a/src/ctxpage/overview/OverviewPage.js
+++ b/src/ctxpage/overview/OverviewPage.js
@@ -1,0 +1,83 @@
+
+import { getOption, setOption } from "../conf-options.js";
+import { createDOM } from "../../util/dom.js";
+import { getLogger } from "../../util/logger.js";
+import OGIData from "../../util/OGIData.js";
+
+class OverviewPage {
+
+    logger;
+
+    constructor() {
+        this.logger = getLogger("OverviewPage");
+    }
+
+    UpdatePlanetOverviewDisplay(toggle, partName) {
+        const optionName = `overview_display_planet_${partName}`;
+        const attributeName = `${partName}-active`;
+
+        // get the current display status
+        let display = getOption(optionName);
+
+        // if the display is not set, set it to true
+        display = display === undefined || display === null || display === true;
+
+        if (toggle) {
+            const options = OGIData.options;
+
+            //toggle the display
+            planet.setAttribute(attributeName, !display);
+
+            //in this context, 'this' is a dom element, so we need to use self instead
+            //save the display preference
+            setOption(optionName, !display);
+            options[optionName] = !display;
+            OGIData.options = options;
+        }
+        else {
+            planet.setAttribute(attributeName, display);
+        }
+    }
+
+    MakePrettierOverview(currentPage) {
+        if (currentPage !== "overview") {
+            return;
+        }
+
+        try {
+
+            const planet = document.querySelector('#overviewcomponent #planet');
+            const detailWrapper = planet.querySelector('#detailWrapper');
+
+            // create the toggle planet details button
+            const togglePlanetDataButton = createDOM('div', { class: 'togglePlanetDetails' });
+            togglePlanetDataButton.addEventListener("click", () => {
+                this.UpdatePlanetOverviewDisplay(true, "details");
+            });
+
+            // add the toggle planet details button to the header
+            detailWrapper.querySelector('#header_text').appendChild(togglePlanetDataButton);
+
+            // create the toggle buff bar button, and add it instead of the spaceObjectHeaderActionIcons
+            const toggleBuffBarButton = createDOM('div', { id: "toggleBuffBar" });
+            toggleBuffBarButton.addEventListener("click", () => {
+                this.UpdatePlanetOverviewDisplay(true, "buffBar");
+            });
+            planet.insertBefore(toggleBuffBarButton, detailWrapper);
+
+            const spaceObjectHeaderActionIcons = planet.querySelector('#spaceObjectHeaderActionIcon');
+            planet.removeChild(spaceObjectHeaderActionIcons);
+
+            // init the display of the planet details and buff bar
+            this.UpdatePlanetOverviewDisplay(false, "details");
+            this.UpdatePlanetOverviewDisplay(false, "buffBar");
+
+        }
+        catch (e) {
+            // it would be a shame if a UI error break the game...
+            this.logger.error(e);
+        }
+    }
+}
+
+export default OverviewPage;

--- a/src/ctxpage/overview/OverviewPage.js
+++ b/src/ctxpage/overview/OverviewPage.js
@@ -19,16 +19,12 @@ class OverviewPage {
         // get the current display status
         let display = getOption(optionName);
 
-        // if the display is not set, set it to true
-        display = display === undefined || display === null || display === true;
-
         if (toggle) {
             const options = OGIData.options;
 
             //toggle the display
             planet.setAttribute(attributeName, !display);
 
-            //in this context, 'this' is a dom element, so we need to use self instead
             //save the display preference
             setOption(optionName, !display);
             options[optionName] = !display;
@@ -40,9 +36,7 @@ class OverviewPage {
     }
 
     MakePrettierOverview(currentPage) {
-        if (currentPage !== "overview") {
-            return;
-        }
+        if (currentPage !== "overview") return;
 
         try {
 

--- a/src/ctxpage/overview/OverviewPage.js
+++ b/src/ctxpage/overview/OverviewPage.js
@@ -17,7 +17,7 @@ class OverviewPage {
         const attributeName = `${partName}-active`;
 
         // get the current display status
-        let display = getOption(optionName);
+        const display = getOption(optionName);
 
         if (toggle) {
             const options = OGIData.options;

--- a/src/global.css
+++ b/src/global.css
@@ -3724,12 +3724,9 @@ div[data-raw-depletion="4"] + .msgHead a.txt_link{
 }
 #overviewcomponent #planet #toggleBuffBar {
   cursor: pointer;
-  background-image: none;
   position: absolute;
   left: 4px;
   bottom: 4px;
-}
-#overviewcomponent #planet #toggleBuffBar {
   width: 36px;
   height: 28px;
   background-image: url("https://gf1.geo.gfsrv.net/cdnce/54d37c899703757907c1160db0b1b9.png");
@@ -3741,12 +3738,12 @@ div[data-raw-depletion="4"] + .msgHead a.txt_link{
 }
 
 #overviewcomponent #planet[buffBar-active="true"] #toggleBuffBar {
-  filter: brightness(0.7);
+  filter: brightness(0.5);
 }
 
 #overviewcomponent #planet[buffBar-active="true"] #toggleBuffBar:hover,
 #overviewcomponent #planet[buffBar-active="false"] #toggleBuffBar:hover {
-  filter: brightness(1) !important;
+  filter: brightness(0) saturate(100%) invert(77%) sepia(23%) saturate(1188%) hue-rotate(338deg) brightness(86%) contrast(92%);
 }
 
 

--- a/src/global.css
+++ b/src/global.css
@@ -3715,7 +3715,7 @@ div[data-raw-depletion="4"] + .msgHead a.txt_link{
 #overviewcomponent #planet #spaceObjectHeaderActionIcon {
   width: 36px;
   height: 28px;
-  background-image: url(//gf1.geo.gfsrv.net/cdnce/54d37c899703757907c1160db0b1b9.png);
+  background-image: url("https://gf1.geo.gfsrv.net/cdnce/54d37c899703757907c1160db0b1b9.png");
   background-position: center;
   background-repeat: no-repeat;
   background-size: 25px 25px;
@@ -3732,7 +3732,7 @@ div[data-raw-depletion="4"] + .msgHead a.txt_link{
 #overviewcomponent #planet #toggleBuffBar {
   width: 36px;
   height: 28px;
-  background-image: url(//gf1.geo.gfsrv.net/cdnce/54d37c899703757907c1160db0b1b9.png);
+  background-image: url("https://gf1.geo.gfsrv.net/cdnce/54d37c899703757907c1160db0b1b9.png");
   background-position: center;
   background-repeat: no-repeat;
   background-size: 25px 25px;

--- a/src/global.css
+++ b/src/global.css
@@ -3719,7 +3719,7 @@ div[data-raw-depletion="4"] + .msgHead a.txt_link{
   background-position: center;
   background-repeat: no-repeat;
   background-size: 25px 25px;
-  filter: brightness(0.3);
+  filter: brightness(0) saturate(100%) invert(17%) sepia(7%) saturate(497%) hue-rotate(161deg) brightness(94%) contrast(84%);
   display: block;
 }
 #overviewcomponent #planet #toggleBuffBar {
@@ -3733,12 +3733,12 @@ div[data-raw-depletion="4"] + .msgHead a.txt_link{
   background-position: center;
   background-repeat: no-repeat;
   background-size: 25px 25px;
-  filter: brightness(0.3);
+  filter: brightness(0) saturate(100%) invert(17%) sepia(7%) saturate(497%) hue-rotate(161deg) brightness(94%) contrast(84%);
   display: block;
 }
 
 #overviewcomponent #planet[buffBar-active="true"] #toggleBuffBar {
-  filter: brightness(0.5);
+  filter: brightness(0) saturate(100%) invert(63%) sepia(11%) saturate(483%) hue-rotate(160deg) brightness(91%) contrast(91%);
 }
 
 #overviewcomponent #planet[buffBar-active="true"] #toggleBuffBar:hover,

--- a/src/global.css
+++ b/src/global.css
@@ -3633,6 +3633,123 @@ div[data-raw-depletion="4"] + .msgHead a.txt_link{
   background-position-y: 0px;
 }
 
+#overviewcomponent #planet #detailWrapper #header_text h2 {
+  width: auto !important;
+  float: left;
+}
+
+#overviewcomponent #planet #detailWrapper #header_text h2 a {
+  float: unset !important;
+}
+
+#overviewcomponent #planet #detailWrapper .togglePlanetDetails {
+  cursor: pointer;
+  float: right;
+  width: 23px;
+  height: 23px;
+  margin-right: 15px;
+  margin-top: 6.5px;
+}
+
+#overviewcomponent #planet[details-active="true"] #detailWrapper #planetdata {
+  position: relative;
+  visibility: hidden;
+  animation: appearing-planetdata 0.8s forwards;
+}
+@keyframes appearing-planetdata {
+  from {
+    visibility: visible;
+    right: -407px;
+    opacity: 0;
+    }
+  to {  
+    visibility: visible;
+    right: 0px;
+    opacity: 1;     
+  }
+}
+
+#overviewcomponent #planet #detailWrapper #planetdata {
+  visibility: hidden;
+}
+#overviewcomponent #planet[details-active="true"] #detailWrapper .togglePlanetDetails:hover,
+#overviewcomponent #planet[details-active="false"] #detailWrapper .togglePlanetDetails:hover {
+  background: url("chrome-extension://__MSG_@@extension_id__/assets/images/menuicons.png") calc(-23px * 9) -46px;
+  background-size: calc(23px * 14) !important;
+}
+#overviewcomponent #planet[details-active="true"] #detailWrapper .togglePlanetDetails {
+  background: url("chrome-extension://__MSG_@@extension_id__/assets/images/menuicons.png") calc(-23px * 9) -23px;
+  background-size: calc(23px * 14) !important;
+}
+#overviewcomponent #planet[details-active="false"] #detailWrapper .togglePlanetDetails {
+  background: url("chrome-extension://__MSG_@@extension_id__/assets/images/menuicons.png") calc(-23px * 9) 0;
+  background-size: calc(23px * 14) !important;
+}
+
+#overviewcomponent #planet #detailWrapper #planetdata {
+  clear: right;
+}
+
+#overviewcomponent #planet[buffBar-active="true"] #buffBar {
+  position: absolute;
+  visibility: hidden;
+  animation: appearing-buffBar 0.8s forwards;
+}
+@keyframes appearing-buffBar {
+  from {
+    visibility: visible;
+    bottom: -36px;
+    opacity: 0;
+    }
+  to {  
+    visibility: visible;
+    bottom: 4px;
+    opacity: 1;     
+  }
+}
+
+#overviewcomponent #planet #buffBar {
+  visibility: hidden;
+}
+
+#overviewcomponent #planet #spaceObjectHeaderActionIcon {
+  width: 36px;
+  height: 28px;
+  background-image: url(//gf1.geo.gfsrv.net/cdnce/54d37c899703757907c1160db0b1b9.png);
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 25px 25px;
+  filter: brightness(0.3);
+  display: block;
+}
+#overviewcomponent #planet #toggleBuffBar {
+  cursor: pointer;
+  background-image: none;
+  position: absolute;
+  left: 4px;
+  bottom: 4px;
+}
+#overviewcomponent #planet #toggleBuffBar {
+  width: 36px;
+  height: 28px;
+  background-image: url(//gf1.geo.gfsrv.net/cdnce/54d37c899703757907c1160db0b1b9.png);
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: 25px 25px;
+  filter: brightness(0.3);
+  display: block;
+}
+
+#overviewcomponent #planet[buffBar-active="true"] #toggleBuffBar {
+  filter: brightness(0.7);
+}
+
+#overviewcomponent #planet[buffBar-active="true"] #toggleBuffBar:hover,
+#overviewcomponent #planet[buffBar-active="false"] #toggleBuffBar:hover {
+  filter: brightness(1) !important;
+}
+
+
 .ogl-option {
   background-color: #1b1b1b !important;
   border: 1px solid #000;

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -1578,7 +1578,7 @@ class OGInfinity {
     this.listenKeyboard();
     this.sideOptions();
     this.minesLevel();
-    this.resourceDetail();
+    this.resourceDetail();    
 
     // refresh right planet list, after ogame resets it when something ends and there is no page reload
     const rightObserver = new OGIObserver();
@@ -1644,7 +1644,8 @@ class OGInfinity {
     this.utilities();
     this.chat();
     this.uvlinks();
-    this.betterHighscore();
+    this.prettierOverview();
+    this.betterHighscore();    
     this.overviewDates();
     needsUtil.display();
     this.jumpGate();
@@ -13603,6 +13604,73 @@ class OGInfinity {
         window.open(`${this.json.options.simulator}${this.univerviewLang}?#prefill=${base64}`, "_blank");
       }
     });
+  }
+
+  prettierOverview() {
+    if (this.page == "overview") {
+      try {
+        // we will need the current oject in the UpdatePlanetOverviewDisplay function
+        const self = this;
+
+        function UpdatePlanetOverviewDisplay(toggle, partName) {
+          const optionName = `overview_display_planet_${partName}`;
+          const attributeName = `${partName}-active`;
+
+          // get the current display status
+          let display = getOption(optionName);
+
+          // if the display is not set, set it to true
+          display = display === undefined || display === null || display === true;
+
+          if(toggle)
+          {
+            //toggle the display
+            planet.setAttribute(attributeName, !display);
+
+            //in this context, 'this' is a dom element, so we need to use self instead
+            //save the display preference
+            setOption(optionName, !display);
+            self.saveData();
+          }
+          else
+          {          
+            planet.setAttribute(attributeName, display);
+          }
+        }
+
+        const planet = document.querySelector('#overviewcomponent #planet');
+        const detailWrapper = planet.querySelector('#detailWrapper');
+
+        // create the toggle planet details button
+        const togglePlanetDataButton = createDOM('div', { class: 'togglePlanetDetails' });
+        togglePlanetDataButton.addEventListener("click", () => {
+          UpdatePlanetOverviewDisplay(true, "details");        
+        });
+
+        // add the toggle planet details button to the header
+        detailWrapper.querySelector('#header_text').appendChild(togglePlanetDataButton);
+
+
+        // create the toggle buff bar button, and add it instead of the spaceObjectHeaderActionIcons
+        const toggleBuffBarButton = createDOM('div', { id: "toggleBuffBar" });
+        toggleBuffBarButton.addEventListener("click", () => {
+          UpdatePlanetOverviewDisplay(true, "buffBar");   
+        });
+        planet.insertBefore(toggleBuffBarButton, detailWrapper);
+
+        const spaceObjectHeaderActionIcons = planet.querySelector('#spaceObjectHeaderActionIcon');
+        planet.removeChild(spaceObjectHeaderActionIcons);
+        
+
+        // init the display of the planet details and buff bar
+        UpdatePlanetOverviewDisplay(false, "details");
+        UpdatePlanetOverviewDisplay(false, "buffBar");
+
+      } catch (error) {
+        // it would be a shame if a UI error would break the game...        
+        console.error("Error in prettierOverview", error);
+      }
+    }
   }
 
   betterHighscore() {

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -30,6 +30,7 @@ import * as loadingUtil from "./util/loading.js";
 import * as standardUnit from "./util/standardUnit.js";
 import planetType from "./util/enum/planetType.js";
 import shipEnum from "./util/enum/ship.js";
+import OverviewPage from "./ctxpage/overview/OverviewPage.js";
 
 const DISCORD_INVITATION_URL = "https://discord.gg/8Y4SWup";
 //const VERSION = "__VERSION__";
@@ -1360,6 +1361,8 @@ const isOwnPlanet = (coords) => {
 };
 
 class OGInfinity {
+  OverviewPage = new OverviewPage();
+
   constructor() {
     this.commander = document.querySelector("#officers > a.commander.on") !== null;
     this.rawURL = new URL(window.location.href);
@@ -1578,7 +1581,7 @@ class OGInfinity {
     this.listenKeyboard();
     this.sideOptions();
     this.minesLevel();
-    this.resourceDetail();    
+    this.resourceDetail();
 
     // refresh right planet list, after ogame resets it when something ends and there is no page reload
     const rightObserver = new OGIObserver();
@@ -1644,7 +1647,7 @@ class OGInfinity {
     this.utilities();
     this.chat();
     this.uvlinks();
-    this.prettierOverview();
+    this.OverviewPage.MakePrettierOverview(this.page);
     this.betterHighscore();    
     this.overviewDates();
     needsUtil.display();
@@ -13604,73 +13607,6 @@ class OGInfinity {
         window.open(`${this.json.options.simulator}${this.univerviewLang}?#prefill=${base64}`, "_blank");
       }
     });
-  }
-
-  prettierOverview() {
-    if (this.page == "overview") {
-      try {
-        // we will need the current oject in the UpdatePlanetOverviewDisplay function
-        const self = this;
-
-        function UpdatePlanetOverviewDisplay(toggle, partName) {
-          const optionName = `overview_display_planet_${partName}`;
-          const attributeName = `${partName}-active`;
-
-          // get the current display status
-          let display = getOption(optionName);
-
-          // if the display is not set, set it to true
-          display = display === undefined || display === null || display === true;
-
-          if(toggle)
-          {
-            //toggle the display
-            planet.setAttribute(attributeName, !display);
-
-            //in this context, 'this' is a dom element, so we need to use self instead
-            //save the display preference
-            setOption(optionName, !display);
-            self.saveData();
-          }
-          else
-          {          
-            planet.setAttribute(attributeName, display);
-          }
-        }
-
-        const planet = document.querySelector('#overviewcomponent #planet');
-        const detailWrapper = planet.querySelector('#detailWrapper');
-
-        // create the toggle planet details button
-        const togglePlanetDataButton = createDOM('div', { class: 'togglePlanetDetails' });
-        togglePlanetDataButton.addEventListener("click", () => {
-          UpdatePlanetOverviewDisplay(true, "details");        
-        });
-
-        // add the toggle planet details button to the header
-        detailWrapper.querySelector('#header_text').appendChild(togglePlanetDataButton);
-
-
-        // create the toggle buff bar button, and add it instead of the spaceObjectHeaderActionIcons
-        const toggleBuffBarButton = createDOM('div', { id: "toggleBuffBar" });
-        toggleBuffBarButton.addEventListener("click", () => {
-          UpdatePlanetOverviewDisplay(true, "buffBar");   
-        });
-        planet.insertBefore(toggleBuffBarButton, detailWrapper);
-
-        const spaceObjectHeaderActionIcons = planet.querySelector('#spaceObjectHeaderActionIcon');
-        planet.removeChild(spaceObjectHeaderActionIcons);
-        
-
-        // init the display of the planet details and buff bar
-        UpdatePlanetOverviewDisplay(false, "details");
-        UpdatePlanetOverviewDisplay(false, "buffBar");
-
-      } catch (error) {
-        // it would be a shame if a UI error would break the game...        
-        console.error("Error in prettierOverview", error);
-      }
-    }
   }
 
   betterHighscore() {


### PR DESCRIPTION
A special demand from my child: to see the planet skins without anything blocking the view.

So i added a button to hide the planet data div, and another to hide the buff bar.

It work for planets and moons.

![Animation](https://github.com/user-attachments/assets/b4598a61-52d2-4028-9106-fa6f36eb63c7)
