### PR TITLE
 Fix: spy report row hides as deleted even when deletion failed

### DIFF
--- a/src/ctxcontent/services/analyzer/SpyMessagesAnalyzer.js
+++ b/src/ctxcontent/services/analyzer/SpyMessagesAnalyzer.js
@@ -23,7 +23,6 @@ class SpyMessagesAnalyzer {
   #tabId;
   #onTrash = false;
   reportsToDelete = [];
-  #countRestoration = 0;
   #spyReports = [];
 
   constructor() {
@@ -640,18 +639,10 @@ class SpyMessagesAnalyzer {
         }
       } else if (document.querySelector('.messagesTrashcanBtns button.custom_btn[disabled="disabled"]')) {
         const optColRestoreButton = createDOM("button", { class: "icon icon_restore" });
-        optColRestoreButton.getAttribute("data-id", report.id);
+        optColRestoreButton.setAttribute("data-id", report.id);
 
         optColRestoreButton.addEventListener("click", () => {
-          bodyRow.classList.add("hide");
-          this.#countRestoration++;
-          new Promise((r) => setTimeout(r, 300)).then(() => {
-            this.#countRestoration--;
-            if (!document.querySelector(`.msgRestoreBtn[data-message-id="${report.id}"]`)) return;
-            document.querySelector(`.msgRestoreBtn[data-message-id="${report.id}"]`).click();
-          });
-          new Promise((r) => setTimeout(r, 800)).then(() => {
-            if (this.#countRestoration > 0) return;
+          this.#flagDeleted([report.id], [bodyRow], () => {
             window.dispatchEvent(new CustomEvent("ogi-spyTableReload"));
           });
         });
@@ -780,38 +771,25 @@ class SpyMessagesAnalyzer {
     this.deleteReports();
   }
 
-  deleteReports() {
-    this.#logger.debug("Delete messages", this.reportsToDelete);
-
-    if (this.reportsToDelete.length === 0) return;
-
-    // Take everything queued right now as a single batch. Manual clicks queue one report
-    // at a time and call deleteReports() immediately, so they end up as a batch of one.
-    // The auto-delete pass queues several reports and calls deleteReports() once after
-    // building the whole table, so those go out together as one request.
-    const batch = this.reportsToDelete;
-    this.reportsToDelete = [];
-
-    const messageIds = batch.map(({ report }) => report.id);
-    this.#logger.debug("Messages to be deleted", messageIds);
-
-    // Optimistic UI: hide the rows immediately instead of waiting for server confirmation.
-    // ogame.messages.flagDeleted() has been confirmed to work safely with a detached element
-    // (it looks up the row and any open dialog by data-msg-id itself, and no-ops harmlessly
-    // if it doesn't find them), so the deletion itself is reliable - this only guards against
-    // genuinely unexpected failures (a thrown error, or no server confirmation at all).
-    batch.forEach(({ row }) => row.classList.add("hide"));
-
+  // Shared by delete and restore: the game reuses the same ogame.messages.flagDeleted()
+  // endpoint for both actions (toggles the message's trashed state), and it's been confirmed
+  // to work safely with a detached element regardless of whether the real button is in the
+  // DOM - it looks up the row and any open dialog by data-msg-id itself, and no-ops harmlessly
+  // if it doesn't find them. rows are hidden optimistically and only put back if something
+  // genuinely goes wrong (thrown error, or no server confirmation within 10s).
+  #flagDeleted(messageIds, rows, onConfirmed) {
     const obj = this;
 
+    rows.forEach((row) => row.classList.add("hide"));
+
     const revert = (reason) => {
-      obj.#logger.warn(`Deletion failed for [${messageIds.join(", ")}]: ${reason}`);
-      batch.forEach(({ row }) => row.classList.remove("hide"));
+      obj.#logger.warn(`Action failed for [${messageIds.join(", ")}]: ${reason}`);
+      rows.forEach((row) => row.classList.remove("hide"));
     };
 
     try {
       // ogame.messages.flagDeleted() reads $(obj).data('messageId'), which can be a single
-      // id or an array of ids - passing the whole batch sends one request instead of one
+      // id or an array of ids - passing several at once sends one request instead of one
       // per report.
       const fakeBtn = document.createElement("button");
       $(fakeBtn).data("messageId", messageIds);
@@ -842,15 +820,7 @@ class SpyMessagesAnalyzer {
         return;
       }
 
-      // ogame.messages.flagDeleted() only cleans up the native message row for a single
-      // id - when messageId is an array, it gets stringified straight into the selector
-      // (e.g. ".msg[data-msg-id='123,456']"), which matches nothing. So for a batch, the
-      // server-side deletion succeeds but the native rows never disappear from the list
-      // below. Clean them up ourselves instead of relying on that. Safe to always run:
-      // if the game already removed a row (single-delete case), this is just a no-op.
-      messageIds.forEach((id) => {
-        document.querySelector(`.messagesHolder .msg[data-msg-id='${id}']`)?.remove();
-      });
+      onConfirmed?.();
     };
 
     $(document).on("ajaxSuccess", onAjaxSuccess);
@@ -864,6 +834,35 @@ class SpyMessagesAnalyzer {
       $(document).off("ajaxSuccess", onAjaxSuccess);
       revert("no server confirmation within 10s");
     }, 10000);
+  }
+
+  deleteReports() {
+    this.#logger.debug("Delete messages", this.reportsToDelete);
+
+    if (this.reportsToDelete.length === 0) return;
+
+    // Take everything queued right now as a single batch. Manual clicks queue one report
+    // at a time and call deleteReports() immediately, so they end up as a batch of one.
+    // The auto-delete pass queues several reports and calls deleteReports() once after
+    // building the whole table, so those go out together as one request.
+    const batch = this.reportsToDelete;
+    this.reportsToDelete = [];
+
+    const messageIds = batch.map(({ report }) => report.id);
+    const rows = batch.map(({ row }) => row);
+    this.#logger.debug("Messages to be deleted", messageIds);
+
+    this.#flagDeleted(messageIds, rows, () => {
+      // ogame.messages.flagDeleted() only cleans up the native message row for a single
+      // id - when messageId is an array, it gets stringified straight into the selector
+      // (e.g. ".msg[data-msg-id='123,456']"), which matches nothing. So for a batch, the
+      // server-side deletion succeeds but the native rows never disappear from the list
+      // below. Clean them up ourselves instead of relying on that. Safe to always run:
+      // if the game already removed a row (single-delete case), this is just a no-op.
+      messageIds.forEach((id) => {
+        document.querySelector(`.messagesHolder .msg[data-msg-id='${id}']`)?.remove();
+      });
+    });
   }
 
   #ptreSpy() {

