### PR TITLE
feat(storage): create new dedicated galaxy storage

### DIFF
--- a/src/ctxcontent/data-helper.js
+++ b/src/ctxcontent/data-helper.js
@@ -1,5 +1,6 @@
 import { getLogger } from "../util/logger.js";
 import { COORDINATE_PLANET, toNumber as toNumberCoordinate } from "../util/ogame.coordinate.js";
+import OGIData from "../util/OGIData.js";
 import { getAlliances } from "./helpers/universe.alliances.js";
 import { getPlayersHighscore, NAN_HIGHSCORE } from "./helpers/universe.highscore.js";
 import { getPlanets } from "./helpers/universe.planets.js";
@@ -15,19 +16,41 @@ export class DataHelper {
 
   init() {
     return new Promise(async (resolve, reject) => {
-      chrome.storage.local.get("ogi-scanned-" + this.universe, (result) => {
-        let json;
-        try {
-          json = JSON.parse(result["ogi-scanned-" + this.universe]);
-        } catch (error) {
-          json = {};
+      chrome.storage.local.get(
+        ["ogi-scanned-" + this.universe, "ogi-galaxy-" + this.universe],
+        (result) => {
+          let scannedJson;
+          try {
+            scannedJson = JSON.parse(result["ogi-scanned-" + this.universe]);
+          } catch (error) {
+            scannedJson = {};
+          }
+          this.scannedPlanets = scannedJson.scannedPlanets || {};
+          this.scannedPlayers = scannedJson.scannedPlayers || {};
+          this.lastPlayersUpdate = this.lastPlayersUpdate || new Date(0);
+          this.lastPlanetsUpdate = this.lastPlayersUpdate || new Date(0);
+
+          // Galaxy storage lives in its own key so hot writes (from scan()) stay small
+          // and never drag the big `[UNIVERSE]` blob along. The dedicated key is the
+          // SOLE source of truth; do not fall back to `this.galaxyStorage` /
+          // `this.lastGalaxyUpdateTS` values inherited from the big blob via
+          // Object.assign in main() - a manual reset would be defeated otherwise.
+          let galaxyJson;
+          try {
+            galaxyJson = JSON.parse(result["ogi-galaxy-" + this.universe]);
+          } catch (error) {
+            galaxyJson = null;
+          }
+          if (galaxyJson && typeof galaxyJson === "object") {
+            this.galaxyStorage = galaxyJson.galaxyStorage || {};
+            this.lastGalaxyUpdateTS = galaxyJson.lastGalaxyUpdateTS ?? -1;
+          } else {
+            this.galaxyStorage = {};
+            this.lastGalaxyUpdateTS = -1;
+          }
+          resolve();
         }
-        this.scannedPlanets = json.scannedPlanets || {};
-        this.scannedPlayers = json.scannedPlayers || {};
-        this.lastPlayersUpdate = this.lastPlayersUpdate || new Date(0);
-        this.lastPlanetsUpdate = this.lastPlayersUpdate || new Date(0);
-        resolve();
-      });
+      );
     });
   }
 
@@ -223,6 +246,31 @@ export class DataHelper {
     });
   }
 
