### PR TITLE
Feature/remove historic players

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -3703,11 +3703,13 @@ div[data-raw-depletion="4"] + .msgHead a.txt_link {
   z-index: 10;
 }
 
-.ogl-sideStalk > a {
+.ogl-sideStalk > a,
+.ogl-sideStalk > .ogi-sideStalkRemoveDetail {
   opacity: 0.5;
 }
 
-.ogl-sideStalk:hover > a {
+.ogl-sideStalk:hover > a,
+.ogl-sideStalk:hover > .ogi-sideStalkRemoveDetail {
   opacity: 1;
 }
 
@@ -3739,11 +3741,17 @@ div[data-raw-depletion="4"] + .msgHead a.txt_link {
 }
 
 .ogl-sideStalk .ogl-player {
+  align-items: center;
   border: solid 2px #2f2f2f;
   background: #1e2123;
+  box-sizing: border-box;
+  display: flex;
+  gap: 5px;
+  justify-content: space-between;
   padding: 5px;
   margin-bottom: 3px;
   font-size: 11px;
+  min-height: 27px;
   border-radius: 5px;
   cursor: pointer;
 }
@@ -3752,12 +3760,118 @@ div[data-raw-depletion="4"] + .msgHead a.txt_link {
   border-color: #3c536d;
 }
 
+.ogl-sideStalk .ogl-player > span:first-child {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .ogl-sideStalk .ogi-ranking,
-.ogl-sideStalk .ogl-player span:last-child {
+.ogl-sideStalk .ogl-player .ogi-sideStalkRank {
   font-size: 10px;
   color: #e6648e !important;
-  float: right;
-  margin-left: 5px;
+}
+
+.ogl-sideStalk .ogi-sideStalkPlayerActions {
+  align-items: center;
+  display: flex;
+  flex: 0 0 24px;
+  height: 16px;
+  justify-content: flex-end;
+  min-width: 24px;
+  position: relative;
+}
+
+.ogl-sideStalk .ogi-sideStalkRank,
+.ogl-sideStalk .ogi-sideStalkRemove {
+  display: block;
+  line-height: 16px !important;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+.ogl-sideStalk .ogl-player .ogi-sideStalkRemove {
+  opacity: 0;
+  pointer-events: none;
+  visibility: hidden;
+}
+
+.ogl-sideStalk .ogl-player:hover .ogi-sideStalkRank,
+.ogl-sideStalk .ogl-player:focus-within .ogi-sideStalkRank {
+  opacity: 0;
+  visibility: hidden;
+}
+
+.ogl-sideStalk .ogl-player:hover .ogi-sideStalkRemove,
+.ogl-sideStalk .ogl-player:focus-within .ogi-sideStalkRemove {
+  opacity: 1;
+  pointer-events: auto;
+  visibility: visible;
+}
+
+.ogl-sideStalk .ogi-sideStalkRemoveDetail {
+  border: 0;
+  margin-right: 3px;
+  padding: 0;
+  vertical-align: bottom;
+}
+
+.ogl-sideStalk button.ogi-sideStalkRemove {
+  border: 0;
+  padding: 0;
+}
+
+.ogl-sideStalk .ogi-sideStalkEmpty {
+  clear: both;
+  color: #bbb;
+  font-size: 11px;
+  line-height: 14px;
+  margin-top: 8px;
+}
+
+.ogl-sideStalk .ogi-sideStalkUndo {
+  background: rgba(120, 45, 45, 0.28);
+  border-color: #7f4c4c;
+  color: #d9b0b0;
+  cursor: default;
+  opacity: 1;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.ogl-sideStalk .ogi-sideStalkUndo.ogi-removing {
+  opacity: 0;
+  transform: translateY(-2px);
+}
+
+.ogl-sideStalk .ogi-sideStalkUndoMessage {
+  display: block;
+  flex: 1 1 auto;
+  max-width: 100%;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ogl-sideStalk .ogi-sideStalkUndoButton {
+  background: none;
+  border: 0;
+  color: #ffc9c9;
+  cursor: pointer;
+  flex: 0 0 auto;
+  font-size: 11px;
+  line-height: 14px;
+  margin: 0;
+  padding: 0;
+  white-space: nowrap;
+}
+
+.ogl-sideStalk .ogi-sideStalkUndoButton:hover,
+.ogl-sideStalk .ogi-sideStalkUndoButton:focus {
+  color: #c75817;
 }
 
 .ogl-sideStalk.ogi-hidden {

--- a/src/util/stalk.js
+++ b/src/util/stalk.js
@@ -9,11 +9,17 @@ import OgamePageData from "./OgamePageData.js";
 import OGIData from "./OGIData.js";
 import { loading } from "./loading.js";
 import { action } from "./ptre.js";
+import Translator from "./translate.js";
 
 const rawUrl = new URL(window.location.href);
 const page = rawUrl.searchParams.get("component") || rawUrl.searchParams.get("page");
 const universe = window.location.host.replace(/\D/g, "");
 let keepTooltip = OGIData.keepTooltip || true;
+let undoSideStalkRemoval = null;
+let undoSideStalkTimer = null;
+
+const SIDE_STALK_UNDO_DURATION = 6000;
+const SIDE_STALK_UNDO_FADE_DURATION = 300;
 
 function sendMessage(id) {
   if (OGIData.tchat) {
@@ -109,6 +115,181 @@ function generateGalaxyLink(coords, playerId = undefined) {
   });
 
   return `?${url.toString()}`;
+}
+
+function getRemovedFromHistoricText(playerName) {
+  return Translator.translate(226).replace("{player}", playerName);
+}
+
+function removeSideStalkPlayer(playerId) {
+  playerId = parseInt(playerId);
+  const sideStalk = OGIData.sideStalk.slice();
+  const index = sideStalk.indexOf(playerId);
+
+  if (index === -1) return null;
+
+  sideStalk.splice(index, 1);
+  OGIData.sideStalk = sideStalk;
+
+  return { playerId, index };
+}
+
+function restoreSideStalkPlayer(removedPlayer) {
+  const sideStalk = OGIData.sideStalk.slice();
+
+  if (!removedPlayer || sideStalk.includes(removedPlayer.playerId)) return;
+
+  sideStalk.splice(removedPlayer.index, 0, removedPlayer.playerId);
+  OGIData.sideStalk = sideStalk;
+}
+
+function clearSideStalkUndo(resetRemoval = true) {
+  if (undoSideStalkTimer) clearTimeout(undoSideStalkTimer);
+  undoSideStalkTimer = null;
+  if (resetRemoval) undoSideStalkRemoval = null;
+}
+
+function getHistoricTitle(sideStalk) {
+  return Array.from(sideStalk.children).find((child) => child.classList.contains("title"));
+}
+
+function updateHistoricTitle(sideStalk) {
+  const title = getHistoricTitle(sideStalk);
+
+  if (title) title.textContent = "Historic " + OGIData.sideStalk.length + "/20";
+}
+
+function removeHistoricEmptyState(list) {
+  list.querySelector(".ogi-sideStalkEmpty")?.remove();
+}
+
+function ensureHistoricEmptyState(list) {
+  if (OGIData.sideStalk.length || list.querySelector(".ogi-sideStalkUndo, .ogi-sideStalkEmpty")) return;
+
+  list.appendChild(createDOM("div", { class: "ogi-sideStalkEmpty" }, Translator.translate(228)));
+}
+
+function removeExistingSideStalkUndo(sideStalk) {
+  sideStalk.querySelectorAll(".ogi-sideStalkUndo").forEach((undo) => undo.remove());
+}
+
+function showSideStalkUndo(list, playerName) {
+  clearSideStalkUndo(false);
+  removeHistoricEmptyState(list);
+
+  const undo = list.querySelector(".ogi-sideStalkUndo") || list.appendChild(createSideStalkUndoRow(playerName));
+
+  undo.querySelector(".ogi-sideStalkUndoButton").addEventListener("click", (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    restoreSideStalkPlayer(undoSideStalkRemoval);
+    clearSideStalkUndo();
+    renderHistoricList(list.closest(".ogl-sideStalk"));
+  });
+
+  undoSideStalkTimer = setTimeout(() => {
+    undo.classList.add("ogi-removing");
+    undoSideStalkTimer = setTimeout(() => {
+      undo.remove();
+      clearSideStalkUndo();
+      ensureHistoricEmptyState(list);
+    }, SIDE_STALK_UNDO_FADE_DURATION);
+  }, SIDE_STALK_UNDO_DURATION);
+}
+
+function createSideStalkUndoRow(playerName) {
+  const undo = createDOM("div", { class: "ogl-player ogi-sideStalkUndo" });
+  undo.appendChild(createDOM("span", { class: "ogi-sideStalkUndoMessage" }, getRemovedFromHistoricText(playerName)));
+  undo.appendChild(
+    createDOM("button", { class: "ogi-sideStalkUndoButton", type: "button" }, Translator.translate(227))
+  );
+
+  return undo;
+}
+
+function removeSideStalkPlayerWithFeedback(playerId, playerName, sideStalk, showUndoOnTop = false, playerRow = null) {
+  const removedPlayer = removeSideStalkPlayer(playerId);
+
+  if (!removedPlayer) return;
+
+  undoSideStalkRemoval = removedPlayer;
+
+  if (!showUndoOnTop && playerRow?.isConnected && playerRow.closest(".ogl-sideStalk") === sideStalk) {
+    const list = playerRow.closest(".ogi-sideStalkList");
+
+    if (list) {
+      removeExistingSideStalkUndo(sideStalk);
+      removeHistoricEmptyState(list);
+      playerRow.replaceWith(createSideStalkUndoRow(playerName));
+      updateHistoricTitle(sideStalk);
+      showSideStalkUndo(list, playerName);
+      return;
+    }
+  }
+
+  const list = renderHistoricList(sideStalk, { playerName, index: removedPlayer.index, showOnTop: showUndoOnTop });
+  showSideStalkUndo(list, playerName);
+}
+
+function renderHistoricList(sideStalk, undoRow = null) {
+  sideStalk.replaceChildren();
+  sideStalk.appendChild(createDOM("div", { class: "title" }, "Historic " + OGIData.sideStalk.length + "/20"));
+  sideStalk.appendChild(createDOM("hr"));
+
+  const list = sideStalk.appendChild(createDOM("div", { class: "ogi-sideStalkList" }));
+
+  if (undoRow?.showOnTop) {
+    list.appendChild(createSideStalkUndoRow(undoRow.playerName));
+  }
+
+  if (!OGIData.sideStalk.length) {
+    list.appendChild(createDOM("div", { class: "ogi-sideStalkEmpty" }, Translator.translate(228)));
+    return list;
+  }
+
+  OGIData.sideStalk
+    .slice()
+    .reverse()
+    .forEach((id, visualIndex) => {
+      if (undoRow && !undoRow.showOnTop && visualIndex === OGIData.sideStalk.length - undoRow.index) {
+        list.appendChild(createSideStalkUndoRow(undoRow.playerName));
+      }
+
+      const playerDiv = list.appendChild(createDOM("div", { class: "ogl-player" }));
+      player.get(id).then((p) => {
+        if (!OGIData.sideStalk.includes(parseInt(p.id))) {
+          playerDiv.remove();
+          return;
+        }
+
+        playerDiv.appendChild(createDOM("span", { class: player.status(p.status) }, p.name));
+        const actions = playerDiv.appendChild(createDOM("span", { class: "ogi-sideStalkPlayerActions" }));
+        actions.appendChild(createDOM("span", { class: "ogi-sideStalkRank" }, "#" + p.points.position));
+        const removeBtn = actions.appendChild(
+          createDOM("button", {
+            class: "icon icon_trash tooltip ogi-sideStalkRemove",
+            title: Translator.translate(225),
+            "aria-label": Translator.translate(225),
+            type: "button",
+          })
+        );
+
+        playerDiv.addEventListener("click", () => {
+          side(p.id);
+        });
+        removeBtn.addEventListener("click", (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          removeSideStalkPlayerWithFeedback(p.id, p.name, sideStalk, false, playerDiv);
+        });
+      });
+    });
+
+  if (undoRow && !undoRow.showOnTop && undoRow.index === 0) {
+    list.appendChild(createSideStalkUndoRow(undoRow.playerName));
+  }
+
+  return list;
 }
 
 export function stalk(sender, player, delay = undefined) {
@@ -472,7 +653,7 @@ export function side(playerId) {
       sideStalk.remove();
     }
     sideStalk = document.querySelector("#links").appendChild(createDOM("div", { class: "ogl-sideStalk" }));
-    let actBtn, watchlistBtn, ptreBtn;
+    let actBtn, watchlistBtn, ptreBtn, removeBtn;
     const options = OGIData.options;
     if (!options.sideStalkVisible) {
       sideStalk.classList.add("ogi-hidden");
@@ -491,6 +672,14 @@ export function side(playerId) {
           createDOM("a", { class: "ogl-text-btn ogl-ptre-acti tooltip", title: "Display PTRE data" }, "PTRE")
         );
       }
+      removeBtn = sideStalk.appendChild(
+        createDOM("button", {
+          class: "icon icon_trash tooltip ogi-sideStalkRemoveDetail",
+          title: Translator.translate(225),
+          "aria-label": Translator.translate(225),
+          type: "button",
+        })
+      );
       const closeBtn = sideStalk.appendChild(
         createDOM(
           "span",
@@ -536,24 +725,15 @@ export function side(playerId) {
         });
       watchlistBtn &&
         watchlistBtn.addEventListener("click", () => {
-          sideStalk.replaceChildren();
-          sideStalk.appendChild(createDOM("div", { class: "title" }, "Historic " + OGIData.sideStalk.length + "/20"));
-          sideStalk.appendChild(createDOM("hr"));
-          OGIData.sideStalk
-            .slice()
-            .reverse()
-            .forEach((id) => {
-              player.get(id).then((p) => {
-                let playerDiv = sideStalk.appendChild(createDOM("div", { class: "ogl-player" }));
-                playerDiv.appendChild(createDOM("span", { class: player.status(p.status) }, p.name));
-                playerDiv.appendChild(createDOM("span", {}, "#" + p.points.position));
-                playerDiv.addEventListener("click", () => {
-                  side(p.id);
-                });
-              });
-            });
+          renderHistoricList(sideStalk);
         });
 
+      removeBtn &&
+        removeBtn.addEventListener("click", (event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          removeSideStalkPlayerWithFeedback(p.id, p.name, sideStalk, true);
+        });
       if (ptreBtn) {
         ptreBtn.addEventListener("click", () => {
           loading();

--- a/src/util/stalk.js
+++ b/src/util/stalk.js
@@ -627,6 +627,52 @@ export function update(planets) {
   return domArr;
 }
 
+function getVisibleSideStalkPlanetCount(container) {
+  return Array.from(container.children).filter(
+    (planet) => planet.tagName === "A" && !Array.from(planet.classList).some((className) => /delete/i.test(className))
+  ).length;
+}
+
+function updateSideStalkPlayerTitle(playerTitle, playerName, container) {
+  const planetCount = getVisibleSideStalkPlanetCount(container);
+  const playerTitleText = `${playerName} - [${planetCount}]`;
+
+  playerTitle.textContent = playerTitleText;
+  playerTitle.title = playerTitleText;
+}
+
+function observeSideStalkPlayerTitle(playerTitle, playerName, container) {
+  const shouldUpdateTitle = (mutation) => {
+    if (mutation.type === "childList" && mutation.target === container) {
+      return Array.from(mutation.addedNodes)
+        .concat(Array.from(mutation.removedNodes))
+        .some((node) => node.tagName === "A");
+    }
+
+    return (
+      mutation.type === "attributes" && mutation.target.parentElement === container && mutation.target.tagName === "A"
+    );
+  };
+
+  const observer = new MutationObserver((mutations) => {
+    if (!container.isConnected) {
+      observer.disconnect();
+      return;
+    }
+
+    if (mutations.some(shouldUpdateTitle)) {
+      updateSideStalkPlayerTitle(playerTitle, playerName, container);
+    }
+  });
+
+  observer.observe(container, {
+    childList: true,
+    attributes: true,
+    attributeFilter: ["class"],
+    subtree: true,
+  });
+}
+
 export function side(playerId) {
   const sideStalk = OGIData.sideStalk;
   if (playerId) {
@@ -696,13 +742,15 @@ export function side(playerId) {
       });
     }
     player.get(playerId).then((p) => {
-      sideStalk.appendChild(
+      const playerTitle = sideStalk.appendChild(
         createDOM("div", { style: "cursor: pointer", class: "ogi-title " + player.status(p.status) }, p.name)
       );
       sideStalk.appendChild(createDOM("hr"));
       let container = sideStalk.appendChild(createDOM("div", { class: "ogl-stalkPlanets", "player-id": p.id }));
       let planets = update(p.planets);
       planets.forEach((dom) => container.appendChild(dom));
+      updateSideStalkPlayerTitle(playerTitle, p.name, container);
+      observeSideStalkPlayerTitle(playerTitle, p.name, container);
 
       highlightTarget();
 

--- a/src/util/translate.js
+++ b/src/util/translate.js
@@ -2242,12 +2242,36 @@ const translation = Object.freeze({
       br: "Destaque",
     },
     225: {
-      de: undefined,
-      en: undefined,
-      es: undefined,
-      fr: undefined,
-      tr: undefined,
-      br: undefined,
+      de: "Aus Historic entfernen",
+      en: "Remove from Historic",
+      es: "Quitar de Historic",
+      fr: "Retirer de Historic",
+      tr: "Historic'ten kaldır",
+      br: "Remover do Historic",
+    },
+    226: {
+      de: "{player} aus Historic entfernt",
+      en: "{player} removed from Historic",
+      es: "{player} quitado de Historic",
+      fr: "{player} retiré de Historic",
+      tr: "{player} Historic'ten kaldırıldı",
+      br: "{player} removido do Historic",
+    },
+    227: {
+      de: "Rückgängig",
+      en: "Undo",
+      es: "Deshacer",
+      fr: "Annuler",
+      tr: "Geri al",
+      br: "Desfazer",
+    },
+    228: {
+      de: "Keine Spieler in Historic",
+      en: "No players in Historic",
+      es: "No hay jugadores en Historic",
+      fr: "Aucun joueur dans Historic",
+      tr: "Historic'te oyuncu yok",
+      br: "Nenhum jogador no Historic",
     },
   },
 });
@@ -2306,8 +2330,7 @@ class Translator {
       this.logger.debug(`Translations (${currentLanguage}) will be updated`);
 
       this.#ForceUpdateAllTechNamesFromEmpire(translations, empireFromPlanets);
-      if(empireFromMoons)
-      {
+      if (empireFromMoons) {
         this.#ForceUpdateAllTechNamesFromEmpire(translations, empireFromMoons);
       }
 


### PR DESCRIPTION
The new functionality includes:
- Remove players from the historic list.
- Create a temporary element to undo player deletion.
- Delete a user from the Historic list on their player details page.
- Player names on the player details page now have a counter showing the number of active planets.