### PR TITLE
add children chaining capability to createDOM()

### DIFF
--- a/src/util/dom.js
+++ b/src/util/dom.js
@@ -1,9 +1,13 @@
-export function createDOM(element, attributes, textContent) {
+export function createDOM(element, attributes, ...children) {
   const e = document.createElement(element);
   for (const key in attributes) {
     e.setAttribute(key, attributes[key]);
   }
-  if (textContent) e.textContent = textContent;
+
+  // children can be any number of elements or text strings, allowing easy chaining
+  if (children.length > 0) {
+    e.append(...children);
+  }
 
   //if element is a select, and doesn't have dropdownInitialized claass, add it => it prevent Ogame restyling it
   if (element === "select" && !e.classList.contains("dropdownInitialized")) {


### PR DESCRIPTION
children can be any number of elements or text strings, allowing easy chaining. this can be useful to convert old html code into structures in some cases without needing auxiliary variables:

<img width="907" height="656" alt="imagen" src="https://github.com/user-attachments/assets/cd2acbcc-5a49-454f-8355-30fbc85e0830" />

it should be 100% compatible with existing code using now createDOM()