+  // Immediate persistence of galaxyStorage into its dedicated key. Callers that
+  // update this store frequently (e.g. scan() from the PTRE PR) should prefer
+  // scheduleGalaxyStorageFlush() to coalesce writes.
+  flushGalaxyStorage() {
+    if (this._galaxyFlushTimer) {
+      clearTimeout(this._galaxyFlushTimer);
+      this._galaxyFlushTimer = null;
+    }
+    chrome.storage.local.set({
+      [`ogi-galaxy-${this.universe}`]: JSON.stringify({
+        galaxyStorage: this.galaxyStorage,
+        lastGalaxyUpdateTS: this.lastGalaxyUpdateTS,
+      }),
+    });
+  }
+
+  // Debounced flush. Multiple calls within `delayMs` collapse into one write.
+  scheduleGalaxyStorageFlush(delayMs = 2000) {
+    if (this._galaxyFlushTimer) return;
+    this._galaxyFlushTimer = setTimeout(() => {
+      this._galaxyFlushTimer = null;
+      this.flushGalaxyStorage();
+    }, delayMs);
+  }
+
   async update() {
     const logger = getLogger("updateUniverse");
 
@@ -236,12 +284,77 @@ export class DataHelper {
     let players = {};
 
     try {
-      const [playersScore, playersInformation, playerPlanets, allianceInformation] = await Promise.all([
+      const [playersScore, playersInformation, planetsSnapshot, allianceInformation] = await Promise.all([
         getPlayersHighscore(this.universe),
         getPlayers(this.universe),
         getPlanets(this.universe),
         getAlliances(this.universe),
       ]);
+
+      // ----------------------------------------------
+      // Galaxy Storage Update (snapshot of all planets in the universe)
+      // universe.xml is updated ONCE A WEEK (except for migrations, merge, etc)
+      // Only update this structure if the API has been updated
+      // Otherwise, it is purely useless (and we wont keep PTRE tracking data)
+      // The build is also gated on the presence of a PTRE team key in settings (might and should change)
+
+      const galaxyBuildStart = performance.now();
+      const playerPlanets = planetsSnapshot.planets;
+      const planetList = planetsSnapshot.planetList;
+      const newGalaxyTs = planetsSnapshot.timestamp;
+      const previousGalaxyTs = this.lastGalaxyUpdateTS ?? -1;
+      const galaxyUpdateNeeded = Number.isFinite(newGalaxyTs) && newGalaxyTs > previousGalaxyTs;
+      const ptreKeyPresent = !!(OGIData.options && OGIData.options.ptreTK);
+
+      logger.debug(`[galaxyStorage] prevTs=${previousGalaxyTs} newTS=${newGalaxyTs} => ${galaxyUpdateNeeded ? "OPEN" : "SKIP"} | PTRE=${ptreKeyPresent}`);
+
+      if (galaxyUpdateNeeded && ptreKeyPresent) {
+        // Do not use current storage if API was really updated
+        this.galaxyStorage = {};
+        let updatedSystemsCount = 0;
+        let updatedPlanetsCount = 0;
+        let updatedMoonsCount = 0;
+
+        planetList.forEach((planet) => {
+          const parts = (planet.coords || "").split(":");
+          if (parts.length !== 3) return;
+          const g = parts[0];
+          const s = parts[1];
+          const p = parts[2];
+
+          if (!this.galaxyStorage[g]) {
+            this.galaxyStorage[g] = {};
+          }
+          if (!this.galaxyStorage[g][s]) {
+            this.galaxyStorage[g][s] = {};
+            for (let i = 1; i <= 15; i++) {
+              this.galaxyStorage[g][s][String(i)] = {
+                playerId: -1,
+                planetId: -1,
+                moonId: -1,
+                ts: newGalaxyTs,
+              };
+            }
+            updatedSystemsCount++;
+          }
+
+          this.galaxyStorage[g][s][p] = {
+            playerId: planet.player,
+            planetId: planet.id,
+            moonId: planet.moon ? planet.moon : -1,
+            ts: newGalaxyTs,
+          };
+          updatedPlanetsCount++;
+          if (planet.moon) updatedMoonsCount++;
+        });
+
+        this.lastGalaxyUpdateTS = newGalaxyTs;
+        const galaxyBuildDurationMs = Math.round(performance.now() - galaxyBuildStart);
+        logger.debug(`[galaxyStorage] New data: systems=${updatedSystemsCount} planets=${updatedPlanetsCount} moons=${updatedMoonsCount} | TS=${this.lastGalaxyUpdateTS} | Took ${galaxyBuildDurationMs}ms`);
+        this.flushGalaxyStorage();
+      }
+      // End Galaxy Storage Update
+      // --------------------------------------------
 
       // -- TopScore --------------------------------
       /** @type {HighscoreTypes | undefined} */

--- a/src/ctxcontent/data-helper.js
+++ b/src/ctxcontent/data-helper.js
@@ -1,6 +1,5 @@
 import { getLogger } from "../util/logger.js";
 import { COORDINATE_PLANET, toNumber as toNumberCoordinate } from "../util/ogame.coordinate.js";
-import OGIData from "../util/OGIData.js";
 import { getAlliances } from "./helpers/universe.alliances.js";
 import { getPlayersHighscore, NAN_HIGHSCORE } from "./helpers/universe.highscore.js";
 import { getPlanets } from "./helpers/universe.planets.js";
@@ -12,6 +11,8 @@ export class DataHelper {
     this.names = {};
     this.topScore = 0;
     this.loading = false;
+    // Transient cache of the last successful universe.xml fetch. Stripped from the persisted blob in processData().
+    this._galaxySnapshot = null;
   }
 
   init() {
@@ -288,6 +289,72 @@ export class DataHelper {
     }, delayMs);
   }
 
+  // Rebuild `galaxyStorage` from the cached API snapshot. The PTRE key is
+  // never stored on DataHelper; callers must supply it (same pattern as scan()).
+  // No-op when the key is missing, when no snapshot has been cached yet, or
+  // when the cached snapshot is not strictly newer than the persisted state.
+  rebuildGalaxyStorage(ptreKey) {
+    const logger = getLogger("updateUniverse");
+    if (!ptreKey) {
+      logger.debug(`[galaxyStorage] rebuild skipped: no PTRE key`);
+      return;
+    }
+    if (!this._galaxySnapshot) {
+      logger.debug(`[galaxyStorage] rebuild skipped: no cached snapshot`);
+      return;
+    }
+    const newGalaxyTs = this._galaxySnapshot.timestamp;
+    const previousGalaxyTs = this.lastGalaxyUpdateTS ?? -1;
+    if (!Number.isFinite(newGalaxyTs) || newGalaxyTs <= previousGalaxyTs) {
+      logger.debug(`[galaxyStorage] rebuild skipped: prevTs=${previousGalaxyTs} newTS=${newGalaxyTs}`);
+      return;
+    }
+
+    const galaxyBuildStart = performance.now();
+    this.galaxyStorage = {};
+    let updatedSystemsCount = 0;
+    let updatedPlanetsCount = 0;
+    let updatedMoonsCount = 0;
+
+    this._galaxySnapshot.planetList.forEach((planet) => {
+      const parts = (planet.coords || "").split(":");
+      if (parts.length !== 3) return;
+      const g = parts[0];
+      const s = parts[1];
+      const p = parts[2];
+
+      if (!this.galaxyStorage[g]) {
+        this.galaxyStorage[g] = {};
+      }
+      if (!this.galaxyStorage[g][s]) {
+        this.galaxyStorage[g][s] = {};
+        for (let i = 1; i <= 15; i++) {
+          this.galaxyStorage[g][s][String(i)] = {
+            playerId: -1,
+            planetId: -1,
+            moonId: -1,
+            ts: newGalaxyTs,
+          };
+        }
+        updatedSystemsCount++;
+      }
+
+      this.galaxyStorage[g][s][p] = {
+        playerId: planet.player,
+        planetId: planet.id,
+        moonId: planet.moon ? planet.moon : -1,
+        ts: newGalaxyTs,
+      };
+      updatedPlanetsCount++;
+      if (planet.moon) updatedMoonsCount++;
+    });
+
+    this.lastGalaxyUpdateTS = newGalaxyTs;
+    const galaxyBuildDurationMs = Math.round(performance.now() - galaxyBuildStart);
+    logger.debug(`[galaxyStorage] New data: systems=${updatedSystemsCount} planets=${updatedPlanetsCount} moons=${updatedMoonsCount} | TS=${this.lastGalaxyUpdateTS} | Took ${galaxyBuildDurationMs}ms`);
+    this.flushGalaxyStorage();
+  }
+
   async update() {
     const logger = getLogger("updateUniverse");
 
@@ -309,68 +376,16 @@ export class DataHelper {
       ]);
 
       // ----------------------------------------------
-      // Galaxy Storage Update (snapshot of all planets in the universe)
-      // universe.xml is updated ONCE A WEEK (except for migrations, merge, etc)
-      // Only update this structure if the API has been updated
-      // Otherwise, it is purely useless (and we wont keep PTRE tracking data)
-      // The build is also gated on the presence of a PTRE team key in settings (might and should change)
-
-      const galaxyBuildStart = performance.now();
+      // Galaxy Snapshot Cache (planets fetched from universe.xml, once a week)
+      // The actual `galaxyStorage` rebuild is deferred to rebuildGalaxyStorage(ptreKey)
+      // so the PTRE team key never crosses into the content-script context.
       const playerPlanets = planetsSnapshot.planets;
-      const planetList = planetsSnapshot.planetList;
-      const newGalaxyTs = planetsSnapshot.timestamp;
-      const previousGalaxyTs = this.lastGalaxyUpdateTS ?? -1;
-      const galaxyUpdateNeeded = Number.isFinite(newGalaxyTs) && newGalaxyTs > previousGalaxyTs;
-      const ptreKeyPresent = !!(OGIData.options && OGIData.options.ptreTK);
-
-      logger.debug(`[galaxyStorage] prevTs=${previousGalaxyTs} newTS=${newGalaxyTs} => ${galaxyUpdateNeeded ? "OPEN" : "SKIP"} | PTRE=${ptreKeyPresent}`);
-
-      if (galaxyUpdateNeeded && ptreKeyPresent) {
-        // Do not use current storage if API was really updated
-        this.galaxyStorage = {};
-        let updatedSystemsCount = 0;
-        let updatedPlanetsCount = 0;
-        let updatedMoonsCount = 0;
-
-        planetList.forEach((planet) => {
-          const parts = (planet.coords || "").split(":");
-          if (parts.length !== 3) return;
-          const g = parts[0];
-          const s = parts[1];
-          const p = parts[2];
-
-          if (!this.galaxyStorage[g]) {
-            this.galaxyStorage[g] = {};
-          }
-          if (!this.galaxyStorage[g][s]) {
-            this.galaxyStorage[g][s] = {};
-            for (let i = 1; i <= 15; i++) {
-              this.galaxyStorage[g][s][String(i)] = {
-                playerId: -1,
-                planetId: -1,
-                moonId: -1,
-                ts: newGalaxyTs,
-              };
-            }
-            updatedSystemsCount++;
-          }
-
-          this.galaxyStorage[g][s][p] = {
-            playerId: planet.player,
-            planetId: planet.id,
-            moonId: planet.moon ? planet.moon : -1,
-            ts: newGalaxyTs,
-          };
-          updatedPlanetsCount++;
-          if (planet.moon) updatedMoonsCount++;
-        });
-
-        this.lastGalaxyUpdateTS = newGalaxyTs;
-        const galaxyBuildDurationMs = Math.round(performance.now() - galaxyBuildStart);
-        logger.debug(`[galaxyStorage] New data: systems=${updatedSystemsCount} planets=${updatedPlanetsCount} moons=${updatedMoonsCount} | TS=${this.lastGalaxyUpdateTS} | Took ${galaxyBuildDurationMs}ms`);
-        this.flushGalaxyStorage();
-      }
-      // End Galaxy Storage Update
+      this._galaxySnapshot = {
+        planetList: planetsSnapshot.planetList,
+        timestamp: planetsSnapshot.timestamp,
+      };
+      logger.debug(`[galaxyStorage] snapshot cached (ts=${planetsSnapshot.timestamp})`);
+      // End Galaxy Snapshot Cache
       // --------------------------------------------
 
       // -- TopScore --------------------------------

--- a/src/ctxcontent/data-helper.js
+++ b/src/ctxcontent/data-helper.js
@@ -254,11 +254,27 @@ export class DataHelper {
       clearTimeout(this._galaxyFlushTimer);
       this._galaxyFlushTimer = null;
     }
-    chrome.storage.local.set({
-      [`ogi-galaxy-${this.universe}`]: JSON.stringify({
+    const logger = getLogger("galaxyStorage");
+    const key = `ogi-galaxy-${this.universe}`;
+    let payload;
+    try {
+      payload = JSON.stringify({
         galaxyStorage: this.galaxyStorage,
         lastGalaxyUpdateTS: this.lastGalaxyUpdateTS,
-      }),
+      });
+    } catch (err) {
+      this._lastFlushError = `serialize: ${err && err.message ? err.message : err}`;
+      logger.error(`[${key}] serialize failed: ${this._lastFlushError}`);
+      return;
+    }
+    chrome.storage.local.set({ [key]: payload }, () => {
+      const lastError = chrome.runtime.lastError;
+      if (lastError) {
+        this._lastFlushError = `write (${payload.length}B): ${lastError.message}`;
+        logger.error(`[${key}] write failed: ${this._lastFlushError}`);
+        return;
+      }
+      this._lastFlushError = null;
     });
   }
 

--- a/src/ctxcontent/data-helper.js
+++ b/src/ctxcontent/data-helper.js
@@ -270,7 +270,8 @@ export class DataHelper {
     chrome.storage.local.set({ [key]: payload }, () => {
       const lastError = chrome.runtime.lastError;
       if (lastError) {
-        this._lastFlushError = `write (${payload.length}B): ${lastError.message}`;
+        const bytes = new Blob([payload]).size;
+        this._lastFlushError = `write (${bytes}B): ${lastError.message}`;
         logger.error(`[${key}] write failed: ${this._lastFlushError}`);
         return;
       }

--- a/src/ctxcontent/helpers/universe.planets.js
+++ b/src/ctxcontent/helpers/universe.planets.js
@@ -3,11 +3,18 @@ import { requestOGamePlanets } from "../services/request.ogamePlanets.js";
 /**
  *
  * @param {string} universe
- * @return Promise<PlayerPlanetsMap>
+ * @return Promise<PlanetsSnapshot>
  */
 export function getPlanets(universe) {
-  const planetResponse = requestOGamePlanets(universe).then(toPlanetResponse);
-  return planetResponse.then(toPlanetMap);
+  return requestOGamePlanets(universe).then((response) => {
+    const timestamp = parseInt(response.document.documentElement.getAttribute("timestamp"), 10);
+    const planetList = toPlanetResponse(response);
+    return {
+      planets: toPlanetMap(planetList),
+      planetList: planetList,
+      timestamp: Number.isFinite(timestamp) ? timestamp : -1,
+    };
+  });
 }
 
 /**
@@ -48,6 +55,13 @@ function toPlanetResponse(response) {
 
 /**
  * @typedef {Map<number, PlanetResponse[]>} PlayerPlanetsMap
+ */
+
+/**
+ * @typedef {Object} PlanetsSnapshot
+ * @property {PlayerPlanetsMap} planets - planets grouped by player id
+ * @property {PlanetResponse[]} planetList - flat list of every planet in the universe
+ * @property {number} timestamp - universe.xml root `timestamp` attribute (unix seconds), -1 if missing
  */
 
 /**

--- a/src/ctxcontent/index.js
+++ b/src/ctxcontent/index.js
@@ -43,6 +43,7 @@ function processData() {
         delete tempSaveData.lastGalaxyUpdateTS;
         // Runtime-only setTimeout id; must not survive a reload.
         delete tempSaveData._galaxyFlushTimer;
+        delete tempSaveData._lastFlushError;
 
         chrome.storage.local.set({ [UNIVERSE]: tempSaveData }, function (at) {});
       });

--- a/src/ctxcontent/index.js
+++ b/src/ctxcontent/index.js
@@ -36,6 +36,11 @@ function processData() {
         tempSaveData.lastUpdate = universes[UNIVERSE].lastUpdate.toJSON();
         tempSaveData.lastPlanetsUpdate = universes[UNIVERSE].lastPlanetsUpdate.toJSON();
         tempSaveData.lastPlayersUpdate = universes[UNIVERSE].lastPlayersUpdate.toJSON();
+        // galaxyStorage lives in its own key `ogi-galaxy-<UNIVERSE>`; don't
+        // duplicate it into the big blob or a manual reset gets resurrected
+        // on next boot via Object.assign in main().
+        delete tempSaveData.galaxyStorage;
+        delete tempSaveData.lastGalaxyUpdateTS;
 
         chrome.storage.local.set({ [UNIVERSE]: tempSaveData }, function (at) {});
       });
@@ -91,6 +96,13 @@ window.addEventListener(
 
 document.addEventListener("ogi-clear", function (e) {
   dataHelper.clearData();
+});
+document.addEventListener("ogi-galaxy-clear", function (e) {
+  if (dataHelper) {
+    dataHelper.galaxyStorage = {};
+    dataHelper.lastGalaxyUpdateTS = -1;
+  }
+  chrome.storage.local.remove(`ogi-galaxy-${UNIVERSE}`);
 });
 document.addEventListener("ogi-notification", function (e) {
   const msg = Object.assign({ iconUrl: "assets/images/logo128.png" }, e.detail);

--- a/src/ctxcontent/index.js
+++ b/src/ctxcontent/index.js
@@ -41,6 +41,8 @@ function processData() {
         // on next boot via Object.assign in main().
         delete tempSaveData.galaxyStorage;
         delete tempSaveData.lastGalaxyUpdateTS;
+        // Runtime-only setTimeout id; must not survive a reload.
+        delete tempSaveData._galaxyFlushTimer;
 
         chrome.storage.local.set({ [UNIVERSE]: tempSaveData }, function (at) {});
       });

--- a/src/ctxcontent/index.js
+++ b/src/ctxcontent/index.js
@@ -7,10 +7,20 @@ import { DataHelper } from "./data-helper.js";
 
 const mainLogger = getLogger();
 
+// PTRE team key held in the content script only for the lifetime of the tab.
+// Pushed in from the page via `ptre.setTeamKey`; never persisted here.
+let pendingPtreKey = "";
+
 contentContextInit({
   ptre: {
     galaxy: function (changes, ptreKey = null, serverTime = null) {
       return dataHelper.scan(changes, ptreKey, serverTime);
+    },
+    setTeamKey: function (key) {
+      pendingPtreKey = typeof key === "string" ? key : "";
+      if (pendingPtreKey && dataHelper && dataHelper._galaxySnapshot) {
+        dataHelper.rebuildGalaxyStorage(pendingPtreKey);
+      }
     },
   },
   messages: {
@@ -32,6 +42,9 @@ function processData() {
   universes[UNIVERSE].init().then(() => {
     try {
       universes[UNIVERSE].update().then(() => {
+        if (pendingPtreKey && universes[UNIVERSE]._galaxySnapshot) {
+          universes[UNIVERSE].rebuildGalaxyStorage(pendingPtreKey);
+        }
         let tempSaveData = { ...universes[UNIVERSE] };
         tempSaveData.lastUpdate = universes[UNIVERSE].lastUpdate.toJSON();
         tempSaveData.lastPlanetsUpdate = universes[UNIVERSE].lastPlanetsUpdate.toJSON();
@@ -44,6 +57,7 @@ function processData() {
         // Runtime-only setTimeout id; must not survive a reload.
         delete tempSaveData._galaxyFlushTimer;
         delete tempSaveData._lastFlushError;
+        delete tempSaveData._galaxySnapshot;
 
         chrome.storage.local.set({ [UNIVERSE]: tempSaveData }, function (at) {});
       });

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -15038,6 +15038,14 @@ class OGInfinity {
         <input type="checkbox" id="scan" name="scan">`
       )
     );
+    let galaxyBox = dataManagement.appendChild(
+      this.createDOM(
+        "div",
+        { class: "ogi-checkbox" },
+        `<label for="galaxy_reset">${this.getTranslatedText(226)}</label>
+        <input type="checkbox" id="galaxy_reset" name="galaxy_reset">`
+      )
+    );
     let OptionsBox = dataManagement.appendChild(
       this.createDOM(
         "div",
@@ -15378,6 +15386,9 @@ class OGInfinity {
         json.spies = {};
         if (scanBox.children[1].checked) {
           document.dispatchEvent(new CustomEvent("ogi-clear"));
+        }
+        if (galaxyBox.children[1].checked) {
+          document.dispatchEvent(new CustomEvent("ogi-galaxy-clear"));
         }
         if (purgeBox.children[1].checked) {
           this.purgeLocalStorage();

--- a/src/util/translate.js
+++ b/src/util/translate.js
@@ -2249,6 +2249,14 @@ const translation = Object.freeze({
       tr: undefined,
       br: undefined,
     },
+    226: {
+      de: "Galaxie-Speicher",
+      en: "Galaxy Storage",
+      es: "Almacenamiento de galaxia",
+      fr: "Stockage de la Galaxie",
+      tr: "Galaksi depolama",
+      br: "Armazenamento de galáxia",
+    },
   },
 });
 


### PR DESCRIPTION
# Add per-position galaxy snapshot store (`galaxyStorage`)

Requirement for: https://github.com/ogame-infinity/web-extension/pull/531

## Why?

- Today we can only look up "who owns coord `2:5:96`?" by iterating every player's planet list - the existing storage is player-indexed.
- This PR adds `galaxyStorage`, a coord-indexed map (`galaxy > system > position`) built from `universe.xml`.
- Unlocks proper `O(1)` coord lookups for anything that needs them - starting with the PTRE reset PR (see below).

## Shape

```jsonc
{
    "<galaxyId>": {
        "<systemId>": {
            "<position>": { "playerId": -1, "planetId": -1, "moonId": -1, "ts": <unix> }
            // 15 positions per system, empties kept as -1 so slot presence is meaningful
        }
    }
}
```

## Details

- Adds `galaxyStorage`, a coord-indexed snapshot of the universe (`galaxy > system > position`) built from `universe.xml`, enabling `O(1)` planet/moon lookups by coord.
- Persisted under a dedicated `chrome.storage.local` key `ogi-galaxy-<UNIVERSE>` with immediate and debounced flush helpers => no performance impact.
- Rebuild is gated on API `timestamp` bump + PTRE team key (at least, for now).
- New reset entry under *Settings > Data management > Stockage galaxie*. Companion PR will migrate `scan()` on top of this store.