### PR TITLE
fix: update fleet and construction icon links to use current page context

### DIFF
--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -15764,7 +15764,7 @@ class OGInfinity {
       const createFleetIcon = (standardUnitSum, planetOrMoonId, iconClass, redirect) => {
         const fleetIcon = DOM.createDOM("a", {
           class: "fleetIcon planet tooltip js_hideTipOnMobile",
-          href: `/game/index.php?page=ingame&component=${redirect ? "fleetdispatch" : "overview"}&cp=${planetOrMoonId}`,
+          href: `/game/index.php?page=ingame&component=${redirect ? "fleetdispatch" : this.page}&cp=${planetOrMoonId}`,
         });
 
         fleetIcon.appendChild(DOM.createDOM("span", { class: `icon12px ${iconClass}` }));
@@ -16050,7 +16050,7 @@ class OGInfinity {
       const createConstructionIcon = (elem, planetOrMoonId, techName, iconClass, component, addToolTip, redirect) => {
         const constructionIcon = DOM.createDOM("a", {
           class: "constructionIcon planet tooltip js_hideTipOnMobile",
-          href: `/game/index.php?page=ingame&component=${redirect ? component : "overview"}&cp=${planetOrMoonId}`,
+          href: `/game/index.php?page=ingame&component=${redirect ? component : this.page}&cp=${planetOrMoonId}`,
         });
 
         if (addToolTip) {


### PR DESCRIPTION
When clicking on a building or ship icon, whose display mode is set to Visible, a redirection to the overview page is performed, instead of keeping the context of the current page