--- a/src/ctxcontent/services/analyzer/SpyMessagesAnalyzer.js
+++ b/src/ctxcontent/services/analyzer/SpyMessagesAnalyzer.js
@@ -839,7 +839,18 @@ class SpyMessagesAnalyzer {
 
       if (xhr?.responseJSON?.status !== "success") {
         revert("server responded with a non-success status");
+        return;
       }
+
+      // ogame.messages.flagDeleted() only cleans up the native message row for a single
+      // id - when messageId is an array, it gets stringified straight into the selector
+      // (e.g. ".msg[data-msg-id='123,456']"), which matches nothing. So for a batch, the
+      // server-side deletion succeeds but the native rows never disappear from the list
+      // below. Clean them up ourselves instead of relying on that. Safe to always run:
+      // if the game already removed a row (single-delete case), this is just a no-op.
+      messageIds.forEach((id) => {
+        document.querySelector(`.messagesHolder .msg[data-msg-id='${id}']`)?.remove();
+      });
     };
 
     $(document).on("ajaxSuccess", onAjaxSuccess);

--- a/src/ctxcontent/services/analyzer/SpyMessagesAnalyzer.js
+++ b/src/ctxcontent/services/analyzer/SpyMessagesAnalyzer.js
@@ -780,38 +780,48 @@ class SpyMessagesAnalyzer {
     this.deleteReports();
   }
 
