### PR TITLE
fix : v13 SAC position and planetType

### DIFF
--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -9866,15 +9866,15 @@ class OGInfinity {
               createDOM(
                 "div",
                 { class: "ogl-quickPlanet" },
-                `${union.name} [${union.galaxy}:${union.system}:${union.planet}] ${union.planettype == 1 ? "P" : "M"}`
+                `${union.name} [${union.galaxy}:${union.system}:${union.position}] ${union.planetType == 1 ? "P" : "M"}`
               )
             );
             unionDiv.addEventListener("click", () => {
               fleetDispatcher.union = union.id;
-              fleetDispatcher.targetPlanet.position = union.planet;
+              fleetDispatcher.targetPlanet.position = union.position;
               fleetDispatcher.targetPlanet.system = union.system;
               fleetDispatcher.targetPlanet.galaxy = union.galaxy;
-              fleetDispatcher.targetPlanet.type = union.planettype;
+              fleetDispatcher.targetPlanet.type = union.planetType;
               galaxyInput.value = fleetDispatcher.targetPlanet.galaxy;
               systemInput.value = fleetDispatcher.targetPlanet.system;
               positionInput.value = fleetDispatcher.targetPlanet.position;


### PR DESCRIPTION
Found a bug in:

- ogl-quickPlanet when presenting the union information and not passing the correct information to fleetdispatch, resulting in not being able to join forces in a SAC.

<img width="243" height="69" alt="image" src="https://github.com/user-attachments/assets/aaff172b-4a3d-4fc1-a01b-b605e231aee7" />
<img width="674" height="682" alt="image" src="https://github.com/user-attachments/assets/86457120-11f8-4ca5-9821-6eccd76d0515" />
