### PR TITLE
feat(ptre): rework galaxy live events notifications

### DIFF
--- a/src/ctxcontent/data-helper.js
+++ b/src/ctxcontent/data-helper.js
@@ -1,5 +1,6 @@
 import { getLogger } from "../util/logger.js";
 import { COORDINATE_PLANET, toNumber as toNumberCoordinate } from "../util/ogame.coordinate.js";
+import OGIData from "../util/OGIData.js";
 import { getAlliances } from "./helpers/universe.alliances.js";
 import { getPlayersHighscore, NAN_HIGHSCORE } from "./helpers/universe.highscore.js";
 import { getPlanets } from "./helpers/universe.planets.js";
@@ -15,19 +16,41 @@ export class DataHelper {
 
   init() {
     return new Promise(async (resolve, reject) => {
-      chrome.storage.local.get("ogi-scanned-" + this.universe, (result) => {
-        let json;
-        try {
-          json = JSON.parse(result["ogi-scanned-" + this.universe]);
-        } catch (error) {
-          json = {};
+      chrome.storage.local.get(
+        ["ogi-scanned-" + this.universe, "ogi-galaxy-" + this.universe],
+        (result) => {
+          let scannedJson;
+          try {
+            scannedJson = JSON.parse(result["ogi-scanned-" + this.universe]);
+          } catch (error) {
+            scannedJson = {};
+          }
+          this.scannedPlanets = scannedJson.scannedPlanets || {};
+          this.scannedPlayers = scannedJson.scannedPlayers || {};
+          this.lastPlayersUpdate = this.lastPlayersUpdate || new Date(0);
+          this.lastPlanetsUpdate = this.lastPlayersUpdate || new Date(0);
+
+          // Galaxy storage lives in its own key so hot writes (from scan()) stay small
+          // and never drag the big `[UNIVERSE]` blob along. The dedicated key is the
+          // SOLE source of truth; do not fall back to `this.galaxyStorage` /
+          // `this.lastGalaxyUpdateTS` values inherited from the big blob via
+          // Object.assign in main() - a manual reset would be defeated otherwise.
+          let galaxyJson;
+          try {
+            galaxyJson = JSON.parse(result["ogi-galaxy-" + this.universe]);
+          } catch (error) {
+            galaxyJson = null;
+          }
+          if (galaxyJson && typeof galaxyJson === "object") {
+            this.galaxyStorage = galaxyJson.galaxyStorage || {};
+            this.lastGalaxyUpdateTS = galaxyJson.lastGalaxyUpdateTS ?? -1;
+          } else {
+            this.galaxyStorage = {};
+            this.lastGalaxyUpdateTS = -1;
+          }
+          resolve();
         }
-        this.scannedPlanets = json.scannedPlanets || {};
-        this.scannedPlayers = json.scannedPlayers || {};
-        this.lastPlayersUpdate = this.lastPlayersUpdate || new Date(0);
-        this.lastPlanetsUpdate = this.lastPlayersUpdate || new Date(0);
-        resolve();
-      });
+      );
     });
   }
 
@@ -223,6 +246,31 @@ export class DataHelper {
     });
   }
 
