### PR TITLE
feat(ptre): send debris field size + debug-log player activities

### DIFF
--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -4202,6 +4202,17 @@ class OGInfinity {
             ? "*"
             : row.querySelector("[data-moon-id] .activity")?.textContent.trim() || 60;
 
+          // Sum of the debris resource stacks. PTRE contract: -1 = no data, 0+ = actual size.
+          // An empty `.cellDebris` (no children) is a confirmed empty field, not missing data.
+          let cdrTotalSize = -1;
+          const debrisCell = row.querySelector(".cellDebris");
+          if (debrisCell) {
+            cdrTotalSize = 0;
+            debrisCell.querySelectorAll(".debris-content").forEach((el) => {
+              cdrTotalSize += fromFormatedNumber(el.textContent.replace(/(\D*)/, "")) || 0;
+            });
+          }
+
           ptreJSON[coords] = {};
           ptreJSON[coords].id = planetId;
           ptreJSON[coords].player_id = playerId;
@@ -4212,6 +4223,7 @@ class OGInfinity {
           ptreJSON[coords].system = system;
           ptreJSON[coords].position = String(pos);
           ptreJSON[coords].main = false;
+          ptreJSON[coords].cdr_total_size = cdrTotalSize;
 
           if (moonId > -1) {
             ptreJSON[coords].moon = {};

--- a/src/ogkush.js
+++ b/src/ogkush.js
@@ -40,6 +40,7 @@ import RecyclingYieldCalculator from "./util/recyclingYieldCalculator.js";
 const DISCORD_INVITATION_URL = "https://discord.gg/8Y4SWup";
 //const VERSION = "__VERSION__";
 const logger = getLogger();
+const ptreActivityLogger = getLogger("ogkush.ptre.activity");
 pageContextInit();
 
 var dataHelper = (function () {
@@ -4309,6 +4310,25 @@ class OGInfinity {
       if (typeof mainPlanet !== "undefined") {
         ptreJSON[coords].main = mainPlanet.coords === coords || false;
       }
+    }
+
+    if (this.json.options.ptreDebugLogs) {
+      const coordsList = Object.keys(ptreJSON);
+      ptreActivityLogger.debug(
+        "[ACTIVITY] Sending " + coordsList.length + " position(s) to PTRE (system " + systemCoords[0] + ":" + systemCoords[1] + ")"
+      );
+      coordsList.forEach((coords) => {
+        const entry = ptreJSON[coords];
+        const moonPart = entry.moon
+          ? " | Moon: " + entry.moon.id + " act=" + entry.moon.activity
+          : " | Moon: -";
+        ptreActivityLogger.debug(
+          "[ACTIVITY] [" + coords + "] Player " + entry.player_id +
+            " | Planet: " + entry.id + " act=" + entry.activity +
+            moonPart +
+            " | CDR: " + entry.cdr_total_size
+        );
+      });
     }
 
     ptreService.importPlayerActivity(OgamePageData.gameLang, this.universe, ptreJSON).then((result) => {


### PR DESCRIPTION
> ⚠️ Depends on [chore/ptre-galaxy-fix](https://github.com/ogame-infinity/web-extension/pull/552) - the debug-log commit here reuses the `ptreDebugLogs` option and its Settings checkbox introduced there. Do not merge before that PR lands.

Two commits on top of master:

## 1. feat(ptre): send galaxy debris field size with player activities

Adds `cdr_total_size` to each activity entry pushed to PTRE via `oglight_import_player_activity.php`. Semantics match EasyPTRE/OGLight:

- `-1`: unexpected DOM (no `.cellDebris` cell on the row) - no data.
- `0`: `.cellDebris` present but empty (confirmed empty debris field).
- `>0`: sum of Metal + Crystal + Deuterium stacks parsed from `.cellDebris .debris-content`.

Parses through Infinity's own `fromFormattedNumber` helper so locale group separators (`,` / `.` / space) and abbreviated units (`K` / `M` / `G` / `T` / `Tsd.` / `Mio.` / `Mrd.`) are all handled.

## 2. feat(ptre): debug-log activities pushed to PTRE

Gated by `this.json.options.ptreDebugLogs`; emits one summary line plus one per position right before the POST, e.g.:
