### PR TITLE
add delay to parallel empire planet/moon page retrieval

### DIFF
--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -11788,9 +11788,9 @@ class OGInfinity {
           )
         );
     const empireRequestPlanets = empireRequest(new URLSearchParams({ page: "standalone", component: "empire" }));
-    const empireRequestMoons = hasMoon ? empireRequest(
+    const empireRequestMoons = hasMoon ? wait.delay(10).then(() => empireRequest(
       new URLSearchParams({ page: "standalone", component: "empire", planetType: "1" })
-    ) : null;
+    )) : null;
 
     const getWorkinProgressGroupsAndPatterns = (groups) => {
       //create a list of patterns to match the groups ('?' is a wildcard for lifeform groups)


### PR DESCRIPTION
Add a little delay between the start of the 2 parallel empire data page fetches. V13 seems to have problems in server side with this, resulting sometimes in a 302 fail in one fetch.