-deleteReports() {
+  deleteReports() {
     this.#logger.debug("Delete messages", this.reportsToDelete);
 
     if (this.reportsToDelete.length === 0) return;
 
-    const { report, row } = this.reportsToDelete.shift();
-    this.#logger.debug("Messages to be deleted", report.id);
+    // Take everything queued right now as a single batch. Manual clicks queue one report
+    // at a time and call deleteReports() immediately, so they end up as a batch of one.
+    // The auto-delete pass queues several reports and calls deleteReports() once after
+    // building the whole table, so those go out together as one request.
+    const batch = this.reportsToDelete;
+    this.reportsToDelete = [];
+
+    const messageIds = batch.map(({ report }) => report.id);
+    this.#logger.debug("Messages to be deleted", messageIds);
+
+    // Optimistic UI: hide the rows immediately instead of waiting for server confirmation.
+    // ogame.messages.flagDeleted() has been confirmed to work safely with a detached element
+    // (it looks up the row and any open dialog by data-msg-id itself, and no-ops harmlessly
+    // if it doesn't find them), so the deletion itself is reliable - this only guards against
+    // genuinely unexpected failures (a thrown error, or no server confirmation at all).
+    batch.forEach(({ row }) => row.classList.add("hide"));
+
     const obj = this;
 
+    const revert = (reason) => {
+      obj.#logger.warn(`Deletion failed for [${messageIds.join(", ")}]: ${reason}`);
+      batch.forEach(({ row }) => row.classList.remove("hide"));
+    };
+
     try {
-      const deleteBtn = document.querySelector(`.msgDeleteBtn[data-message-id="${report.id}"]`);
-
-      if (deleteBtn) {
-        deleteBtn.click();
-      } else {
-        this.#logger.debug(`Native button not in DOM for report ${report.id}, calling ogame.messages.flagDeleted directly`);
-
-        const fakeBtn = document.createElement("button");
-        fakeBtn.setAttribute("data-message-id", report.id);
-        ogame.messages.flagDeleted(fakeBtn);
-      }
+      // ogame.messages.flagDeleted() reads $(obj).data('messageId'), which can be a single
+      // id or an array of ids - passing the whole batch sends one request instead of one
+      // per report.
+      const fakeBtn = document.createElement("button");
+      $(fakeBtn).data("messageId", messageIds);
+      ogame.messages.flagDeleted(fakeBtn);
     } catch (err) {
-      this.#logger.error(`Failed to delete report ${report.id}`, err);
-
-      new Promise((r) => setTimeout(r, 100)).then(() => {
-        obj.deleteReports();
-      });
-
+      // Something failed synchronously (e.g. the game changed how flagDeleted works).
+      // Undo the optimistic hide right away instead of waiting for a reload.
+      revert(err);
       return;
     }
-
-    const refresh = this.reportsToDelete.length === 0;
 
     let settled = false;
 
@@ -819,35 +829,29 @@ deleteReports() {
       const urlParams = new URLSearchParams(settings.url);
       const requestPayload = new URLSearchParams(settings.data);
 
-      if (xhr?.responseJSON?.status !== "success") return;
       if (urlParams.get("action") !== "flagDeleted") return;
 
-      if (!requestPayload.getAll("messageIds[]").includes(report.id)) {
-        return;
-      }
+      const requestIds = requestPayload.getAll("messageIds[]");
+      if (!messageIds.every((id) => requestIds.includes(String(id)))) return;
 
       settled = true;
       $(document).off("ajaxSuccess", onAjaxSuccess);
 
-      // Only hide the row once the deletion is actually confirmed by the server.
-      row.classList.add("hide");
-
-      if (!refresh) {
-        new Promise((r) => setTimeout(r, 100)).then(() => {
-          obj.deleteReports();
-        });
+      if (xhr?.responseJSON?.status !== "success") {
+        revert("server responded with a non-success status");
       }
     };
 
     $(document).on("ajaxSuccess", onAjaxSuccess);
 
-    // Safety net: if the server never confirms this specific deletion (request failed,
-    // unexpected response, etc.), don't leave the listener attached to document forever.
+    // Safety net: if the server never confirms this batch (request failed, unexpected
+    // response, etc.), don't leave the listener attached to document forever, and undo
+    // the optimistic hide instead of leaving the user misled until they reload.
     setTimeout(() => {
       if (settled) return;
 
       $(document).off("ajaxSuccess", onAjaxSuccess);
-      this.#logger.warn(`Deletion of report ${report.id} was never confirmed by the server`);
+      revert("no server confirmation within 10s");
     }, 10000);
   }
 

--- a/src/ctxcontent/services/analyzer/SpyMessagesAnalyzer.js
+++ b/src/ctxcontent/services/analyzer/SpyMessagesAnalyzer.js
@@ -780,7 +780,7 @@ class SpyMessagesAnalyzer {
     this.deleteReports();
   }
 
-  deleteReports() {
+deleteReports() {
     this.#logger.debug("Delete messages", this.reportsToDelete);
 
     if (this.reportsToDelete.length === 0) return;
@@ -789,13 +789,20 @@ class SpyMessagesAnalyzer {
     this.#logger.debug("Messages to be deleted", report.id);
     const obj = this;
 
-    const deleteBtn = document.querySelector(`.msgDeleteBtn[data-message-id="${report.id}"]`);
+    try {
+      const deleteBtn = document.querySelector(`.msgDeleteBtn[data-message-id="${report.id}"]`);
 
-    if (!deleteBtn) {
-      // The native message row got unloaded from the DOM (pagination), the click has
-      // nothing to trigger and would silently do nothing. Keep the row visible instead of
-      // hiding it as if it had been deleted, and move on to the next queued report.
-      this.#logger.warn(`Could not delete report ${report.id}: native message button not found in DOM`);
+      if (deleteBtn) {
+        deleteBtn.click();
+      } else {
+        this.#logger.debug(`Native button not in DOM for report ${report.id}, calling ogame.messages.flagDeleted directly`);
+
+        const fakeBtn = document.createElement("button");
+        fakeBtn.setAttribute("data-message-id", report.id);
+        ogame.messages.flagDeleted(fakeBtn);
+      }
+    } catch (err) {
+      this.#logger.error(`Failed to delete report ${report.id}`, err);
 
       new Promise((r) => setTimeout(r, 100)).then(() => {
         obj.deleteReports();
@@ -803,6 +810,46 @@ class SpyMessagesAnalyzer {
 
       return;
     }
+
+    const refresh = this.reportsToDelete.length === 0;
+
+    let settled = false;
+
+    const onAjaxSuccess = function (e, xhr, settings) {
+      const urlParams = new URLSearchParams(settings.url);
+      const requestPayload = new URLSearchParams(settings.data);
+
+      if (xhr?.responseJSON?.status !== "success") return;
+      if (urlParams.get("action") !== "flagDeleted") return;
+
+      if (!requestPayload.getAll("messageIds[]").includes(report.id)) {
+        return;
+      }
+
+      settled = true;
+      $(document).off("ajaxSuccess", onAjaxSuccess);
+
+      // Only hide the row once the deletion is actually confirmed by the server.
+      row.classList.add("hide");
+
+      if (!refresh) {
+        new Promise((r) => setTimeout(r, 100)).then(() => {
+          obj.deleteReports();
+        });
+      }
+    };
+
+    $(document).on("ajaxSuccess", onAjaxSuccess);
+
+    // Safety net: if the server never confirms this specific deletion (request failed,
+    // unexpected response, etc.), don't leave the listener attached to document forever.
+    setTimeout(() => {
+      if (settled) return;
+
+      $(document).off("ajaxSuccess", onAjaxSuccess);
+      this.#logger.warn(`Deletion of report ${report.id} was never confirmed by the server`);
+    }, 10000);
+  }
 
     deleteBtn.click();
 

--- a/src/ctxcontent/services/analyzer/SpyMessagesAnalyzer.js
+++ b/src/ctxcontent/services/analyzer/SpyMessagesAnalyzer.js
@@ -619,8 +619,7 @@ class SpyMessagesAnalyzer {
         const optColDeleteButton = createDOM("button", { class: "icon icon_trash" });
         optColDeleteButton.setAttribute("data-id", report.id);
         optColDeleteButton.addEventListener("click", () => {
-          bodyRow.classList.add("hide");
-          this.reportsToDelete.push(report);
+          this.reportsToDelete.push({ report, row: bodyRow });
 
           this.deleteReports();
         });
@@ -637,8 +636,7 @@ class SpyMessagesAnalyzer {
             ) <
             OGIData.options.rvalLimit
         ) {
-          bodyRow.classList.add("hide");
-          this.reportsToDelete.push(report);
+          this.reportsToDelete.push({ report, row: bodyRow });
         }
       } else if (document.querySelector('.messagesTrashcanBtns button.custom_btn[disabled="disabled"]')) {
         const optColRestoreButton = createDOM("button", { class: "icon icon_restore" });
@@ -787,12 +785,26 @@ class SpyMessagesAnalyzer {
 
     if (this.reportsToDelete.length === 0) return;
 
-    const report = this.reportsToDelete.shift();
+    const { report, row } = this.reportsToDelete.shift();
     this.#logger.debug("Messages to be deleted", report.id);
     const obj = this;
 
-    if (!document.querySelector(`.msgDeleteBtn[data-message-id="${report.id}"]`)) return;
-    document.querySelector(`.msgDeleteBtn[data-message-id="${report.id}"]`).click();
+    const deleteBtn = document.querySelector(`.msgDeleteBtn[data-message-id="${report.id}"]`);
+
+    if (!deleteBtn) {
+      // The native message row got unloaded from the DOM (pagination), the click has
+      // nothing to trigger and would silently do nothing. Keep the row visible instead of
+      // hiding it as if it had been deleted, and move on to the next queued report.
+      this.#logger.warn(`Could not delete report ${report.id}: native message button not found in DOM`);
+
+      new Promise((r) => setTimeout(r, 100)).then(() => {
+        obj.deleteReports();
+      });
+
+      return;
+    }
+
+    deleteBtn.click();
 
     const refresh = this.reportsToDelete.length === 0;
 
@@ -806,6 +818,9 @@ class SpyMessagesAnalyzer {
       if (!requestPayload.getAll("messageIds[]").includes(report.id)) {
         return;
       }
+
+      // Only hide the row once the deletion is actually confirmed by the server.
+      row.classList.add("hide");
 
       if (!refresh) {
         new Promise((r) => setTimeout(r, 100)).then(() => {

--- a/src/ctxcontent/services/analyzer/SpyMessagesAnalyzer.js
+++ b/src/ctxcontent/services/analyzer/SpyMessagesAnalyzer.js
@@ -881,9 +881,10 @@ class SpyMessagesAnalyzer {
       if (OGIData.spies[id]) return;
 
       try {
-        const tmpHTML = createDOM("div", {});
-        tmpHTML.insertAdjacentHTML("afterbegin", message.querySelector("span.player").getAttribute("data-tooltip-title"));
-        const playerID = tmpHTML.querySelector("[data-playerId]").getAttribute("data-playerId");
+        const playerID = message
+          .querySelector("span.player")
+          .getAttribute("data-tooltip-title")
+          .match(/data-playerId="(\d+)"/)?.[1];
 
         const spyFromUrl = new URLSearchParams(
           message.querySelector(".custom_btn.msgAttackBtn").getAttribute("onclick").split(/=(.*)/)[1].slice(1, -1)

--- a/src/ctxcontent/services/analyzer/SpyMessagesAnalyzer.js
+++ b/src/ctxcontent/services/analyzer/SpyMessagesAnalyzer.js
@@ -23,7 +23,7 @@ class SpyMessagesAnalyzer {
   #tabId;
   #onTrash = false;
   reportsToDelete = [];
-  #spyReports = [];
+  #spyReports = {};
 
   constructor() {
     this.#logger = getLogger("SpyMessagesAnalyer");
@@ -46,7 +46,7 @@ class SpyMessagesAnalyzer {
     )
       return;
 
-    this.#spyReports = [];
+    this.#spyReports = {};
 
     document.querySelector(".ogl-spyTable")?.remove();
     document.querySelector(".ogl-tableOptions")?.remove();
@@ -96,7 +96,7 @@ class SpyMessagesAnalyzer {
       if (!report.targetIsSelf) this.#spyReports[report.id] = report;
     });
 
-    if (this.#spyReports.length === 0) return;
+    if (Object.keys(this.#spyReports).length === 0) return;
 
     this.#spyTableBody(table);
   }
@@ -656,8 +656,7 @@ class SpyMessagesAnalyzer {
           renta[round] = Math.round((report.total * Math.pow(1 - report.loot / 100, round) * report.loot) / 100);
         }
 
-        if (renta.length > 1) {
-          const line = gainCol.parentElement;
+        const line = gainCol.parentElement;
 
           if (line.getAttribute("data") === "expanded") {
             line.setAttribute("data", "closed");
@@ -760,7 +759,6 @@ class SpyMessagesAnalyzer {
             extraLine.appendChild(createDOM("td"));
             extraLine.appendChild(createDOM("td"));
           }
-        }
       };
 
       gainCol.addEventListener("click", () => {
@@ -882,49 +880,55 @@ class SpyMessagesAnalyzer {
       // Check if the spy data already exists and skip if it does
       if (OGIData.spies[id]) return;
 
-      const tmpHTML = createDOM("div", {});
-      tmpHTML.insertAdjacentHTML("afterbegin", message.querySelector("span.player").getAttribute("data-tooltip-title"));
-      const playerID = tmpHTML.querySelector("[data-playerId]").getAttribute("data-playerId");
+      try {
+        const tmpHTML = createDOM("div", {});
+        tmpHTML.insertAdjacentHTML("afterbegin", message.querySelector("span.player").getAttribute("data-tooltip-title"));
+        const playerID = tmpHTML.querySelector("[data-playerId]").getAttribute("data-playerId");
 
-      const spyFromUrl = new URLSearchParams(
-        message.querySelector(".custom_btn.msgAttackBtn").getAttribute("onclick").split(/=(.*)/)[1].slice(1, -1)
-      );
+        const spyFromUrl = new URLSearchParams(
+          message.querySelector(".custom_btn.msgAttackBtn").getAttribute("onclick").split(/=(.*)/)[1].slice(1, -1)
+        );
 
-      const type = parseInt(spyFromUrl.get("type"));
-      const timestamp = dataRaw.getAttribute("data-raw-timestamp");
+        const type = parseInt(spyFromUrl.get("type"));
+        const timestamp = dataRaw.getAttribute("data-raw-timestamp");
 
-      const spy = {
-        id: id,
-        targetPlayerId: playerId,
-        sourcePlayerId: playerID,
-        galaxy: spyFromUrl.get("galaxy"),
-        system: spyFromUrl.get("system"),
-        position: spyFromUrl.get("position"),
-        type: type,
-        timestamp: timestamp * 1e3,
-      };
+        const spy = {
+          id: id,
+          targetPlayerId: playerId,
+          sourcePlayerId: playerID,
+          galaxy: spyFromUrl.get("galaxy"),
+          system: spyFromUrl.get("system"),
+          position: spyFromUrl.get("position"),
+          type: type,
+          timestamp: timestamp * 1e3,
+        };
 
-      ptreJSON[id] = {
-        player_id: spy.sourcePlayerId,
-        teamkey: OGIData.options.ptreTK,
-        galaxy: spy.galaxy,
-        system: spy.system,
-        position: spy.position,
-        spy_message_ts: spy.timestamp,
-        moon: {
-          activity: type === planetType.planet ? "60" : "*",
-        },
-        main: false,
-        activity: type === planetType.planet ? "*" : "60",
-      };
+        ptreJSON[id] = {
+          player_id: spy.sourcePlayerId,
+          teamkey: OGIData.options.ptreTK,
+          galaxy: spy.galaxy,
+          system: spy.system,
+          position: spy.position,
+          spy_message_ts: spy.timestamp,
+          moon: {
+            activity: type === planetType.planet ? "60" : "*",
+          },
+          main: false,
+          activity: type === planetType.planet ? "*" : "60",
+        };
 
-      message.classList.add("ogl-reportReady");
+        message.classList.add("ogl-reportReady");
 
-      OGIData.spies[id] = spy;
+        OGIData.spies[id] = spy;
+      } catch (err) {
+        // Don't let one unexpected message shape (missing player tooltip, attack button,
+        // etc.) throw and stop the rest of the batch from being sent to PTRE.
+        this.#logger.warn(`Skipping PTRE data for message ${id}: unexpected message shape`, err);
+      }
     });
 
     if (Object.keys(ptreJSON).length > 0) {
-      ptreService.importPlayerActivity(OgamePageData.gameLang, universe, ptreJSON).finally(() => "Do nothing");
+      ptreService.importPlayerActivity(OgamePageData.gameLang, universe, ptreJSON).catch(() => {});
     }
   }
 }

--- a/src/ctxcontent/services/analyzer/SpyMessagesAnalyzer.js
+++ b/src/ctxcontent/services/analyzer/SpyMessagesAnalyzer.js
@@ -851,32 +851,6 @@ deleteReports() {
     }, 10000);
   }
 
-    deleteBtn.click();
-
-    const refresh = this.reportsToDelete.length === 0;
-
-    $(document).on("ajaxSuccess", function (e, xhr, settings) {
-      const urlParams = new URLSearchParams(settings.url);
-      const requestPayload = new URLSearchParams(settings.data);
-
-      if (xhr?.responseJSON?.status !== "success") return;
-      if (urlParams.get("action") !== "flagDeleted") return;
-
-      if (!requestPayload.getAll("messageIds[]").includes(report.id)) {
-        return;
-      }
-
-      // Only hide the row once the deletion is actually confirmed by the server.
-      row.classList.add("hide");
-
-      if (!refresh) {
-        new Promise((r) => setTimeout(r, 100)).then(() => {
-          obj.deleteReports();
-        });
-      }
-    });
-  }
-
   #ptreSpy() {
     if (!OGIData.options.ptreTK) return;
 


### PR DESCRIPTION
## Update: instant delete + batching

Checked the actual game code (thanks for pulling that up). Two things it confirmed:
- flagDeleted doesn't need the real button at all, it looks up the row itself by id and just does nothing if it can't find it
- it accepts an array of ids instead of just one, deletes them all in the same request

So I reworked deleteReports() again:

- Rows disappear instantly on click now, no more waiting for server confirmation first (that's why it felt slower before)
- If something fails or the server doesn't confirm within 10s, the row just pops back instead of you having to reload the page
- When there are several to delete at once (mainly the auto-delete), they all go out in one single request now instead of one by one with waits in between
- No longer checking if the button exists in the page either, just calls the game's function directly every time

Still haven't tested it live, only checked it against the real code.