### PR TITLE
updateEmpireData checks ogi mode

### DIFF
--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -1746,8 +1746,9 @@ class OGInfinity {
     if (
       force ||
       isNaN(new Date(this.json.lastEmpireUpdate)) ||
-      (timeSinceLastUpdate > 5 * 60 * 1e3 && this.json.needsUpdate) ||
-      (timeSinceLastUpdate > 1 * 60 * 1e3 && !this.json.options.lessAggressiveEmpireAutomaticUpdate)
+      (this.mode == 0 &&
+        ((timeSinceLastUpdate > 5 * 60 * 1e3 && this.json.needsUpdate) ||
+          (timeSinceLastUpdate > 1 * 60 * 1e3 && !this.json.options.lessAggressiveEmpireAutomaticUpdate)))
     ) {
       await this.updateInfo();
     }


### PR DESCRIPTION
Aborts periodical update when mode is not 0 (0: default mode, >0: chain modes or other features that requires a page load)