### PR TITLE
Implement work in progress tech tracking for planets and moons directly from empire data

### DIFF
--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -11496,7 +11496,6 @@ class OGInfinity {
           JSON.parse(
             string.substring(string.indexOf("createImperiumHtml") + 47, string.indexOf("initEmpire") - 16),
             (key, value) => {
-              if (key.includes("html") && key !== "equipment_html") return;
               if (value === "0") return 0;
               return value;
             }
@@ -11508,11 +11507,94 @@ class OGInfinity {
       new URLSearchParams({ page: "standalone", component: "empire", planetType: "1" })
     );
 
+    const getWorkinProgressGroupsAndPatterns = (groups) => {
+      //create a list of patterns to match the groups ('?' is a wildcard for lifeform groups)
+      //there is also "ships" and "defence" groups for any future evolution
+      const toParseGroups = ["supply", "station", "research", "lifeform?buildings", "lifeform?research"];
+
+      const patterns = toParseGroups.map((pattern) => ({
+        pattern,
+        name: pattern.replace("?", ""),
+        regex: new RegExp("^" + pattern.replace("?", ".*") + "$"),
+      }));
+
+      const result = [];
+      for (const key of Object.keys(groups)) {
+        const match = patterns.find(({ regex }) => regex.test(key));
+        if (match) {
+          result.push({ property: key, name: match.name, techIds: groups[key] });
+        }
+      }
+      return result;
+    };
+    const getWorkInProgressTechs = (planetOrMoon, groups) => {
+      const workInProgressTechs = new Array();
+
+      groups.forEach((group) => {
+        group.techIds.forEach((techId) => {
+          const htmlKey = `${techId}_html`;
+
+          if (planetOrMoon[htmlKey]) {
+            const htmlString = planetOrMoon[htmlKey];
+            if (htmlString) {
+              // Create a temporary element to parse the HTML string
+              const temp = document.createElement("div");
+              temp.innerHTML = htmlString.trim();
+
+              /*
+               * if there is only one child, we can ignore it, because it is just a text node.
+               * but if there is more than one child, there is a downgrade or an upgrade
+               */
+              if (temp.children.length > 1) {
+                const activeElement = temp.querySelector(".active");
+                const activeValue = activeElement ? parseInt(activeElement.textContent.trim(), 10) : null;
+
+                if (!isNaN(activeValue)) {
+                  workInProgressTechs.push({
+                    group: group.name,
+                    id: techId,
+                    from: planetOrMoon[techId],
+                    to:
+                      group.name === "defence" || group.name === "ships"
+                        ? planetOrMoon[techId] + activeValue
+                        : activeValue, // for defence and ships, the value is the current level + the upgrade level
+                  });
+                }
+              }
+            }
+          }
+        });
+      });
+
+      return workInProgressTechs;
+    };
+
+    const setWorkInProgressTechs = (planetsOrMoons, groups) => {
+      planetsOrMoons.forEach((planetOrMoon) => {
+        planetOrMoon.workInProgressTechs = getWorkInProgressTechs(
+          planetOrMoon,
+          getWorkinProgressGroupsAndPatterns(groups)
+        );
+
+        // Remove HTML keys that was only used for the work in progress techs
+        // We don't need the HTML keys anymore, so we can delete them
+        for (const key in planetOrMoon) {
+          if (key.includes("html") && key !== "equipment_html") {
+            delete planetOrMoon[key];
+          }
+        }
+      });
+    };
+
     return Promise.all([empireRequestPlanets, empireRequestMoons]).then((values) => {
       const empireObjectPlanets = values[0];
       const empireObjectMoons = values[1];
 
       Translator.UpdateAllTechNamesFromEmpire(empireObjectPlanets, empireObjectMoons);
+      setWorkInProgressTechs(empireObjectPlanets.planets, empireObjectPlanets.groups);
+      if (empireObjectMoons.planets) {
+        setWorkInProgressTechs(empireObjectMoons.planets, empireObjectMoons.groups);
+      }
 
       empireObjectPlanets.planets.forEach((planet) => {
         planet.invalidate = false;
@@ -15385,9 +15467,13 @@ class OGInfinity {
     let needLifeformUpdateForResearch = false;
 
     const updateProgressIndicators = () => {
+      const regularBuildingsGroups = ["supply", "station"];
+      const lifeformBuildingsGroup = "lifeformbuildings";
+      const lifeformResearchGroup = "lifeformresearch";
       document.querySelectorAll(".planet-koords").forEach((planet) => {
         const smallplanet = planet.parentElement.parentElement;
         const planetId = planet.parentElement.href.match(/=(\d+)/)[1];
+        const planetFromEmpire = OGIData.empire.find((p) => p.id === parseInt(planetId));
         const planetCoords = planet.textContent.trim();
         // remove old constructions icons
         const constructionIconLink = smallplanet.querySelector(".constructionIcon:not(.moon)");
@@ -15451,6 +15537,36 @@ class OGInfinity {
               }
             }
           }
+        } else {
+          //if elem is not found, check if there is a work in progress tech from empire data
+          const moonFromEmpire = planetFromEmpire.moon;
+          if (moonFromEmpire?.workInProgressTechs) {
+            const elemFromEmpire = moonFromEmpire.workInProgressTechs.find((x) =>
+              regularBuildingsGroups.includes(x.group)
+            );
+            if (elemFromEmpire) {
+              const moonConstructionIconsDiv = DOM.createDOM("div", {
+                class: "constructionIcons moonConstructionIcons",
+              });
+              moonConstructionIconsDiv.appendChild(
+                createConstructionIcon(
+                  {
+                    technoId: elemFromEmpire.id,
+                    tolvl: elemFromEmpire.to,
+                  },
+                  moonFromEmpire.id,
+                  Translator.translate(elemFromEmpire.id, "tech"),
+                  "icon_wrench",
+                  SUPPLIES_TECHID.includes(Number(elemFromEmpire.id))
+                    ? "supplies"
+                    : FACILITIES_TECHID.includes(Number(elemFromEmpire.id))
+                    ? "facilities"
+                    : "overview"
+                )
+              );
+              smallplanet.appendChild(moonConstructionIconsDiv);
+            }
+          }
         }
 
         // check if the planet is in lifeform research
@@ -15465,6 +15581,23 @@ class OGInfinity {
             const techName = Translator.translate(elem.technoId, "tech");
             constructionIconsDiv.appendChild(
               createConstructionIcon(elem, planetId, techName, "icon_research_lf", "lfresearch")
+            );
+          }
+        } else {
+          //if elem is not found, check if there is a work in progress tech from empire data
+          const elemFromEmpire = planetFromEmpire.workInProgressTechs.find((x) => x.group == lifeformResearchGroup);
+          if (elemFromEmpire) {
+            constructionIconsDiv.appendChild(
+              createConstructionIcon(
+                {
+                  technoId: elemFromEmpire.id,
+                  tolvl: elemFromEmpire.to,
+                },
+                planetId,
+                Translator.translate(elemFromEmpire.id, "tech"),
+                "icon_research_lf",
+                "lfresearch"
+              )
             );
           }
         }
@@ -15492,6 +15625,23 @@ class OGInfinity {
                 createConstructionIcon(elem, planetId, techName, "icon_wrench_lf", "lfbuildings")
               );
             }
+          }
+        } else {
+          //if elem is not found, check if there is a work in progress tech from empire data
+          const elemFromEmpire = planetFromEmpire.workInProgressTechs.find((x) => x.group == lifeformBuildingsGroup);
+          if (elemFromEmpire) {
+            constructionIconsDiv.appendChild(
+              createConstructionIcon(
+                {
+                  technoId: elemFromEmpire.id,
+                  tolvl: elemFromEmpire.to,
+                },
+                planetId,
+                Translator.translate(elemFromEmpire.id, "tech"),
+                "icon_wrench_lf",
+                "lfbuildings"
+              )
+            );
           }
         }
 
@@ -15523,6 +15673,29 @@ class OGInfinity {
                 )
               );
             }
+          }
+        } else {
+          //if elem is not found, check if there is a work in progress tech from empire data
+          const elemFromEmpire = planetFromEmpire.workInProgressTechs.find((x) =>
+            regularBuildingsGroups.includes(x.group)
+          );
+          if (elemFromEmpire) {
+            constructionIconsDiv.appendChild(
+              createConstructionIcon(
+                {
+                  technoId: elemFromEmpire.id,
+                  tolvl: elemFromEmpire.to,
+                },
+                planetId,
+                Translator.translate(elemFromEmpire.id, "tech"),
+                "icon_wrench",
+                SUPPLIES_TECHID.includes(Number(elemFromEmpire.id))
+                  ? "supplies"
+                  : FACILITIES_TECHID.includes(Number(elemFromEmpire.id))
+                  ? "facilities"
+                  : "overview"
+              )
+            );
           }
         }
 

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -11529,6 +11529,7 @@ class OGInfinity {
     };
     const getWorkInProgressTechs = (planetOrMoon, groups) => {
       const workInProgressTechs = new Array();
+      const parser = new window.DOMParser();
 
       groups.forEach((group) => {
         group.techIds.forEach((techId) => {
@@ -11537,9 +11538,8 @@ class OGInfinity {
           if (planetOrMoon[htmlKey]) {
             const htmlString = planetOrMoon[htmlKey];
             if (htmlString) {
-              // Create a temporary element to parse the HTML string
-              const temp = document.createElement("div");
-              temp.innerHTML = htmlString.trim();
+              // Create a temporary document to parse the HTML string
+              const temp = parser.parseFromString(htmlString, "text/html").querySelector("body");
 
               /*
                * if there is only one child, we can ignore it, because it is just a text node.

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -15503,41 +15503,42 @@ class OGInfinity {
         // check if the moon is in regular construction
         let elem = this.json.moonProductionProgress[planetCoords];
         const moon = smallplanet.querySelector(".moonlink");
+        let checkFromEmpire = false;
         if (elem && moon) {
           const moonId = moon.href.match(/=(\d+)/)[1];
-          if (elem) {
-            const endDate = new Date(elem.endDate);
-            if (endDate < now) {
-              // regular construction work is finished, so show border color
-              if (this.json.options.showProgressIndicators) moon.classList.add("finished");
-            } else {
-              // if some regular construction work is finished, remove the border color
-              if (this.json.options.showProgressIndicators) moon.classList.remove("finished");
-              if (endDate > now) {
-                // regular construction work is still in progress, so show the icon
-                const techName = Translator.translate(elem.technoId, "tech");
-                const moonConstructionIconsDiv = DOM.createDOM("div", {
-                  class: "constructionIcons moonConstructionIcons",
-                });
-                moonConstructionIconsDiv.appendChild(
-                  createConstructionIcon(
-                    elem,
-                    moonId,
-                    techName,
-                    "icon_wrench",
-                    SUPPLIES_TECHID.includes(Number(elem.technoId))
-                      ? "supplies"
-                      : FACILITIES_TECHID.includes(Number(elem.technoId))
-                      ? "facilities"
-                      : "overview"
-                  )
-                );
+          const endDate = new Date(elem.endDate);
+          if (endDate < now) {
+            // regular construction work is finished, so show border color
+            if (this.json.options.showProgressIndicators) moon.classList.add("finished");
+            checkFromEmpire = true;
+          } else {
+            // if some regular construction work is finished, remove the border color
+            if (this.json.options.showProgressIndicators) moon.classList.remove("finished");
+            if (endDate > now) {
+              // regular construction work is still in progress, so show the icon
+              const techName = Translator.translate(elem.technoId, "tech");
+              const moonConstructionIconsDiv = DOM.createDOM("div", {
+                class: "constructionIcons moonConstructionIcons",
+              });
+              moonConstructionIconsDiv.appendChild(
+                createConstructionIcon(
+                  elem,
+                  moonId,
+                  techName,
+                  "icon_wrench",
+                  SUPPLIES_TECHID.includes(Number(elem.technoId))
+                    ? "supplies"
+                    : FACILITIES_TECHID.includes(Number(elem.technoId))
+                    ? "facilities"
+                    : "overview"
+                )
+              );
 
-                smallplanet.appendChild(moonConstructionIconsDiv);
-              }
+              smallplanet.appendChild(moonConstructionIconsDiv);
             }
           }
-        } else {
+        }
+        if (checkFromEmpire) {
           //if elem is not found, check if there is a work in progress tech from empire data
           const moonFromEmpire = planetFromEmpire.moon;
           if (moonFromEmpire?.workInProgressTechs) {
@@ -15571,11 +15572,13 @@ class OGInfinity {
 
         // check if the planet is in lifeform research
         elem = this.json.lfResearchProgress[planetCoords];
+        checkFromEmpire = false;
         if (elem) {
           const endDate = new Date(elem.endDate);
           if (endDate < now) {
             // lifeform research work is finished, so we need to update the lifeform
             needLifeformUpdateForResearch = true;
+            checkFromEmpire = true;
           } else if (endDate > now) {
             // lifeform research work is in progress, so show the icon
             const techName = Translator.translate(elem.technoId, "tech");
@@ -15583,7 +15586,8 @@ class OGInfinity {
               createConstructionIcon(elem, planetId, techName, "icon_research_lf", "lfresearch")
             );
           }
-        } else {
+        }
+        if (checkFromEmpire) {
           //if elem is not found, check if there is a work in progress tech from empire data
           const elemFromEmpire = planetFromEmpire.workInProgressTechs.find((x) => x.group == lifeformResearchGroup);
           if (elemFromEmpire) {
@@ -15604,6 +15608,7 @@ class OGInfinity {
 
         // check if the planet is in lifeform construction
         elem = this.json.lfProductionProgress[planetCoords];
+        checkFromEmpire = false;
         if (elem) {
           const endDate = new Date(elem.endDate);
 
@@ -15614,6 +15619,7 @@ class OGInfinity {
               // regular construction work is finished, so show border color
               planet.parentElement.classList.add("finishedLf");
             }
+            checkFromEmpire = true;
           } else {
             // if some lifeform construction work is finished, remove the border color
             if (this.json.options.showProgressIndicators) planet.parentElement.classList.remove("finishedLf");
@@ -15626,7 +15632,8 @@ class OGInfinity {
               );
             }
           }
-        } else {
+        }
+        if (checkFromEmpire) {
           //if elem is not found, check if there is a work in progress tech from empire data
           const elemFromEmpire = planetFromEmpire.workInProgressTechs.find((x) => x.group == lifeformBuildingsGroup);
           if (elemFromEmpire) {
@@ -15647,12 +15654,14 @@ class OGInfinity {
 
         // check if the planet is in regular construction
         elem = this.json.productionProgress[planetCoords];
+        checkFromEmpire = false;
         if (elem) {
           const endDate = new Date(elem.endDate);
           const techName = Translator.translate(elem.technoId, "tech");
           if (endDate < now) {
             // regular construction work is finished, so show border color
             if (this.json.options.showProgressIndicators) planet.parentElement.classList.add("finished");
+            checkFromEmpire = true;
           } else {
             // if some regular construction work is finished, remove the border color
             if (this.json.options.showProgressIndicators) planet.parentElement.classList.remove("finished");
@@ -15674,7 +15683,8 @@ class OGInfinity {
               );
             }
           }
-        } else {
+        }
+        if (checkFromEmpire) {
           //if elem is not found, check if there is a work in progress tech from empire data
           const elemFromEmpire = planetFromEmpire.workInProgressTechs.find((x) =>
             regularBuildingsGroups.includes(x.group)

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -11549,7 +11549,7 @@ class OGInfinity {
                 const activeElement = temp.querySelector(".active");
                 const activeValue = activeElement ? parseInt(activeElement.textContent.trim(), 10) : null;
 
-                if (!isNaN(activeValue)) {
+                if (activeValue && !isNaN(activeValue)) {
                   workInProgressTechs.push({
                     group: group.name,
                     id: techId,


### PR DESCRIPTION
Regarding the evolution of the construction icons, since it retrieves information from the DOM, there might be some display shortcomings when switching from a PC to a phone, or when using the commander's construction lists.

Actually, it's possible to retrieve construction information directly from the empire page. Of course, it's incomplete (it doesn't have the end date), but at least the data is as "fresh" as possible.