### PR TITLE
chore(ptre): galaxy scan cleanups + opt-in debug logs

### DIFF
--- a/src/ctxcontent/data-helper.js
+++ b/src/ctxcontent/data-helper.js
@@ -32,6 +32,8 @@ export class DataHelper {
     this.loading = false;
     // Transient cache of the last successful universe.xml fetch. Stripped from the persisted blob in processData().
     this._galaxySnapshot = null;
+    // Pushed from the page via `ptre.setDebugLogs`; gates the verbose scan() debug output.
+    this._ptreDebugLogs = false;
   }
 
   init() {
@@ -226,7 +228,7 @@ export class DataHelper {
       const currentSystemSnapshot = {};
       let systemChanged = false;
 
-      if (teamKey && !previousSystemFound) {
+      if (teamKey && !previousSystemFound && this._ptreDebugLogs) {
         ptreLogger.debug("[GALAXY] [" + galaxy + ":" + system + "] Warning: No previous snapshot found!");
       }
 
@@ -235,10 +237,12 @@ export class DataHelper {
         const extra = (additionnal && (additionnal[pos] || additionnal[String(pos)])) || {};
         const coords = galaxy + ":" + system + ":" + pos;
 
-        ptreLogger.debug("[GALAXY] [" + coords +"] Player " + previousSystemSnapshot[pos].playerId + "=>" + cur.playerId +
-            " | Planet: " + previousSystemSnapshot[pos].planetId + "=>" + cur.planetId +
-            " | Moon: " + previousSystemSnapshot[pos].moonId + "=>" + cur.moonId +
-            " (" + (extra.playerName || "") + " - " + (extra.playerRank ?? -1) + ")");
+        if (this._ptreDebugLogs) {
+          ptreLogger.debug("[GALAXY] [" + coords +"] Player " + previousSystemSnapshot[pos].playerId + "=>" + cur.playerId +
+              " | Planet: " + previousSystemSnapshot[pos].planetId + "=>" + cur.planetId +
+              " | Moon: " + previousSystemSnapshot[pos].moonId + "=>" + cur.moonId +
+              " (" + (extra.playerName || "") + " - " + (extra.playerRank ?? -1) + ")");
+        }
 
         // ---- Section A: scannedPlanets / scannedPlayers (always runs, no teamKey needed).
         // Restores pre-PR-533 semantics: only write when the (coords, moon-presence) pair
@@ -279,7 +283,9 @@ export class DataHelper {
             cur.planetId !== previousSystemSnapshot[pos].planetId ||
             cur.moonId !== previousSystemSnapshot[pos].moonId;
           if (changed) {
-            ptreLogger.debug("[GALAXY] [" + coords + "] Position changed");
+            if (this._ptreDebugLogs) {
+              ptreLogger.debug("[GALAXY] [" + coords + "] Position changed");
+            }
             systemChanged = true;
 
             const entry = {

--- a/src/ctxcontent/index.js
+++ b/src/ctxcontent/index.js
@@ -22,6 +22,9 @@ contentContextInit({
         dataHelper.rebuildGalaxyStorage(pendingPtreKey);
       }
     },
+    setDebugLogs: function (enabled) {
+      if (dataHelper) dataHelper._ptreDebugLogs = !!enabled;
+    },
     galaxyInfo: function () {
       if (!dataHelper || !dataHelper.galaxyStorage) {
         return Promise.resolve({ systemCount: 0, lastGalaxyUpdateTS: -1, storageBytes: 0 });

--- a/src/ctxpage/conf-options.js
+++ b/src/ctxpage/conf-options.js
@@ -100,6 +100,7 @@ const _options = {
   lifeformConstructionsIconsDisplayMode: 4,
   lifeformResearchsIconsDisplayMode: 4,
   ownFleetYieldIconsDisplayMode: 4,
+  ptreDebugLogs: false,
 };
 
 export function initConfOptions(options) {

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -4129,11 +4129,16 @@ class OGInfinity {
       if (playerDiv || ownPlayerSpan) {
         const planetDiv = row.querySelector(".cellPlanet div");
         const moonDiv = row.querySelector(".cellMoon div");
+        // Normalize any non-finite parse result to -1 so downstream diffs don't fire on NaN !== NaN.
+        const toFiniteId = (v) => {
+          const n = Number(v);
+          return Number.isFinite(n) ? n : -1;
+        };
         let playerId = -1;
         let name = "";
         if (playerDiv) {
           const rawPlayerId = playerDiv.getAttribute("id")?.replace("player", "");
-          playerId = rawPlayerId && rawPlayerId !== "" ? Number(rawPlayerId) : -1;
+          playerId = rawPlayerId ? toFiniteId(rawPlayerId) : -1;
           name = playerDiv.querySelector("span:first-of-type")?.textContent || "";
         } else {
           // own-planet row: no player id in the row itself, fall back to the current player id.
@@ -4141,9 +4146,9 @@ class OGInfinity {
           name = ownPlayerSpan.textContent?.trim() || "";
         }
         const rawPlanetId = planetDiv ? planetDiv.getAttribute("data-planet-id") : null;
-        const planetId = rawPlanetId ? Number(rawPlanetId) : -1;
+        const planetId = rawPlanetId ? toFiniteId(rawPlanetId) : -1;
         const rawMoonId = moonDiv ? moonDiv.getAttribute("data-moon-id") : null;
-        const moonId = rawMoonId ? Number(rawMoonId) : -1;
+        const moonId = rawMoonId ? toFiniteId(rawMoonId) : -1;
 
         // Status flags (matches EasyPTRE extraction).
         let statusStr = "";

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -1538,6 +1538,7 @@ class OGInfinity {
     this.autoQueue = new AutoQueue();
 
     pageContextRequest("ptre", "setTeamKey", this.json.options.ptreTK || "");
+    pageContextRequest("ptre", "setDebugLogs", !!this.json.options.ptreDebugLogs);
   }
 
   start() {
@@ -15410,12 +15411,30 @@ class OGInfinity {
     // Systems count row in PTRE settings. Live query against `dataHelper.galaxyStorage`
     // via the page->content bridge - the value reflects the current in-memory store
     // at the moment the settings modal opens.
+    let ptreDebugLogsRow = ptreSection.appendChild(
+      createDOM(
+        "span",
+        { style: "display: flex;justify-content: space-between; align-items: center;" },
+        this.getTranslatedText(229)
+      )
+    );
+    let ptreDebugLogsCheck = ptreDebugLogsRow.appendChild(createDOM("input", { type: "checkbox" }));
+    ptreDebugLogsCheck.addEventListener("change", () => {
+      this.json.options.ptreDebugLogs = ptreDebugLogsCheck.checked;
+      pageContextRequest("ptre", "setDebugLogs", !!this.json.options.ptreDebugLogs);
+      this.saveData();
+    });
+    if (this.json.options.ptreDebugLogs) {
+      ptreDebugLogsCheck.checked = true;
+    }
+
     let ptreLastApiUpdateRow = ptreSection.appendChild(createDOM("span"));
     ptreLastApiUpdateRow.textContent = "Last API update: ...";
     let ptreSystemCountRow = ptreSection.appendChild(createDOM("span"));
     ptreSystemCountRow.textContent = "Systems count: ...";
     let ptreStorageSizeRow = ptreSection.appendChild(createDOM("span"));
     ptreStorageSizeRow.textContent = "Storage size: ...";
+
     pageContextRequest("ptre", "galaxyInfo")
       .then((r) => {
         const n = r?.response?.systemCount ?? 0;

--- a/src/util/translate.js
+++ b/src/util/translate.js
@@ -2274,12 +2274,12 @@ const translation = Object.freeze({
       br: "Nenhum jogador no Historic",
     },
     226: {
-      de: "Galaxie-Speicher",
-      en: "Galaxy Storage",
-      es: "Almacenamiento de galaxia",
-      fr: "Stockage de la Galaxie",
-      tr: "Galaksi depolama",
-      br: "Armazenamento de galáxia",
+      de: "Galaxie-Speicher (PTRE)",
+      en: "Galaxy Storage (PTRE)",
+      es: "Almacenamiento de galaxia (PTRE)",
+      fr: "Stockage de la Galaxie (PTRE)",
+      tr: "Galaksi depolama (PTRE)",
+      br: "Armazenamento de galáxia (PTRE)",
     },
   },
 });

--- a/src/util/translate.js
+++ b/src/util/translate.js
@@ -2273,6 +2273,14 @@ const translation = Object.freeze({
       tr: "Historic'te oyuncu yok",
       br: "Nenhum jogador no Historic",
     },
+    229: {
+      de: "PTRE Debug-Logs",
+      en: "PTRE debug logs",
+      es: "Logs de depuración PTRE",
+      fr: "Logs de debug PTRE",
+      tr: "PTRE hata ayıklama günlükleri",
+      br: "Logs de depuração PTRE",
+    },
     226: {
       de: "Galaxie-Speicher (PTRE)",
       en: "Galaxy Storage (PTRE)",


### PR DESCRIPTION
> ⚠️ Depends on: https://github.com/ogame-infinity/web-extension/pull/555
> Merge 555 first

Three small, independent commits on top of master.

## Commits
1. **fix(ptre): normalize galaxy row IDs to -1 on non-numeric parse**  
   The DOM parse in `scan()` fed `Number(...)` directly into `playerId`/`planetId`/`moonId`. A future non-numeric attribute would leak `NaN` into the diff (`NaN !== NaN`), causing phantom "position changed" emits on every visit. Wraps the parse in a `toFiniteId(v)` helper that collapses non-finite results to `-1`.

2. **chore(i18n): tag Galaxy Storage label with (PTRE)**  
   Renames label 226 from `Galaxy Storage` to `Galaxy Storage (PTRE)` across all six locales, clarifying in the Data management settings that the reset only affects the PTRE-facing snapshot store.

3. **feat(ptre): opt-in debug logs toggle in PTRE settings**  
   New `ptreDebugLogs` option (default off), surfaced as a checkbox in the PTRE settings section. Toggling it is pushed to the content script via a new `ptre.setDebugLogs` bridge, and `DataHelper.scan()` gates its per-position debug output behind the flag so a fresh install stays quiet even with DevTools verbose enabled.

## Test plan
- Fresh install → open galaxy view with Verbose enabled → no `[GALAXY] [...]` lines in console.
- Settings → PTRE settings → tick "PTRE debug logs" → visit galaxy → per-position debug lines appear immediately (no reload).
- Untick → next scan is silent again.
- Settings → Data management → the label reads `Galaxy Storage (PTRE)` in every UI language.
- With a valid PTRE key, visit a system whose DOM has been altered (e.g. via extension) to introduce a non-numeric player id → no spurious diff emission (previously would have fired every scan).