### PR TITLE
fix fleetStatus cosmetics in the fleetdispatch page

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -564,6 +564,10 @@ input[type="password"]::selection {
   opacity: 1;
 }
 
+.fleetStatus #slots {
+  display: block !important;
+}
+
 .fleetStatus .fleft:first-of-type .advice span {
   margin-right: 5px;
   color: #9099a3;
@@ -575,6 +579,12 @@ input[type="password"]::selection {
   font-weight: 800;
   color: #ddd;
   line-height: 27px !important;
+}
+
+.fleetStatus .fleft,
+.fleetStatus .fleft:first-of-type .bonus:first-of-type,
+.fleetStatus .fleft .ogk-label.ogi-info {
+  margin-left: 10px;
 }
 
 #shipsChosen .sprite.recycler,


### PR DESCRIPTION
fixes v13 little mess in fleetStatus bar

From this:
<img width="651" height="36" alt="Captura de pantalla_2026-08-08_01-19-01" src="https://github.com/user-attachments/assets/c16cf3aa-b3d1-4fa3-9693-d2df519100ef" />

To this:
<img width="650" height="37" alt="Captura de pantalla_2026-08-08_01-04-33" src="https://github.com/user-attachments/assets/db5e6477-e75a-4931-9b71-41ddd19a6777" />

