### PR TITLE
fix - disable ENTER shortcut in player search textInput

### DIFF
--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -13416,7 +13416,7 @@ class OGInfinity {
       }
       return false;
     };
-    const avoidIn = ["chat_box_textarea", "markItUpEditor", "textBox"];
+    const avoidIn = ["chat_box_textarea", "markItUpEditor", "textBox", "textInput"];
     document.addEventListener("keydown", (event) => {
       if (avoidIn.some((avoidInClass) => document.activeElement.classList.contains(avoidInClass))) return;
       if (event.key == "Escape") {


### PR DESCRIPTION
<img width="658" height="448" alt="image" src="https://github.com/user-attachments/assets/a0a1e358-d8c4-4e40-8b31-e944005cd3da" />