+  // Immediate persistence of galaxyStorage into its dedicated key. Callers that
+  // update this store frequently (e.g. scan() from the PTRE PR) should prefer
+  // scheduleGalaxyStorageFlush() to coalesce writes.
+  flushGalaxyStorage() {
+    if (this._galaxyFlushTimer) {
+      clearTimeout(this._galaxyFlushTimer);
+      this._galaxyFlushTimer = null;
+    }
+    chrome.storage.local.set({
+      [`ogi-galaxy-${this.universe}`]: JSON.stringify({
+        galaxyStorage: this.galaxyStorage,
+        lastGalaxyUpdateTS: this.lastGalaxyUpdateTS,
+      }),
+    });
+  }
+
+  // Debounced flush. Multiple calls within `delayMs` collapse into one write.
+  scheduleGalaxyStorageFlush(delayMs = 2000) {
+    if (this._galaxyFlushTimer) return;
+    this._galaxyFlushTimer = setTimeout(() => {
+      this._galaxyFlushTimer = null;
+      this.flushGalaxyStorage();
+    }, delayMs);
+  }
+
   async update() {
     const logger = getLogger("updateUniverse");
 
@@ -236,12 +284,77 @@ export class DataHelper {
     let players = {};
 
     try {
-      const [playersScore, playersInformation, playerPlanets, allianceInformation] = await Promise.all([
+      const [playersScore, playersInformation, planetsSnapshot, allianceInformation] = await Promise.all([
         getPlayersHighscore(this.universe),
         getPlayers(this.universe),
         getPlanets(this.universe),
         getAlliances(this.universe),
       ]);
+
+      // ----------------------------------------------
+      // Galaxy Storage Update (snapshot of all planets in the universe)
+      // universe.xml is updated ONCE A WEEK (except for migrations, merge, etc)
+      // Only update this structure if the API has been updated
+      // Otherwise, it is purely useless (and we wont keep PTRE tracking data)
+      // The build is also gated on the presence of a PTRE team key in settings (might and should change)
+
+      const galaxyBuildStart = performance.now();
+      const playerPlanets = planetsSnapshot.planets;
+      const planetList = planetsSnapshot.planetList;
+      const newGalaxyTs = planetsSnapshot.timestamp;
+      const previousGalaxyTs = this.lastGalaxyUpdateTS ?? -1;
+      const galaxyUpdateNeeded = Number.isFinite(newGalaxyTs) && newGalaxyTs > previousGalaxyTs;
+      const ptreKeyPresent = !!(OGIData.options && OGIData.options.ptreTK);
+
+      logger.debug(`[galaxyStorage] prevTs=${previousGalaxyTs} newTS=${newGalaxyTs} => ${galaxyUpdateNeeded ? "OPEN" : "SKIP"} | PTRE=${ptreKeyPresent}`);
+
+      if (galaxyUpdateNeeded && ptreKeyPresent) {
+        // Do not use current storage if API was really updated
+        this.galaxyStorage = {};
+        let updatedSystemsCount = 0;
+        let updatedPlanetsCount = 0;
+        let updatedMoonsCount = 0;
+
+        planetList.forEach((planet) => {
+          const parts = (planet.coords || "").split(":");
+          if (parts.length !== 3) return;
+          const g = parts[0];
+          const s = parts[1];
+          const p = parts[2];
+
+          if (!this.galaxyStorage[g]) {
+            this.galaxyStorage[g] = {};
+          }
+          if (!this.galaxyStorage[g][s]) {
+            this.galaxyStorage[g][s] = {};
+            for (let i = 1; i <= 15; i++) {
+              this.galaxyStorage[g][s][String(i)] = {
+                playerId: -1,
+                planetId: -1,
+                moonId: -1,
+                ts: newGalaxyTs,
+              };
+            }
+            updatedSystemsCount++;
+          }
+
+          this.galaxyStorage[g][s][p] = {
+            playerId: planet.player,
+            planetId: planet.id,
+            moonId: planet.moon ? planet.moon : -1,
+            ts: newGalaxyTs,
+          };
+          updatedPlanetsCount++;
+          if (planet.moon) updatedMoonsCount++;
+        });
+
+        this.lastGalaxyUpdateTS = newGalaxyTs;
+        const galaxyBuildDurationMs = Math.round(performance.now() - galaxyBuildStart);
+        logger.debug(`[galaxyStorage] New data: systems=${updatedSystemsCount} planets=${updatedPlanetsCount} moons=${updatedMoonsCount} | TS=${this.lastGalaxyUpdateTS} | Took ${galaxyBuildDurationMs}ms`);
+        this.flushGalaxyStorage();
+      }
+      // End Galaxy Storage Update
+      // --------------------------------------------
 
       // -- TopScore --------------------------------
       /** @type {HighscoreTypes | undefined} */

--- a/src/ctxcontent/data-helper.js
+++ b/src/ctxcontent/data-helper.js
@@ -232,6 +232,10 @@ export class DataHelper {
       const currentSystemSnapshot = {};
       let systemChanged = false;
 
+      if (!previousSystemFound) {
+        ptreLogger.debug("[GALAXY] [" + galaxy + ":" + system + "] Warning: No previous snapshot found!");
+      }
+
       for (let pos = 1; pos <= SCANNED_SYSTEM_POSITION_COUNT; pos++) {
         const cur = positions[pos] || positions[String(pos)] || { playerId: -1, planetId: -1, moonId: -1 };
         const extra = (additionnal && (additionnal[pos] || additionnal[String(pos)])) || {};

--- a/src/ctxcontent/data-helper.js
+++ b/src/ctxcontent/data-helper.js
@@ -1,6 +1,5 @@
 import { getLogger } from "../util/logger.js";
 import { COORDINATE_PLANET, toNumber as toNumberCoordinate } from "../util/ogame.coordinate.js";
-import OGIData from "../util/OGIData.js";
 import { getAlliances } from "./helpers/universe.alliances.js";
 import { getPlayersHighscore, NAN_HIGHSCORE } from "./helpers/universe.highscore.js";
 import { getPlanets } from "./helpers/universe.planets.js";
@@ -12,6 +11,8 @@ export class DataHelper {
     this.names = {};
     this.topScore = 0;
     this.loading = false;
+    // Transient cache of the last successful universe.xml fetch. Stripped from the persisted blob in processData().
+    this._galaxySnapshot = null;
   }
 
   init() {
@@ -288,6 +289,72 @@ export class DataHelper {
     }, delayMs);
   }
 
+  // Rebuild `galaxyStorage` from the cached API snapshot. The PTRE key is
+  // never stored on DataHelper; callers must supply it (same pattern as scan()).
+  // No-op when the key is missing, when no snapshot has been cached yet, or
+  // when the cached snapshot is not strictly newer than the persisted state.
+  rebuildGalaxyStorage(ptreKey) {
+    const logger = getLogger("updateUniverse");
+    if (!ptreKey) {
+      logger.debug(`[galaxyStorage] rebuild skipped: no PTRE key`);
+      return;
+    }
+    if (!this._galaxySnapshot) {
+      logger.debug(`[galaxyStorage] rebuild skipped: no cached snapshot`);
+      return;
+    }
+    const newGalaxyTs = this._galaxySnapshot.timestamp;
+    const previousGalaxyTs = this.lastGalaxyUpdateTS ?? -1;
+    if (!Number.isFinite(newGalaxyTs) || newGalaxyTs <= previousGalaxyTs) {
+      logger.debug(`[galaxyStorage] rebuild skipped: prevTs=${previousGalaxyTs} newTS=${newGalaxyTs}`);
+      return;
+    }
+
+    const galaxyBuildStart = performance.now();
+    this.galaxyStorage = {};
+    let updatedSystemsCount = 0;
+    let updatedPlanetsCount = 0;
+    let updatedMoonsCount = 0;
+
+    this._galaxySnapshot.planetList.forEach((planet) => {
+      const parts = (planet.coords || "").split(":");
+      if (parts.length !== 3) return;
+      const g = parts[0];
+      const s = parts[1];
+      const p = parts[2];
+
+      if (!this.galaxyStorage[g]) {
+        this.galaxyStorage[g] = {};
+      }
+      if (!this.galaxyStorage[g][s]) {
+        this.galaxyStorage[g][s] = {};
+        for (let i = 1; i <= 15; i++) {
+          this.galaxyStorage[g][s][String(i)] = {
+            playerId: -1,
+            planetId: -1,
+            moonId: -1,
+            ts: newGalaxyTs,
+          };
+        }
+        updatedSystemsCount++;
+      }
+
+      this.galaxyStorage[g][s][p] = {
+        playerId: planet.player,
+        planetId: planet.id,
+        moonId: planet.moon ? planet.moon : -1,
+        ts: newGalaxyTs,
+      };
+      updatedPlanetsCount++;
+      if (planet.moon) updatedMoonsCount++;
+    });
+
+    this.lastGalaxyUpdateTS = newGalaxyTs;
+    const galaxyBuildDurationMs = Math.round(performance.now() - galaxyBuildStart);
+    logger.debug(`[galaxyStorage] New data: systems=${updatedSystemsCount} planets=${updatedPlanetsCount} moons=${updatedMoonsCount} | TS=${this.lastGalaxyUpdateTS} | Took ${galaxyBuildDurationMs}ms`);
+    this.flushGalaxyStorage();
+  }
+
   async update() {
     const logger = getLogger("updateUniverse");
 
@@ -309,68 +376,16 @@ export class DataHelper {
       ]);
 
       // ----------------------------------------------
-      // Galaxy Storage Update (snapshot of all planets in the universe)
-      // universe.xml is updated ONCE A WEEK (except for migrations, merge, etc)
-      // Only update this structure if the API has been updated
-      // Otherwise, it is purely useless (and we wont keep PTRE tracking data)
-      // The build is also gated on the presence of a PTRE team key in settings (might and should change)
-
-      const galaxyBuildStart = performance.now();
+      // Galaxy Snapshot Cache (planets fetched from universe.xml, once a week)
+      // The actual `galaxyStorage` rebuild is deferred to rebuildGalaxyStorage(ptreKey)
+      // so the PTRE team key never crosses into the content-script context.
       const playerPlanets = planetsSnapshot.planets;
-      const planetList = planetsSnapshot.planetList;
-      const newGalaxyTs = planetsSnapshot.timestamp;
-      const previousGalaxyTs = this.lastGalaxyUpdateTS ?? -1;
-      const galaxyUpdateNeeded = Number.isFinite(newGalaxyTs) && newGalaxyTs > previousGalaxyTs;
-      const ptreKeyPresent = !!(OGIData.options && OGIData.options.ptreTK);
-
-      logger.debug(`[galaxyStorage] prevTs=${previousGalaxyTs} newTS=${newGalaxyTs} => ${galaxyUpdateNeeded ? "OPEN" : "SKIP"} | PTRE=${ptreKeyPresent}`);
-
-      if (galaxyUpdateNeeded && ptreKeyPresent) {
-        // Do not use current storage if API was really updated
-        this.galaxyStorage = {};
-        let updatedSystemsCount = 0;
-        let updatedPlanetsCount = 0;
-        let updatedMoonsCount = 0;
-
-        planetList.forEach((planet) => {
-          const parts = (planet.coords || "").split(":");
-          if (parts.length !== 3) return;
-          const g = parts[0];
-          const s = parts[1];
-          const p = parts[2];
-
-          if (!this.galaxyStorage[g]) {
-            this.galaxyStorage[g] = {};
-          }
-          if (!this.galaxyStorage[g][s]) {
-            this.galaxyStorage[g][s] = {};
-            for (let i = 1; i <= 15; i++) {
-              this.galaxyStorage[g][s][String(i)] = {
-                playerId: -1,
-                planetId: -1,
-                moonId: -1,
-                ts: newGalaxyTs,
-              };
-            }
-            updatedSystemsCount++;
-          }
-
-          this.galaxyStorage[g][s][p] = {
-            playerId: planet.player,
-            planetId: planet.id,
-            moonId: planet.moon ? planet.moon : -1,
-            ts: newGalaxyTs,
-          };
-          updatedPlanetsCount++;
-          if (planet.moon) updatedMoonsCount++;
-        });
-
-        this.lastGalaxyUpdateTS = newGalaxyTs;
-        const galaxyBuildDurationMs = Math.round(performance.now() - galaxyBuildStart);
-        logger.debug(`[galaxyStorage] New data: systems=${updatedSystemsCount} planets=${updatedPlanetsCount} moons=${updatedMoonsCount} | TS=${this.lastGalaxyUpdateTS} | Took ${galaxyBuildDurationMs}ms`);
-        this.flushGalaxyStorage();
-      }
-      // End Galaxy Storage Update
+      this._galaxySnapshot = {
+        planetList: planetsSnapshot.planetList,
+        timestamp: planetsSnapshot.timestamp,
+      };
+      logger.debug(`[galaxyStorage] snapshot cached (ts=${planetsSnapshot.timestamp})`);
+      // End Galaxy Snapshot Cache
       // --------------------------------------------
 
       // -- TopScore --------------------------------

--- a/src/ctxcontent/data-helper.js
+++ b/src/ctxcontent/data-helper.js
@@ -254,11 +254,27 @@ export class DataHelper {
       clearTimeout(this._galaxyFlushTimer);
       this._galaxyFlushTimer = null;
     }
-    chrome.storage.local.set({
-      [`ogi-galaxy-${this.universe}`]: JSON.stringify({
+    const logger = getLogger("galaxyStorage");
+    const key = `ogi-galaxy-${this.universe}`;
+    let payload;
+    try {
+      payload = JSON.stringify({
         galaxyStorage: this.galaxyStorage,
         lastGalaxyUpdateTS: this.lastGalaxyUpdateTS,
-      }),
+      });
+    } catch (err) {
+      this._lastFlushError = `serialize: ${err && err.message ? err.message : err}`;
+      logger.error(`[${key}] serialize failed: ${this._lastFlushError}`);
+      return;
+    }
+    chrome.storage.local.set({ [key]: payload }, () => {
+      const lastError = chrome.runtime.lastError;
+      if (lastError) {
+        this._lastFlushError = `write (${payload.length}B): ${lastError.message}`;
+        logger.error(`[${key}] write failed: ${this._lastFlushError}`);
+        return;
+      }
+      this._lastFlushError = null;
     });
   }
 

--- a/src/ctxcontent/data-helper.js
+++ b/src/ctxcontent/data-helper.js
@@ -10,11 +10,11 @@ const ptreLogger = getLogger("data-helper.ptre");
 /** Number of positions per system stored in `galaxyStorage` (dense layout). */
 const SCANNED_SYSTEM_POSITION_COUNT = 15;
 /** Filler for absent players/planets/moons in a `galaxyStorage` position. */
-const EMPTY_POSITION = Object.freeze({ playerId: -1, planetId: -1, moonId: -1, ts: -1 });
+const EMPTY_POSITION = Object.freeze({ playerId: -1, planetId: -1, moonId: -1 });
 
 /**
  * Build a fresh empty snapshot with exactly SCANNED_SYSTEM_POSITION_COUNT positions.
- * @return {Object<string, {playerId:number, planetId:number, moonId:number, ts:number}>}
+ * @return {Object<string, {playerId:number, planetId:number, moonId:number}>}
  */
 function generateEmptySystem() {
   const snap = {};
@@ -206,9 +206,8 @@ export class DataHelper {
    *        OGame page's wall-clock server time. NOT a reliable UTC Unix ms: the value is
    *        interpreted in the browser's timezone, so on a server whose timezone differs
    *        from the browser's (e.g. `.en` for a CEST user) it is offset by the timezone
-   *        delta. Sent as-is in the PTRE payload's `timestamp_ig` and written to `ts`
-   *        on positions that get persisted. Do NOT compare directly with
-   *        `lastGalaxyUpdateTS` (Unix seconds from the public API).
+   *        delta. Sent as-is in the PTRE payload's `timestamp_ig`. Do NOT compare directly
+   *        with `lastGalaxyUpdateTS` (Unix seconds from the public API).
    * @return {Object<string, object>} - PTRE payload keyed by "g:s:p"; empty when no diff
    *         or when no team key.
    */
@@ -277,13 +276,11 @@ export class DataHelper {
           // `currentSystemSnapshot` must contain the full dense 15-position map so that,
           // when we persist below, `galaxyStorage[g][s]` always exposes 15 slots. We can't
           // decide up front to skip - a change at a later position would need the earlier
-          // ones too. `ts` records the server time of this scan; it only survives on disk
-          // when at least one position in this system moved.
+          // ones too.
           currentSystemSnapshot[pos] = {
             playerId: cur.playerId,
             planetId: cur.planetId,
             moonId: cur.moonId,
-            ts: serverTime ?? -1,
           };
           const changed =
             !previousSystemFound ||
@@ -334,9 +331,7 @@ export class DataHelper {
 
       // Persist only when at least one position in the system actually moved.
       // Identical revisits (same player/planet/moon layout as previously stored) skip
-      // the write to avoid disk churn during heavy browsing. Stale `ts` values on the
-      // persisted snapshot can only linger until the next weekly API refresh, which
-      // wipes `galaxyStorage` entirely in update().
+      // the write to avoid disk churn during heavy browsing.
       if (teamKey && systemChanged) {
         if (!this.galaxyStorage[galaxy]) this.galaxyStorage[galaxy] = {};
         this.galaxyStorage[galaxy][system] = currentSystemSnapshot;
@@ -447,7 +442,6 @@ export class DataHelper {
             playerId: -1,
             planetId: -1,
             moonId: -1,
-            ts: newGalaxyTs,
           };
         }
         updatedSystemsCount++;
@@ -457,7 +451,6 @@ export class DataHelper {
         playerId: planet.player,
         planetId: planet.id,
         moonId: planet.moon ? planet.moon : -1,
-        ts: newGalaxyTs,
       };
       updatedPlanetsCount++;
       if (planet.moon) updatedMoonsCount++;
@@ -473,7 +466,7 @@ export class DataHelper {
     const logger = getLogger("updateUniverse");
 
     if (this.loading) return;
-    if (!isNaN(this.lastUpdate) && new Date() - this.lastUpdate < 30 * 60 * 1e3) {
+    if (!isNaN(this.lastUpdate) && new Date() - this.lastUpdate < 1 * 60 * 1e3) {
       logger.debug("Last ogame's data update was: " + this.lastUpdate);
       return;
     }

--- a/src/ctxcontent/data-helper.js
+++ b/src/ctxcontent/data-helper.js
@@ -270,7 +270,8 @@ export class DataHelper {
     chrome.storage.local.set({ [key]: payload }, () => {
       const lastError = chrome.runtime.lastError;
       if (lastError) {
-        this._lastFlushError = `write (${payload.length}B): ${lastError.message}`;
+        const bytes = new Blob([payload]).size;
+        this._lastFlushError = `write (${bytes}B): ${lastError.message}`;
         logger.error(`[${key}] write failed: ${this._lastFlushError}`);
         return;
       }

--- a/src/ctxcontent/data-helper.js
+++ b/src/ctxcontent/data-helper.js
@@ -5,6 +5,25 @@ import { getPlayersHighscore, NAN_HIGHSCORE } from "./helpers/universe.highscore
 import { getPlanets } from "./helpers/universe.planets.js";
 import { DEFAULT_PLAYER, getPlayers } from "./helpers/universe.players.js";
 
+const ptreLogger = getLogger("data-helper.ptre");
+
+/** Number of positions per system stored in `galaxyStorage` (dense layout). */
+const SCANNED_SYSTEM_POSITION_COUNT = 15;
+/** Filler for absent players/planets/moons in a `galaxyStorage` position. */
+const EMPTY_POSITION = Object.freeze({ playerId: -1, planetId: -1, moonId: -1, ts: -1 });
+
+/**
+ * Build a fresh empty snapshot with exactly SCANNED_SYSTEM_POSITION_COUNT positions.
+ * @return {Object<string, {playerId:number, planetId:number, moonId:number, ts:number}>}
+ */
+function generateEmptySystem() {
+  const snap = {};
+  for (let pos = 1; pos <= SCANNED_SYSTEM_POSITION_COUNT; pos++) {
+    snap[pos] = { ...EMPTY_POSITION };
+  }
+  return snap;
+}
+
 export class DataHelper {
   constructor(universe) {
     this.universe = universe;
@@ -49,6 +68,7 @@ export class DataHelper {
             this.galaxyStorage = {};
             this.lastGalaxyUpdateTS = -1;
           }
+
           resolve();
         }
       );
@@ -158,82 +178,172 @@ export class DataHelper {
     return response;
   }
 
-  scan(system, ptreKey = null, serverTime = null) {
-    let ptrePosition = {};
+  /**
+   * Process the current galaxy view (positions 1..15).
+   *
+   * Runs unconditionally two side-effect groups:
+   *   1. Non-PTRE - updates `scannedPlanets` / `scannedPlayers` (consumed by `getPlayer()`
+   *      and `filter()` for the stalking sidebar, tooltips, target list and search box)
+   *      and persists them via `saveData()`.
+   *   2. PTRE (only when `teamKey` is provided) - diffs the incoming positions against the
+   *      persisted per-(g,s) snapshot in `this.galaxyStorage[g][s]`, returns the changed positions
+   *      only in the returned payload, and persists the new snapshot only when at least one
+   *      position moved (identical revisits skip the disk write). On first-ever visit of the
+   *      system, all 15 positions are emitted (populated AND empty) so PTRE learns its initial
+   *      shape.
+   *
+   * Any failure is logged and returns an empty payload; galaxy rendering is never impacted.
+   *
+   * @param {number} galaxy
+   * @param {number} system
+   * @param {Object<string, {playerId:number, planetId:number, moonId:number}>} positions
+   *        Keys "1".."15". Missing player/planet/moon -> -1.
+   * @param {Object<string, {playerName:string, playerRank:number, playerStatus:string}>} additionnal
+   *        Keys "1".."15". Enrichment collected live in the page context.
+   * @param {string|null} teamKey - PTRE team key. When null/empty, PTRE work is skipped
+   *        and only the non-PTRE side effects run.
+   * @param {number|null} serverTime - Milliseconds from a JS `Date` built by ogkush from the
+   *        OGame page's wall-clock server time. NOT a reliable UTC Unix ms: the value is
+   *        interpreted in the browser's timezone, so on a server whose timezone differs
+   *        from the browser's (e.g. `.en` for a CEST user) it is offset by the timezone
+   *        delta. Sent as-is in the PTRE payload's `timestamp_ig` and written to `ts`
+   *        on positions that get persisted. Do NOT compare directly with
+   *        `lastGalaxyUpdateTS` (Unix seconds from the public API).
+   * @return {Object<string, object>} - PTRE payload keyed by "g:s:p"; empty when no diff
+   *         or when no team key.
+   */
+  scan(galaxy, system, positions, additionnal, teamKey = null, serverTime = null) {
+    const payload = {};
+    try {
+      if (!positions) {
+        return payload;
+      }
 
-    system.forEach((row) => {
-      let sameOld = false;
-      if (!this.scannedPlanets[row.id]) {
-        this.scannedPlanets[row.id] = {};
-      }
-      if (!this.scannedPlayers[row.id] && row.name) {
-        this.scannedPlayers[row.id] = row.name;
-      }
-      let player = this.players[row.id];
-      let known = false;
-      if (player) {
-        this.players[row.id].planets.forEach((planet) => {
-          if (row.coords == planet.coords) {
-            sameOld = true;
+      // Previous snapshot: loaded from `galaxyStorage` when a team key is set and we
+      // already have data for this (galaxy, system); otherwise an empty stand-in so the
+      // diff / departure logic below stays uniform. `previousSystemFound` distinguishes
+      // "first-ever visit of this system" (false) from "we have a stored snapshot" (true):
+      // on first visit we force-emit all 15 positions - populated AND empty - so PTRE
+      // learns the initial shape of the system. Without a team key we never persist and
+      // never emit (keyless behavior matches master).
+      const storedSystem = this.galaxyStorage && this.galaxyStorage[galaxy] ? this.galaxyStorage[galaxy][system] : undefined;
+      const previousSystemFound = Boolean(teamKey && storedSystem);
+      const previousSystemSnapshot = previousSystemFound ? storedSystem : generateEmptySystem();
+      const currentSystemSnapshot = {};
+      let systemChanged = false;
+
+      for (let pos = 1; pos <= SCANNED_SYSTEM_POSITION_COUNT; pos++) {
+        const cur = positions[pos] || positions[String(pos)] || { playerId: -1, planetId: -1, moonId: -1 };
+        const extra = (additionnal && (additionnal[pos] || additionnal[String(pos)])) || {};
+        const coords = galaxy + ":" + system + ":" + pos;
+
+        ptreLogger.debug("[GALAXY] [" + coords +"] Player " + previousSystemSnapshot[pos].playerId + "=>" + cur.playerId +
+            " | Planet: " + previousSystemSnapshot[pos].planetId + "=>" + cur.planetId +
+            " | Moon: " + previousSystemSnapshot[pos].moonId + "=>" + cur.moonId +
+            " (" + (extra.playerName || "") + " - " + (extra.playerRank ?? -1) + ")");
+
+        // ---- Non-PTRE side effects: refresh OGI's internal maps used by getPlayer/filter.
+        // Runs regardless of whether a PTRE team key is set (matches master behavior).
+        if (cur.playerId !== -1) {
+          if (!this.scannedPlanets[cur.playerId]) {
+            this.scannedPlanets[cur.playerId] = {};
           }
-          if (row.coords == planet.coords && row.moon == planet.moon) {
-            known = true;
+          this.scannedPlanets[cur.playerId][coords] = cur.moonId > -1 ? cur.moonId : false;
+          if (extra.playerName && !this.scannedPlayers[cur.playerId]) {
+            this.scannedPlayers[cur.playerId] = extra.playerName;
           }
-        });
-      }
+        }
 
-      if (ptreKey && (!known || row.deleted)) {
-        ptrePosition[row.coords] = {};
-        ptrePosition[row.coords].id = row.planetId || -1;
-        ptrePosition[row.coords].teamkey = ptreKey;
-        ptrePosition[row.coords].galaxy = row.coords.split(":")[0];
-        ptrePosition[row.coords].system = row.coords.split(":")[1];
-        ptrePosition[row.coords].position = row.coords.split(":")[2];
-        ptrePosition[row.coords].timestamp_ig = serverTime;
-        if (row.moon) {
-          ptrePosition[row.coords].moon = {};
-          ptrePosition[row.coords].moon.id = row.moonId || -1;
+        // Departure detected: flip the prior occupant's coord to null in scannedPlanets
+        // so getPlayer() renders it as deleted. Safe without a team key: the previous
+        // snapshot is empty in that case, so this never fires spuriously.
+        if (previousSystemSnapshot[pos].playerId !== -1 && cur.playerId === -1) {
+          if (!this.scannedPlanets[previousSystemSnapshot[pos].playerId]) {
+            this.scannedPlanets[previousSystemSnapshot[pos].playerId] = {};
+          }
+          this.scannedPlanets[previousSystemSnapshot[pos].playerId][coords] = null;
         }
-      }
 
-      if (!known) {
-        this.scannedPlanets[row.id][row.coords] = row.moon;
-        if (ptreKey && row.id) {
-          let currentPlayer = player ?? "{id:" + row.id + ", name:" + row.name + "}";
-          ptrePosition[row.coords].player_id = row.id;
-          ptrePosition[row.coords].name = row.name || false;
-          ptrePosition[row.coords].rank = currentPlayer?.points?.position || -1;
-          ptrePosition[row.coords].score = currentPlayer?.points?.score || -1;
-          ptrePosition[row.coords].fleet = currentPlayer?.military?.ships || -1;
-          ptrePosition[row.coords].status = currentPlayer?.status;
-          ptrePosition[row.coords].old_player_id = sameOld ? ptrePosition[row.coords].player_id : -1;
-          ptrePosition[row.coords].timestamp_api = sameOld && this.lastUpdate ? this.lastUpdate : -1;
-          ptrePosition[row.coords].old_name = sameOld ? ptrePosition[row.coords].name : false;
-          ptrePosition[row.coords].old_rank = sameOld ? ptrePosition[row.coords].rank : -1;
-          ptrePosition[row.coords].old_score = sameOld ? ptrePosition[row.coords].score : -1;
-          ptrePosition[row.coords].old_fleet = sameOld ? ptrePosition[row.coords].fleet : -1;
+        // ---- PTRE-only: build the delta payload when a team key is set.
+        // On first-ever visit of this system (`previousSystemFound === false`) we
+        // force-emit every position - including empty ones - so PTRE learns the
+        // full initial shape of the system.
+        if (teamKey) {
+          // Build the snapshot for this position regardless of whether it changed:
+          // `currentSystemSnapshot` must contain the full dense 15-position map so that,
+          // when we persist below, `galaxyStorage[g][s]` always exposes 15 slots. We can't
+          // decide up front to skip - a change at a later position would need the earlier
+          // ones too. `ts` records the server time of this scan; it only survives on disk
+          // when at least one position in this system moved.
+          currentSystemSnapshot[pos] = {
+            playerId: cur.playerId,
+            planetId: cur.planetId,
+            moonId: cur.moonId,
+            ts: serverTime ?? -1,
+          };
+          const changed =
+            !previousSystemFound ||
+            cur.playerId !== previousSystemSnapshot[pos].playerId ||
+            cur.planetId !== previousSystemSnapshot[pos].planetId ||
+            cur.moonId !== previousSystemSnapshot[pos].moonId;
+          if (changed) {
+            ptreLogger.debug("[GALAXY] [" + coords + "] Position changed");
+            systemChanged = true;
+
+            const entry = {
+              id: cur.planetId,
+              teamkey: teamKey,
+              galaxy: galaxy,
+              system: system,
+              position: pos,
+              timestamp_ig: serverTime,
+            };
+            if (cur.moonId !== -1) {
+              entry.moon = { id: cur.moonId };
+            }
+
+            // Current-player fields (best-effort enrichment from the OGame public API cache).
+            const curPlayer = cur.playerId !== -1 && this.players ? this.players[cur.playerId] : undefined;
+            entry.player_id = cur.playerId;
+            entry.name = extra.playerName || curPlayer?.name || false;
+            entry.rank = extra.playerRank ?? curPlayer?.points?.position ?? -1;
+            entry.score = curPlayer?.points?.score ?? -1;
+            entry.fleet = curPlayer?.military?.ships ?? -1;
+            entry.status = cur.playerId === -1 ? -1 : extra.playerStatus ?? curPlayer?.status ?? "";
+
+            // Previous-occupant fields.
+            const prevPlayer =
+              previousSystemSnapshot[pos].playerId !== -1 && this.players
+                ? this.players[previousSystemSnapshot[pos].playerId]
+                : undefined;
+            entry.old_player_id = previousSystemSnapshot[pos].playerId;
+            entry.timestamp_api = this.lastUpdate || -1;
+            entry.old_name = prevPlayer?.name || false;
+            entry.old_rank = prevPlayer?.points?.position ?? -1;
+            entry.old_score = prevPlayer?.points?.score ?? -1;
+            entry.old_fleet = prevPlayer?.military?.ships ?? -1;
+
+            payload[coords] = entry;
+          }
         }
+      }// End positions loop
+
+      // Persist only when at least one position in the system actually moved.
+      // Identical revisits (same player/planet/moon layout as previously stored) skip
+      // the write to avoid disk churn during heavy browsing. Stale `ts` values on the
+      // persisted snapshot can only linger until the next weekly API refresh, which
+      // wipes `galaxyStorage` entirely in update().
+      if (teamKey && systemChanged) {
+        if (!this.galaxyStorage[galaxy]) this.galaxyStorage[galaxy] = {};
+        this.galaxyStorage[galaxy][system] = currentSystemSnapshot;
+        this.scheduleGalaxyStorageFlush();
       }
-      if (row.deleted) {
-        this.scannedPlanets[row.id][row.coords] = null;
-        if (ptreKey && row.id) {
-          ptrePosition[row.coords].player_id = -1;
-          ptrePosition[row.coords].name = false;
-          ptrePosition[row.coords].rank = -1;
-          ptrePosition[row.coords].score = -1;
-          ptrePosition[row.coords].fleet = -1;
-          ptrePosition[row.coords].status = -1;
-          ptrePosition[row.coords].old_player_id = row.id || -1;
-          ptrePosition[row.coords].timestamp_api = this.lastUpdate || -1;
-          ptrePosition[row.coords].old_name = player?.name || false;
-          ptrePosition[row.coords].old_rank = player?.points?.position || -1;
-          ptrePosition[row.coords].old_score = player?.points?.score || -1;
-          ptrePosition[row.coords].old_fleet = player?.military?.ships || -1;
-        }
-      }
-    });
-    this.saveData();
-    return ptrePosition;
+      this.saveData();
+    } catch (err) {
+      ptreLogger.error("scan failed", err);
+      return {};
+    }
+    return payload;
   }
 
   saveData() {

--- a/src/ctxcontent/helpers/universe.planets.js
+++ b/src/ctxcontent/helpers/universe.planets.js
@@ -3,11 +3,18 @@ import { requestOGamePlanets } from "../services/request.ogamePlanets.js";
 /**
  *
  * @param {string} universe
- * @return Promise<PlayerPlanetsMap>
+ * @return Promise<PlanetsSnapshot>
  */
 export function getPlanets(universe) {
-  const planetResponse = requestOGamePlanets(universe).then(toPlanetResponse);
-  return planetResponse.then(toPlanetMap);
+  return requestOGamePlanets(universe).then((response) => {
+    const timestamp = parseInt(response.document.documentElement.getAttribute("timestamp"), 10);
+    const planetList = toPlanetResponse(response);
+    return {
+      planets: toPlanetMap(planetList),
+      planetList: planetList,
+      timestamp: Number.isFinite(timestamp) ? timestamp : -1,
+    };
+  });
 }
 
 /**
@@ -48,6 +55,13 @@ function toPlanetResponse(response) {
 
 /**
  * @typedef {Map<number, PlanetResponse[]>} PlayerPlanetsMap
+ */
+
+/**
+ * @typedef {Object} PlanetsSnapshot
+ * @property {PlayerPlanetsMap} planets - planets grouped by player id
+ * @property {PlanetResponse[]} planetList - flat list of every planet in the universe
+ * @property {number} timestamp - universe.xml root `timestamp` attribute (unix seconds), -1 if missing
  */
 
 /**

--- a/src/ctxcontent/index.js
+++ b/src/ctxcontent/index.js
@@ -43,6 +43,7 @@ function processData() {
         delete tempSaveData.lastGalaxyUpdateTS;
         // Runtime-only setTimeout id; must not survive a reload.
         delete tempSaveData._galaxyFlushTimer;
+        delete tempSaveData._lastFlushError;
 
         chrome.storage.local.set({ [UNIVERSE]: tempSaveData }, function (at) {});
       });

--- a/src/ctxcontent/index.js
+++ b/src/ctxcontent/index.js
@@ -13,8 +13,8 @@ let pendingPtreKey = "";
 
 contentContextInit({
   ptre: {
-    galaxy: function (changes, ptreKey = null, serverTime = null) {
-      return dataHelper.scan(changes, ptreKey, serverTime);
+    galaxy: function (galaxy, system, positions, additionnal, ptreKey = null, serverTime = null) {
+      return dataHelper.scan(galaxy, system, positions, additionnal, ptreKey, serverTime);
     },
     setTeamKey: function (key) {
       pendingPtreKey = typeof key === "string" ? key : "";

--- a/src/ctxcontent/index.js
+++ b/src/ctxcontent/index.js
@@ -36,6 +36,11 @@ function processData() {
         tempSaveData.lastUpdate = universes[UNIVERSE].lastUpdate.toJSON();
         tempSaveData.lastPlanetsUpdate = universes[UNIVERSE].lastPlanetsUpdate.toJSON();
         tempSaveData.lastPlayersUpdate = universes[UNIVERSE].lastPlayersUpdate.toJSON();
+        // galaxyStorage lives in its own key `ogi-galaxy-<UNIVERSE>`; don't
+        // duplicate it into the big blob or a manual reset gets resurrected
+        // on next boot via Object.assign in main().
+        delete tempSaveData.galaxyStorage;
+        delete tempSaveData.lastGalaxyUpdateTS;
 
         chrome.storage.local.set({ [UNIVERSE]: tempSaveData }, function (at) {});
       });
@@ -91,6 +96,13 @@ window.addEventListener(
 
 document.addEventListener("ogi-clear", function (e) {
   dataHelper.clearData();
+});
+document.addEventListener("ogi-galaxy-clear", function (e) {
+  if (dataHelper) {
+    dataHelper.galaxyStorage = {};
+    dataHelper.lastGalaxyUpdateTS = -1;
+  }
+  chrome.storage.local.remove(`ogi-galaxy-${UNIVERSE}`);
 });
 document.addEventListener("ogi-notification", function (e) {
   const msg = Object.assign({ iconUrl: "assets/images/logo128.png" }, e.detail);

--- a/src/ctxcontent/index.js
+++ b/src/ctxcontent/index.js
@@ -41,6 +41,8 @@ function processData() {
         // on next boot via Object.assign in main().
         delete tempSaveData.galaxyStorage;
         delete tempSaveData.lastGalaxyUpdateTS;
+        // Runtime-only setTimeout id; must not survive a reload.
+        delete tempSaveData._galaxyFlushTimer;
 
         chrome.storage.local.set({ [UNIVERSE]: tempSaveData }, function (at) {});
       });

--- a/src/ctxcontent/index.js
+++ b/src/ctxcontent/index.js
@@ -22,6 +22,29 @@ contentContextInit({
         dataHelper.rebuildGalaxyStorage(pendingPtreKey);
       }
     },
+    galaxyInfo: function () {
+      if (!dataHelper || !dataHelper.galaxyStorage) {
+        return Promise.resolve({ systemCount: 0, lastGalaxyUpdateTS: -1, storageBytes: 0 });
+      }
+      let systemCount = 0;
+      for (const g in dataHelper.galaxyStorage) {
+        systemCount += Object.keys(dataHelper.galaxyStorage[g]).length;
+      }
+      const lastGalaxyUpdateTS = dataHelper.lastGalaxyUpdateTS ?? -1;
+      const key = `ogi-galaxy-${UNIVERSE}`;
+      return new Promise((resolve) => {
+        try {
+          chrome.storage.local.get([key], (result) => {
+            let storageBytes = 0;
+            const raw = result?.[key];
+            if (typeof raw === "string") storageBytes = new Blob([raw]).size;
+            resolve({ systemCount, lastGalaxyUpdateTS, storageBytes });
+          });
+        } catch (_) {
+          resolve({ systemCount, lastGalaxyUpdateTS, storageBytes: 0 });
+        }
+      });
+    },
   },
   messages: {
     expeditionType: getExpeditionType,

--- a/src/ctxcontent/index.js
+++ b/src/ctxcontent/index.js
@@ -7,10 +7,20 @@ import { DataHelper } from "./data-helper.js";
 
 const mainLogger = getLogger();
 
+// PTRE team key held in the content script only for the lifetime of the tab.
+// Pushed in from the page via `ptre.setTeamKey`; never persisted here.
+let pendingPtreKey = "";
+
 contentContextInit({
   ptre: {
     galaxy: function (changes, ptreKey = null, serverTime = null) {
       return dataHelper.scan(changes, ptreKey, serverTime);
+    },
+    setTeamKey: function (key) {
+      pendingPtreKey = typeof key === "string" ? key : "";
+      if (pendingPtreKey && dataHelper && dataHelper._galaxySnapshot) {
+        dataHelper.rebuildGalaxyStorage(pendingPtreKey);
+      }
     },
   },
   messages: {
@@ -32,6 +42,9 @@ function processData() {
   universes[UNIVERSE].init().then(() => {
     try {
       universes[UNIVERSE].update().then(() => {
+        if (pendingPtreKey && universes[UNIVERSE]._galaxySnapshot) {
+          universes[UNIVERSE].rebuildGalaxyStorage(pendingPtreKey);
+        }
         let tempSaveData = { ...universes[UNIVERSE] };
         tempSaveData.lastUpdate = universes[UNIVERSE].lastUpdate.toJSON();
         tempSaveData.lastPlanetsUpdate = universes[UNIVERSE].lastPlanetsUpdate.toJSON();
@@ -44,6 +57,7 @@ function processData() {
         // Runtime-only setTimeout id; must not survive a reload.
         delete tempSaveData._galaxyFlushTimer;
         delete tempSaveData._lastFlushError;
+        delete tempSaveData._galaxySnapshot;
 
         chrome.storage.local.set({ [UNIVERSE]: tempSaveData }, function (at) {});
       });

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -1536,6 +1536,8 @@ class OGInfinity {
     this.json.reminders = this.json.reminders || {};
     this.isLoading = false;
     this.autoQueue = new AutoQueue();
+
+    pageContextRequest("ptre", "setTeamKey", this.json.options.ptreTK || "");
   }
 
   start() {
@@ -15471,6 +15473,7 @@ class OGInfinity {
         this.json.options.ptreTK = "";
         // TODO: Display an error message "Invalid PTRE Team Key Format. TK should look like: TM-XXXX-XXXX-XXXX-XXXX"
       }
+      pageContextRequest("ptre", "setTeamKey", this.json.options.ptreTK || "");
       this.json.options.pantryKey = pantryInput.value.trim();
       this.json.options.simulator = simulatorInput.value;
       this.json.options.expedition.defaultTime = Math.max(1, Math.min(~~expeditionDefaultTime.value, 16));

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -4119,17 +4119,29 @@ class OGInfinity {
       }
 
       const playerDiv = row.querySelector(".cellPlayerName div");
+      // own-planet rows have NO <div> inside .cellPlayerName (just two <span>s, one
+      // with class .ownPlayerRow bearing the player name). Detect it as a fallback so we
+      // don't miss the current player's own planets in the DOM walk.
+      const ownPlayerSpan = playerDiv ? null : row.querySelector(".cellPlayerName .ownPlayerRow");
 
-      if (playerDiv) {
+      if (playerDiv || ownPlayerSpan) {
         const planetDiv = row.querySelector(".cellPlanet div");
         const moonDiv = row.querySelector(".cellMoon div");
-        const rawPlayerId = playerDiv.getAttribute("id")?.replace("player", "");
-        const playerId = rawPlayerId && rawPlayerId !== "" ? Number(rawPlayerId) : -1;
+        let playerId = -1;
+        let name = "";
+        if (playerDiv) {
+          const rawPlayerId = playerDiv.getAttribute("id")?.replace("player", "");
+          playerId = rawPlayerId && rawPlayerId !== "" ? Number(rawPlayerId) : -1;
+          name = playerDiv.querySelector("span:first-of-type")?.textContent || "";
+        } else {
+          // own-planet row: no player id in the row itself, fall back to the current player id.
+          playerId = Number.isFinite(this.playerId) ? this.playerId : -1;
+          name = ownPlayerSpan.textContent?.trim() || "";
+        }
         const rawPlanetId = planetDiv ? planetDiv.getAttribute("data-planet-id") : null;
         const planetId = rawPlanetId ? Number(rawPlanetId) : -1;
         const rawMoonId = moonDiv ? moonDiv.getAttribute("data-moon-id") : null;
         const moonId = rawMoonId ? Number(rawMoonId) : -1;
-        const name = playerDiv.querySelector("span:first-of-type")?.textContent || "";
 
         // Status flags (matches EasyPTRE extraction).
         let statusStr = "";

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -15038,6 +15038,14 @@ class OGInfinity {
         <input type="checkbox" id="scan" name="scan">`
       )
     );
+    let galaxyBox = dataManagement.appendChild(
+      this.createDOM(
+        "div",
+        { class: "ogi-checkbox" },
+        `<label for="galaxy_reset">${this.getTranslatedText(226)}</label>
+        <input type="checkbox" id="galaxy_reset" name="galaxy_reset">`
+      )
+    );
     let OptionsBox = dataManagement.appendChild(
       this.createDOM(
         "div",
@@ -15378,6 +15386,9 @@ class OGInfinity {
         json.spies = {};
         if (scanBox.children[1].checked) {
           document.dispatchEvent(new CustomEvent("ogi-clear"));
+        }
+        if (galaxyBox.children[1].checked) {
+          document.dispatchEvent(new CustomEvent("ogi-galaxy-clear"));
         }
         if (purgeBox.children[1].checked) {
           this.purgeLocalStorage();

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -4081,12 +4081,7 @@ class OGInfinity {
   }
 
   scan() {
-    let sided = document.querySelectorAll(".ogl-stalkPlanets > a");
     if (!this.activities) this.activities = {};
-    let exists = false;
-    let changes = [];
-    let resets = [];
-    let data = {};
     let ptreJSON = {};
     let baseCords = galaxy + ":" + system;
     let secureCoords =
@@ -4095,52 +4090,90 @@ class OGInfinity {
     if (secureCoords !== baseCords || (doubleCheckCoords && doubleCheckCoords !== baseCords + ":1")) {
       return;
     }
-    document.querySelectorAll("#galaxycomponent .galaxyRow.ctContentRow").forEach((row, index) => {
-      let coords = baseCords + ":" + Number(index + 1);
-      let target = document.querySelector(`.ogl-target-list .ogl-stalkPlanets [data-coords="${coords}"]`);
+
+    // PTRE gala snapshot state - positions 1..15 only (see PTRE_MAX_POS below).
+    // Non-PTRE OGI DOM features (marker/tooltip/activity refresh) run on ALL rows the
+    // DOM exposes, including the expedition slot at position 16 if present, so any
+    // future feature can safely enhance them.
+    const PTRE_MIN_POS = 1;
+    const PTRE_MAX_POS = 15;
+    const galaPositions = {};
+    const galaAdditionnal = {};
+    for (let pos = PTRE_MIN_POS; pos <= PTRE_MAX_POS; pos++) {
+      galaPositions[pos] = { playerId: -1, planetId: -1, moonId: -1 };
+      galaAdditionnal[pos] = { playerName: "", playerRank: -1, playerStatus: "" };
+    }
+
+    document.querySelectorAll("#galaxycomponent .galaxyRow.ctContentRow").forEach((row, indexInDom) => {
+      // Derive the OGame position from the row id (robust against DOM re-ordering
+      // and against extra rows OGame may add). Fallback to DOM index only if the id
+      // is missing / malformed.
+      const posMatch = /^galaxyRow(\d+)$/.exec(row.id || "");
+      const pos = posMatch ? Number(posMatch[1]) : indexInDom + 1;
+      const coords = baseCords + ":" + pos;
+      const isPtrePos = pos >= PTRE_MIN_POS && pos <= PTRE_MAX_POS;
+
+      const target = document.querySelector(`.ogl-target-list .ogl-stalkPlanets [data-coords="${coords}"]`);
       if (target) {
         this.updateSideActivity(target, this.getActivity(row));
       }
 
-      let playerDiv = row.querySelector(".cellPlayerName div");
+      const playerDiv = row.querySelector(".cellPlayerName div");
 
       if (playerDiv) {
-        exists = true;
-        let planetDiv = row.querySelector(".cellPlanet div");
-        let moonDiv = row.querySelector(".cellMoon div");
-        let playerId = playerDiv.getAttribute("id").replace("player", "");
-        let planetId = planetDiv ? planetDiv.getAttribute("data-planet-id") : -1;
-        let moonId = moonDiv ? moonDiv.getAttribute("data-moon-id") : -1;
-        let name = playerDiv.querySelector("span:first-of-type").textContent;
+        const planetDiv = row.querySelector(".cellPlanet div");
+        const moonDiv = row.querySelector(".cellMoon div");
+        const rawPlayerId = playerDiv.getAttribute("id")?.replace("player", "");
+        const playerId = rawPlayerId && rawPlayerId !== "" ? Number(rawPlayerId) : -1;
+        const rawPlanetId = planetDiv ? planetDiv.getAttribute("data-planet-id") : null;
+        const planetId = rawPlanetId ? Number(rawPlanetId) : -1;
+        const rawMoonId = moonDiv ? moonDiv.getAttribute("data-moon-id") : null;
+        const moonId = rawMoonId ? Number(rawMoonId) : -1;
+        const name = playerDiv.querySelector("span:first-of-type")?.textContent || "";
 
-        changes.push({
-          id: playerId,
-          name,
-          planetId,
-          moon: moonId > -1 ? parseInt(moonId) : false,
-          moonId,
-          coords,
-        });
-
-        let sided = document.querySelectorAll(".ogl-stalkPlanets");
-        if (sided.length != 0) {
-          sided.forEach((side) => {
-            if (playerId == side.getAttribute("player-id")) {
-              this.activities[coords] = this.getActivity(row);
-            } else {
+        // Status flags (matches EasyPTRE extraction).
+        let statusStr = "";
+        const preElem = row.querySelector(".cellPlayerName pre");
+        if (preElem) {
+          preElem.querySelectorAll("span").forEach((span) => {
+            const m = typeof span.className === "string" ? span.className.match(/status_abbr_(\w+)/) : null;
+            if (m) {
+              const s = m[1];
+              if (s === "inactive") statusStr += "i";
+              else if (s === "longinactive") statusStr += "I";
+              else if (s === "vacation") statusStr += "v";
+              else if (s === "admin") statusStr += "a";
             }
           });
         }
 
-        // PTRE activities
+        // PTRE snapshot: only for real planet positions.
+        if (isPtrePos) {
+          galaPositions[pos] = { playerId, planetId, moonId };
+          galaAdditionnal[pos].playerName = name;
+          galaAdditionnal[pos].playerStatus = statusStr;
+        }
+
+        const sidedAll = document.querySelectorAll(".ogl-stalkPlanets");
+        if (sidedAll.length != 0) {
+          sidedAll.forEach((side) => {
+            if (playerId == side.getAttribute("player-id")) {
+              this.activities[coords] = this.getActivity(row);
+            }
+          });
+        }
+
+        // PTRE activities (stalked / marked / searched players only, positions 1..15).
+        const playerIdStr = String(playerId);
         if (
+          isPtrePos &&
           this.json.options.ptreTK &&
           playerId > -1 &&
-          (this.json.sideStalk.indexOf(parseInt(playerId)) > -1 ||
-            this.json.sideStalk.indexOf(playerId) > -1 ||
-            this.markedPlayers.indexOf(playerId) > -1 ||
+          (this.json.sideStalk.indexOf(playerId) > -1 ||
+            this.json.sideStalk.indexOf(playerIdStr) > -1 ||
+            this.markedPlayers.indexOf(playerIdStr) > -1 ||
             (this.json.searchHistory.length > 0 &&
-              playerId == this.json.searchHistory[this.json.searchHistory.length - 1].id))
+              playerIdStr == this.json.searchHistory[this.json.searchHistory.length - 1].id))
         ) {
           let planetActivity = row.querySelector("[data-planet-id] .activity.minute15")
             ? "*"
@@ -4157,7 +4190,7 @@ class OGInfinity {
           ptreJSON[coords].activity = planetActivity;
           ptreJSON[coords].galaxy = galaxy;
           ptreJSON[coords].system = system;
-          ptreJSON[coords].position = Number(index + 1).toString();
+          ptreJSON[coords].position = String(pos);
           ptreJSON[coords].main = false;
 
           if (moonId > -1) {
@@ -4167,19 +4200,13 @@ class OGInfinity {
           }
         }
       } else {
-        let sided = document.querySelectorAll(`.ogl-stalkPlanets [data-coords="${coords}"]`);
+        // Empty position: refresh sidebar activity for the stalk tooltip if the coord is watched.
+        const sided = document.querySelectorAll(`.ogl-stalkPlanets [data-coords="${coords}"]`);
         if (sided.length != 0) {
           if (!document.querySelector(".ogl-tooltip.ogl-active") && document.querySelector(".ogl-tooltip")) {
             document.querySelector(".ogl-tooltip").classList.add("ogl-active");
           }
           this.activities[coords] = this.getActivity(row);
-          changes.push({
-            id: sided[0].parentElement.getAttribute("player-id"),
-            moon: false,
-            moonId: undefined,
-            coords,
-            deleted: true,
-          });
         }
       }
     });
@@ -4202,19 +4229,37 @@ class OGInfinity {
       this.ptreActivityUpdate(ptreJSON, systemCoords);
     }
 
-    //DISPATCH EVENT
-    data.changes = changes;
-
-    data.serverTime = serverTime && typeof serverTime.getTime !== "undefined" ? serverTime.getTime() : null;
-    data.ptreKey = this.json.options.ptreTK ?? null;
-    pageContextRequest("ptre", "galaxy", data.changes, data.ptreKey, data.serverTime)
-      .then((value) => {
-        if (Object.keys(value.response).length > 0) {
-          ptreService.updateGalaxy(OgamePageData.gameLang, this.universe, value.response);
-        }
-      })
-      .finally(() => "nothing");
-    //document.dispatchEvent(new CustomEvent("ogi-galaxy", { detail: data }), true, true);
+    // Galaxy scan dispatch. Runs unconditionally so the OGI-internal maps
+    // (scannedPlanets/scannedPlayers -> stalking sidebar, tooltips, search box) are
+    // refreshed even when no PTRE team key is set. PTRE work is gated inside scan().
+    // Any failure here must NOT propagate to the OGame galaxy render path.
+    try {
+      const serverTimeMs =
+        serverTime && typeof serverTime.getTime !== "undefined" ? serverTime.getTime() : null;
+      const ptreKey = this.json.options.ptreTK || null;
+      pageContextRequest(
+        "ptre",
+        "galaxy",
+        Number(galaxy),
+        Number(system),
+        galaPositions,
+        galaAdditionnal,
+        ptreKey,
+        serverTimeMs
+      )
+        .then((value) => {
+          try {
+            if (value && value.response && Object.keys(value.response).length > 0) {
+              ptreService.updateGalaxy(OgamePageData.gameLang, this.universe, value.response);
+            }
+          } catch (err) {
+            console.error("[OGI][PTRE] updateGalaxy failed", err);
+          }
+        })
+        .catch((err) => console.error("[OGI][PTRE] galaxy request failed", err));
+    } catch (err) {
+      console.error("[OGI][PTRE] galaxy dispatch failed", err);
+    }
 
     document.querySelectorAll("div:not(.ogl-target-list) .ogl-stalkPlanets").forEach((reset) => {
       this.refreshStalk(reset);
@@ -15299,14 +15344,18 @@ class OGInfinity {
     }
 
     settingDiv.appendChild(createDOM("hr"));
-    let keys = settingDiv.appendChild(createDOM("div", { style: "display: grid;" }));
-    keys.appendChild(createDOM("h1", {}, this.getTranslatedText(147)));
-    let ptre = keys.appendChild(
+
+    // ---------- PTRE section (dedicated) ----------
+    let ptreSection = settingDiv.appendChild(createDOM("div", { style: "display: grid;" }));
+    ptreSection.appendChild(createDOM("h1", {}, "PTRE settings"));
+
+    // Row 1: Team Key label + input.
+    let ptreKeyRow = ptreSection.appendChild(
       createDOM("span")
         .appendChild(createDOM("a", { href: "https://ptre.chez.gg/", target: "_blank" }, "PTRE"))
         .parentElement.appendChild(document.createTextNode(" Teamkey")).parentElement
     );
-    let ptreInput = ptre.appendChild(
+    let ptreInput = ptreKeyRow.appendChild(
       createDOM("input", {
         type: "password",
         class: "ogl-ptreTeamKey tooltip",
@@ -15314,6 +15363,10 @@ class OGInfinity {
         placeholder: "TM-XXXX-XXXX-XXXX-XXXX",
       })
     );
+
+    settingDiv.appendChild(createDOM("hr"));
+    let keys = settingDiv.appendChild(createDOM("div", { style: "display: grid;" }));
+    keys.appendChild(createDOM("h1", {}, this.getTranslatedText(147)));
     let pantry = keys.appendChild(
       createDOM("span")
         .appendChild(createDOM("a", { href: "https://getpantry.cloud/", target: "_blank" }, "Pantry"))

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -15361,11 +15361,23 @@ class OGInfinity {
     let ptreSection = settingDiv.appendChild(createDOM("div", { style: "display: grid;" }));
     ptreSection.appendChild(createDOM("h1", {}, "PTRE settings"));
 
-    // Row 1: Team Key label + input.
-    let ptreKeyRow = ptreSection.appendChild(
-      createDOM("span")
-        .appendChild(createDOM("a", { href: "https://ptre.chez.gg/", target: "_blank" }, "PTRE"))
-        .parentElement.appendChild(document.createTextNode(" Teamkey")).parentElement
+    const savedPtreKey = this.json.options.ptreTK;
+    const ptreEnabled =
+      typeof savedPtreKey === "string" && savedPtreKey.startsWith("TM") && savedPtreKey.replace(/-/g, "").length === 18;
+
+    let ptreKeyRow = ptreSection.appendChild(createDOM("span"));
+    ptreKeyRow.appendChild(createDOM("a", { href: "https://ptre.chez.gg/", target: "_blank" }, "PTRE"));
+    ptreKeyRow.appendChild(document.createTextNode(" Teamkey "));
+    ptreKeyRow.appendChild(
+      createDOM(
+        "span",
+        {
+          style: ptreEnabled
+            ? "font-size: 10px; font-weight: 700; padding: 1px 6px; border-radius: 4px; letter-spacing: 0.3px; background: #1f7a3a; color: #dff5e2;"
+            : "font-size: 10px; font-weight: 700; padding: 1px 6px; border-radius: 4px; letter-spacing: 0.3px; background: #5a2a2a; color: #f5dcdc;",
+        },
+        ptreEnabled ? "ENABLED" : "DISABLED"
+      )
     );
     let ptreInput = ptreKeyRow.appendChild(
       createDOM("input", {

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -15396,6 +15396,41 @@ class OGInfinity {
       ptreInput.type = "password";
     });
 
+    // Systems count row in PTRE settings. Live query against `dataHelper.galaxyStorage`
+    // via the page->content bridge - the value reflects the current in-memory store
+    // at the moment the settings modal opens.
+    let ptreLastApiUpdateRow = ptreSection.appendChild(createDOM("span"));
+    ptreLastApiUpdateRow.textContent = "Last API update: ...";
+    let ptreSystemCountRow = ptreSection.appendChild(createDOM("span"));
+    ptreSystemCountRow.textContent = "Systems count: ...";
+    let ptreStorageSizeRow = ptreSection.appendChild(createDOM("span"));
+    ptreStorageSizeRow.textContent = "Storage size: ...";
+    pageContextRequest("ptre", "galaxyInfo")
+      .then((r) => {
+        const n = r?.response?.systemCount ?? 0;
+        ptreSystemCountRow.textContent = `Systems count: ${n}`;
+        const ts = r?.response?.lastGalaxyUpdateTS ?? -1;
+        if (ts > 0) {
+          const d = new Date(ts * 1000);
+          const formatted = d.toLocaleDateString(undefined, { day: "numeric", month: "short", year: "numeric" });
+          ptreLastApiUpdateRow.textContent = `Last API update: ${formatted}`;
+        } else {
+          ptreLastApiUpdateRow.textContent = "Last API update: never";
+        }
+        const bytes = r?.response?.storageBytes ?? 0;
+        let sizeStr;
+        if (bytes >= 1024 * 1024) sizeStr = `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+        else if (bytes >= 1024) sizeStr = `${(bytes / 1024).toFixed(1)} KB`;
+        else sizeStr = `${bytes} B`;
+        ptreStorageSizeRow.textContent = `Storage size: ${sizeStr}`;
+      })
+      .catch((err) => {
+        console.warn("[OGI][PTRE] galaxyInfo failed", err);
+        ptreSystemCountRow.textContent = "Systems count: (unavailable)";
+        ptreLastApiUpdateRow.textContent = "Last API update: (unavailable)";
+        ptreStorageSizeRow.textContent = "Storage size: (unavailable)";
+      });
+
     settingDiv.appendChild(createDOM("hr"));
     let keys = settingDiv.appendChild(createDOM("div", { style: "display: grid;" }));
     keys.appendChild(createDOM("h1", {}, this.getTranslatedText(147)));

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -15375,6 +15375,14 @@ class OGInfinity {
         placeholder: "TM-XXXX-XXXX-XXXX-XXXX",
       })
     );
+    // Reveal the team key while the input is focused so the user can verify what they
+    // typed. Blur restores the masked view.
+    ptreInput.addEventListener("focus", () => {
+      ptreInput.type = "text";
+    });
+    ptreInput.addEventListener("blur", () => {
+      ptreInput.type = "password";
+    });
 
     settingDiv.appendChild(createDOM("hr"));
     let keys = settingDiv.appendChild(createDOM("div", { style: "display: grid;" }));

--- a/src/util/translate.js
+++ b/src/util/translate.js
@@ -2249,6 +2249,14 @@ const translation = Object.freeze({
       tr: undefined,
       br: undefined,
     },
+    226: {
+      de: "Galaxie-Speicher",
+      en: "Galaxy Storage",
+      es: "Almacenamiento de galaxia",
+      fr: "Stockage de la Galaxie",
+      tr: "Galaksi depolama",
+      br: "Armazenamento de galáxia",
+    },
   },
 });
 


### PR DESCRIPTION
# PTRE galaxy diff on top of `galaxyStorage`

> ⚠️ **Blocked on [PR #533 – Add per-position galaxy snapshot store (`galaxyStorage`)](https://github.com/ogame-infinity/web-extension/pull/533)**.  
> This branch is rebased onto `feat/galaxy_storage`. Do not merge before #533 – the base provides the `galaxyStorage` field, its dedicated `ogi-galaxy-<UNIVERSE>` key, and the `flushGalaxyStorage()` / `scheduleGalaxyStorageFlush()` helpers this PR consumes.

## What's in this PR

- `scan()` reads previous system state from `galaxyStorage[g][s]`, diffs against the incoming positions, emits the changed slots to PTRE, and writes the fresh system back via `scheduleGalaxyStorageFlush()`.
- First-ever visit of a system force-emits all 15 positions so PTRE learns the initial shape.
- Departure detection: positions that flip from occupied to empty flag the prior owner's coord as deleted in `scannedPlanets` (unchanged sidebar semantics).
- Fix: own-planet rows now correctly detected in the galaxy scan.
- Small settings-UI touches: enabled/disabled badge next to the PTRE team-key label; input reveals on focus, re-masks on blur.

## Explicitly out of scope

- **No parallel storage.** `scannedSystems` and its co-tenancy in `ogi-scanned-<u>` are gone. `galaxyStorage` is the sole source of truth.
- **No garbage collector.** Weekly API wipe already caps age.
- **No dedicated PTRE Clear button.** Reset lives under **Settings > Data management > Stockage galaxie** (from #533).

## Test plan

1. Load OGame with a PTRE key set → `update()` populates `galaxyStorage` from `universe.xml`.
2. Open a galaxy view → `scan()` emits full system as "first visit" payload; `galaxyStorage[g][s]` populated with `ts = serverTime`.
3. Re-visit with a change → payload contains only the changed slot.
4. Remove the PTRE key → `scan()` still updates `scannedPlanets` / `scannedPlayers` but skips PTRE emission and `galaxyStorage` writes.
5. Reset via **Data management > Stockage galaxie** → next boot rebuilds from API, next galaxy visit re-emits.
6. `browser.storage.local.get(null)` shows a single `ogi-galaxy-<UNIVERSE>` key, no `ogi-ptre-gala-*` residuals.

## Follow-ups

- Cosmetic PR off master with the two UI touches (badge + focus reveal) - independent, non-blocking.
- Later cleanup PR to drop `scannedPlanets` / `scannedPlayers` and `ogi-scanned-<UNIVERSE>` once all readers migrate.